### PR TITLE
Update the PINN manual

### DIFF
--- a/docs/src/solvers/pinn.md
+++ b/docs/src/solvers/pinn.md
@@ -10,18 +10,16 @@ Using the PINNs solver, we can solve general nonlinear PDEs:
 
 where time t is a special component of x, and Ω contains the temporal domain.
 
-We describe the PDE in the form of the ModelingToolKit interface. See an example of how this can be done above or take a look at the tests.
-
-A General PDE Problem can be defined using a `PDESystem`:
+PDEs are defined using the ModelingToolkit.jl `PDESystem`:
 
 ```julia
 pde_system = PDESystem(eq,bcs,domains,param,var)
 ```
 
-Here, `eq` is the equation, `bcs` represents the boundary conditions,
-`param` is the parameter of the equation (like `[x,y]`), and `var` represents variables (like `[u]`).
+Here, `eq` is the equation, `bcs` represents the boundary conditions, `param` is 
+the parameter of the equation (like `[x,y]`), and `var` represents variables (like `[u]`).
 
-To solve this problem, use the `PhysicsInformedNN` algorithm.
+The `PhysicsInformedNN` discretizer is defined as:
 
 ```julia
 discretization = PhysicsInformedNN(chain,
@@ -31,9 +29,10 @@ discretization = PhysicsInformedNN(chain,
                                    strategy = GridTraining())
 ```
 
-Here,
+Keyword arguments:
+
 - `chain` is a Flux.jl chain, where the input of NN equals the number of dimensions and output equals the number of equations in the system
-- `init_params` is the initial parameter of the neural network
+- `init_params` is the initial parameter of the neural network. If nothing then automatically generated from the neural network.
 - `phi` is a trial solution
 - `derivative` is a method that calculates the derivative
 - `strategy` determines which training strategy will be used.
@@ -44,36 +43,31 @@ The method `discretize` interprets from the ModelingToolkit PDE form to the PINN
 prob = discretize(pde_system, discretization)
 ```
 
-To run solve, we can use:
-```julia
-res = GalacticOptim.solve(prob, opt;  cb = cb, maxiters=maxiters)
-```
-Here,
-`opt` is an optimizer, `cb` is a callback function, and `maxiters` is a number of iterations.
-
+which outputs an `OptimizationProblem` for [GalacticOptim.jl](https://galacticoptim.sciml.ai/dev/).
 
 ### Training strategy
 
 List of training strategies that are available now:
 
- - `GridTraining()`: Initialize points on a lattice and never change them during
-the training process.
- - `StochasticTraining()`: In each optimization iteration, we randomly select
-the subset of points from a full training set.
-- `QuasiRandomTraining()`: The training set is generated on [Quasi-Monte Carlo
- samples](https://github.com/SciML/QuasiMonteCarlo.jl)
-- `QuadratureTraining()`: Сompute an approximation of the integral of the loss function at each iteration using [adaptive quadrature methods](https://en.wikipedia.org/wiki/Adaptive_quadrature).
-
-The following algorithms are available: CubaVegas, CubaSUAVE, CubaDivonne,HCubatureJL, CubatureJLh, CubatureJLp, CubaCuhre
-
-More details, about the implementation of the algorithms used, can be found in [Quadrature.jl](https://github.com/SciML/Quadrature.jl)
-
+ - `GridTraining(dx)`: Initialize points on a lattice uniformly spaced via `dx`. If
+   `dx` is a scalar, then `dx` corresponds to the spacing in each direction. If `dx`
+   is a vector, then it should be sized to match the number of dimensions and corresponds
+   to the spacing per direction.
+ - `StochasticTraining(points)`: `points` number of sochastically sampled points from the domain. 
+   In each optimization iteration, we randomly select a new subset of points from a full training set.
+- `QuasiRandomTraining(sampling_alg)`: The training set is generated on quasi-random low discrepency
+  sequences. See the [QuasiMonteCarlo.jl](https://github.com/SciML/QuasiMonteCarlo.jl) for the full
+  set of quasi-random sampling algorithms which are available.
+- `QuadratureTraining(quadrature_alg)`: The loss is computed as an approximation of the integral of the PDE loss 
+  at each iteration using [adaptive quadrature methods](https://en.wikipedia.org/wiki/Adaptive_quadrature)
+  via the differentiable [Quadrature.jl](https://github.com/SciML/Quadrature.jl). See the Quadrature.jl
+  documentation for the choices of quadrature methods.
 
 ### Low-level API
 
-Besides the high-level API: `discretize(pde_system, discretization)`, we can also use the low-level API methods:
-`build_loss_function`, `get_loss_function`,`generate_training_sets`,
-`get_phi`, `get_numeric_derivative`,
-`build_symbolic_loss_function`, `symbolic_discretize`.
+These additional methods exist to help with introspection:
+
+- `symbolic_discretize(pde_system,discretization)`: This method is the same as `discretize` but instead
+  returns the unevaluated Julia function to allow the user to see the generated training code.
 
 See how this can be used in the docs examples or take a look at the tests.


### PR DESCRIPTION
This is a big update to the manual page.

- Training strategies are documented succinctly with their arguments.
- The introduction is cut down to be more legible.
- Cut down the low-level API. Do users actually need to use most of those? I don't think they should, and if they need to, I think we need to rework a few things.