### PR TITLE
Adds missing DiffEqFlux import in first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the documentation, which contains the unreleased features.
 ## Example: Solving 2D Poisson Equation via Physics-Informed Neural Networks
 
 ```julia
-using NeuralPDE, ModelingToolkit, GalacticOptim, Optim
+using NeuralPDE, ModelingToolkit, GalacticOptim, Optim, DiffEqFlux
 
 @parameters x y θ
 @variables u(..)


### PR DESCRIPTION
Awesome package, thank you! Just noticed there's a missing `using DiffEqFlux` when directly running the first example in the README.md