### PR TITLE
Symbolic Discretization Version

### DIFF
--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -134,6 +134,7 @@ export NNODE, TerminalPDEProblem, NNPDEHan, NNPDENS, NNRODE,
        GridTraining, StochasticTraining, QuadratureTraining
        build_loss_function, get_loss_function,
        generate_training_sets, get_bc_varibles,get_bounds
-       get_phi, get_derivative
+       get_phi, get_derivative,
+       build_symbolic_loss_function, symbolic_discretize
 
 end # module


### PR DESCRIPTION
```julia
@parameters x
@variables u(..)
@derivatives Dxxx'''~x
@derivatives Dx'~x
eq = Dxxx(u(x)) ~ cos(pi*x)
bcs = [u(0.) ~ 0.0,
       u(1.) ~ cos(pi),
       Dx(u(1.)) ~ 1.0]
domains = [x ∈ IntervalDomain(0.0,1.0)]
dx = 0.05
chain = FastChain(FastDense(1,8,Flux.σ),FastDense(8,1))
discretization = NeuralPDE.PhysicsInformedNN(chain)
pde_system = PDESystem(eq,bcs,domains,[x],[u])

prob = NeuralPDE.symbolic_discretize(pde_system,discretization)
pde_loss, bcs_loss = prob
```
```julia
julia> pde_loss
:((cord, var"##θ#429", phi, derivative, u_arr, u_d_arr)->begin
          #=  =#
          #=  =#
          begin
              (u,) = (u_arr[1],)
              (u_d,) = (u_d_arr[1],)
              let (x,) = (cord[1],)
                  [derivative(phi, u_d, [x], Array{Float32,1}[[0.0049215667], [0.0049215667], [0.0049215667]], 3, var"##θ#429") - (cos)((*)(π, x))]
              end
          end
      end)
```
```julia
julia> bcs_loss
3-element Array{Expr,1}:
 :((cord, var"##θ#429", phi, derivative, u_arr, u_d_arr)->begin
          #=  =#
          #= =#
          begin
              (u,) = (u_arr[1],)
              (u_d,) = (u_d_arr[1],)
              let () = ()
                  [u(0.0, var"##θ#429", phi) - 0.0]
              end
          end
      end)
 :((cord, var"##θ#429", phi, derivative, u_arr, u_d_arr)->begin
          #= =#
          #=  =#
          begin
              (u,) = (u_arr[1],)
              (u_d,) = (u_d_arr[1],)
              let () = ()
                  [u(1.0, var"##θ#429", phi) - -1.0]
              end
          end
      end)
 :((cord, var"##θ#429", phi, derivative, u_arr, u_d_arr)->begin
          #=  =#
          #= =#
          begin
              (u,) = (u_arr[1],)
              (u_d,) = (u_d_arr[1],)
              let () = ()
                  [derivative(phi, u_d, [1.0], Array{Float32,1}[[0.0049215667]], 1, var"##θ#429") - 1.0]
              end
          end
      end)
```
