### PR TITLE
[WIP] Added better support for heterogeneous input dependent variables

### DIFF
--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -429,7 +429,7 @@ function get_vars(indvars_, depvars_)
             dname = nameof(value(d).f)
             push!(depvars, dname)
             push!(dict_depvar_input, dname => [nameof(value(argument)) for argument in value(d).arguments])
-        elseif value(d) isa Symbol
+        elseif value(d) isa Sym
             dname = nameof(value(d))
             push!(depvars, dname)
             push!(dict_depvar_input, dname => indvars) # default to all inputs if not given

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -137,9 +137,9 @@ Dict{Symbol,Int64} with 3 entries:
 get_dict_vars(vars) = Dict( [Symbol(v) .=> i for (i,v) in enumerate(vars)])
 
 # Wrapper for _transform_expression
-function transform_expression(ex,dict_indvars,dict_depvars, chain,initθ, strategy)
+function transform_expression(ex,dict_indvars,dict_depvars, dict_depvar_input, chain,initθ, strategy)
     if ex isa Expr
-        ex = _transform_expression(ex,dict_indvars,dict_depvars,chain,initθ,strategy)
+        ex = _transform_expression(ex,dict_indvars,dict_depvars, dict_depvar_input,chain,initθ,strategy)
     end
     return ex
 end
@@ -169,7 +169,7 @@ where
  order - order of derivative
  θ - weight in neural network
 """
-function _transform_expression(ex,dict_indvars,dict_depvars, chain, initθ, strategy)
+function _transform_expression(ex,dict_indvars,dict_depvars, dict_depvar_input, chain,initθ, strategy)
     _args = ex.args
     for (i,e) in enumerate(_args)
         if !(e isa Expr)
@@ -196,9 +196,12 @@ function _transform_expression(ex,dict_indvars,dict_depvars, chain, initθ, stra
                 num_depvar = dict_depvars[depvar]
                 indvars = _args[2:end]
                 cord = :cord
+                #dim_l = length(dict_indvars)
                 dim_l = length(indvars)
                 εs = [get_ε(dim_l,d) for d in 1:dim_l]
-                undv = [dict_indvars[d_p] for d_p  in derivative_variables]
+                dict_interior_indvars = Dict([indvar .=> j for (j, indvar) in enumerate(dict_depvar_input[depvar])])
+                #undv = [dict_indvars[d_p] for d_p  in derivative_variables]
+                undv = [dict_interior_indvars[d_p] for d_p  in derivative_variables]
                 εs_dnv = [εs[d] for d in undv]
                 ex.args = if !(typeof(chain) <: AbstractVector)
                     [:derivative, :phi, :u, cord, εs_dnv, order, :($θ)]
@@ -208,7 +211,7 @@ function _transform_expression(ex,dict_indvars,dict_depvars, chain, initθ, stra
                 break
             end
         else
-            ex.args[i] = _transform_expression(ex.args[i],dict_indvars,dict_depvars,chain,initθ,strategy)
+            ex.args[i] = _transform_expression(ex.args[i],dict_indvars,dict_depvars, dict_depvar_input,chain,initθ,strategy)
         end
     end
     return ex
@@ -242,18 +245,18 @@ Example:
        (derivative(phi2, u2, [x, y], [[ε,0]], 1, θ2) + 9 * derivative(phi1, u, [x, y], [[0,ε]], 1, θ1)) - 0]
 """
 
-function build_symbolic_equation(eq,_indvars,_depvars,chain,initθ,strategy)
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(_indvars, _depvars)
-    parse_equation(eq,dict_indvars,dict_depvars,chain,initθ,strategy)
+function build_symbolic_equation(eq,_indvars,_depvars, dict_depvar_input,chain,initθ,strategy)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(_indvars, _depvars)
+    parse_equation(eq,dict_indvars,dict_depvars, dict_depvar_input,chain,initθ,strategy)
 end
 
 
-function parse_equation(eq,dict_indvars,dict_depvars,chain,initθ, strategy)
+function parse_equation(eq,dict_indvars,dict_depvars, dict_depvar_input,chain,initθ, strategy)
     eq_lhs = isequal(expand_derivatives(eq.lhs), 0) ? eq.lhs : expand_derivatives(eq.lhs)
     eq_rhs = isequal(expand_derivatives(eq.rhs), 0) ? eq.rhs : expand_derivatives(eq.rhs)
 
-    left_expr = transform_expression(toexpr(eq_lhs),dict_indvars,dict_depvars,chain,initθ,strategy)
-    right_expr = transform_expression(toexpr(eq_rhs),dict_indvars,dict_depvars,chain,initθ,strategy)
+    left_expr = transform_expression(toexpr(eq_lhs),dict_indvars,dict_depvars, dict_depvar_input,chain,initθ,strategy)
+    right_expr = transform_expression(toexpr(eq_rhs),dict_indvars,dict_depvars, dict_depvar_input,chain,initθ,strategy)
     left_expr = Broadcast.__dot__(left_expr)
     right_expr = Broadcast.__dot__(right_expr)
     loss_func = :($left_expr .- $right_expr)
@@ -284,12 +287,12 @@ to
           end
       end)
 """
-function build_symbolic_loss_function(eqs,_indvars,_depvars, phi, derivative,chain,initθ,strategy; bc_indvars=nothing , eq_params = SciMLBase.NullParameters(), param_estim = false,default_p=nothing)
+function build_symbolic_loss_function(eqs,_indvars,_depvars,dict_depvar_input, phi, derivative,chain,initθ,strategy; bc_indvars=nothing , eq_params = SciMLBase.NullParameters(), param_estim = false,default_p=nothing)
     # dictionaries: variable -> unique number
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(_indvars, _depvars)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(_indvars, _depvars)
     bc_indvars = bc_indvars==nothing ? indvars : bc_indvars
     return build_symbolic_loss_function(eqs,indvars,depvars,
-                                        dict_indvars,dict_depvars,
+                                        dict_indvars,dict_depvars,dict_depvar_input,
                                         phi, derivative,chain,initθ,strategy,
                                         bc_indvars = bc_indvars, eq_params = eq_params, param_estim = param_estim,default_p=default_p)
 end
@@ -309,11 +312,11 @@ function get_indvars_ex(bc_indvars)
 end
 
 function build_symbolic_loss_function(eqs,indvars,depvars,
-                                      dict_indvars,dict_depvars,
+                                      dict_indvars,dict_depvars, dict_depvar_input,
                                       phi, derivative, chain,initθ, strategy; eq_params = SciMLBase.NullParameters(), param_estim = param_estim,default_p=default_p,
                                       bc_indvars = indvars)
 
-    loss_function = parse_equation(eqs,dict_indvars,dict_depvars,chain,initθ,strategy)
+    loss_function = parse_equation(eqs,dict_indvars,dict_depvars, dict_depvar_input,chain,initθ,strategy)
     vars = :(cord, $θ, phi, derivative,u,p)
     ex = Expr(:block)
     if typeof(chain) <: AbstractVector
@@ -377,8 +380,10 @@ function build_symbolic_loss_function(eqs,indvars,depvars,
         vars_eq = Expr(:(=), build_expr(:tuple, left_arg_pairs), build_expr(:tuple, right_arg_pairs))
 
     else
-        indvars_ex = [:($:cord[[$i],:]) for (i, u) ∈ enumerate(indvars)]
-        left_arg_pairs, right_arg_pairs = indvars,indvars_ex
+        #indvars_ex = [:($:cord[[$i],:]) for (i, u) ∈ enumerate(indvars)]
+        indvars_ex = [:($:cord[[$i],:]) for (i, u) ∈ enumerate(bc_indvars)]
+        #left_arg_pairs, right_arg_pairs = indvars,indvars_ex
+        left_arg_pairs, right_arg_pairs = bc_indvars,indvars_ex
         vars_eq = Expr(:(=), build_expr(:tuple, left_arg_pairs), build_expr(:tuple, right_arg_pairs))
         vcat_expr_loss_functions = loss_function #TODO rename
     end
@@ -389,22 +394,22 @@ function build_symbolic_loss_function(eqs,indvars,depvars,
     expr_loss_function = :(($vars) -> begin $ex end)
 end
 
-function build_loss_function(eqs,_indvars,_depvars, phi, derivative,chain,initθ,strategy;bc_indvars=nothing,eq_params=SciMLBase.NullParameters(),param_estim=false,default_p=nothing)
+function build_loss_function(eqs,_indvars,_depvars,dict_depvar_input, phi, derivative,chain,initθ,strategy;bc_indvars=nothing,eq_params=SciMLBase.NullParameters(),param_estim=false,default_p=nothing)
     # dictionaries: variable -> unique number
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(_indvars, _depvars)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(_indvars, _depvars)
     bc_indvars = bc_indvars==nothing ? indvars : bc_indvars
     return build_loss_function(eqs,indvars,depvars,
-                               dict_indvars,dict_depvars,
+                               dict_indvars,dict_depvars,dict_depvar_input,
                                phi, derivative,chain,initθ,strategy,
                                bc_indvars = bc_indvars, eq_params=eq_params,param_estim=param_estim,default_p=default_p)
 end
 
 function build_loss_function(eqs,indvars,depvars,
-                             dict_indvars,dict_depvars,
+                             dict_indvars,dict_depvars,dict_depvar_input,
                              phi, derivative, chain,initθ, strategy;
                              bc_indvars = indvars,eq_params=SciMLBase.NullParameters(),param_estim=false,default_p=nothing)
      expr_loss_function = build_symbolic_loss_function(eqs,indvars,depvars,
-                                                       dict_indvars,dict_depvars,
+                                                       dict_indvars,dict_depvars,dict_depvar_input,
                                                        phi, derivative, chain,initθ,strategy;
                                                        bc_indvars = bc_indvars,eq_params = eq_params,param_estim=param_estim,default_p=default_p)
     u = get_u()
@@ -416,15 +421,29 @@ function build_loss_function(eqs,indvars,depvars,
 end
 
 function get_vars(indvars_, depvars_)
-    depvars = [nameof(value(d)) for d in depvars_]
     indvars = [nameof(value(i)) for i in indvars_]
+    depvars = Symbol[]
+    dict_depvar_input = Dict{Symbol, Vector{Symbol}}()
+    for d in depvars_
+        if value(d) isa Term
+            dname = nameof(value(d).f)
+            push!(depvars, dname)
+            push!(dict_depvar_input, dname => [nameof(value(argument)) for argument in value(d).arguments])
+        elseif value(d) isa Symbol
+            dname = nameof(value(d))
+            push!(depvars, dname)
+            push!(dict_depvar_input, dname => indvars) # default to all inputs if not given
+        end
+    end
+    
+    #depvars = [nameof(value(d)) for d in depvars_]
     dict_indvars = get_dict_vars(indvars)
     dict_depvars = get_dict_vars(depvars)
-    return depvars,indvars,dict_indvars,dict_depvars
+    return depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input
 end
 
 function get_variables(eqs,_indvars::Array,_depvars::Array)
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(_indvars, _depvars)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(_indvars, _depvars)
     return get_variables(eqs,dict_indvars,dict_depvars)
 end
 
@@ -452,7 +471,7 @@ end
 
 # Get arguments from boundary condition functions
 function get_argument(eqs,_indvars::Array,_depvars::Array)
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(_indvars, _depvars)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(_indvars, _depvars)
     get_argument(eqs,dict_indvars,dict_depvars)
 end
 function get_argument(eqs,dict_indvars,dict_depvars)
@@ -469,7 +488,7 @@ function get_argument(eqs,dict_indvars,dict_depvars)
 end
 
 function generate_training_sets(domains,dx,eqs,bcs,_indvars::Array,_depvars::Array)
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(_indvars, _depvars)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(_indvars, _depvars)
     return generate_training_sets(domains,dx,eqs,bcs,dict_indvars,dict_depvars)
 end
 # Generate training set in the domain and on the boundary
@@ -519,12 +538,12 @@ function generate_training_sets(domains,dx,eqs,bcs,dict_indvars::Dict,dict_depva
 end
 
 function get_bounds(domains,eqs,bcs,_indvars::Array,_depvars::Array)
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(_indvars, _depvars)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(_indvars, _depvars)
     return get_bounds(domains,eqs,bcs,dict_indvars,dict_depvars)
 end
 
 function get_bounds(domains,bcs,_indvars::Array,_depvars::Array,strategy::QuadratureTraining)
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(_indvars, _depvars)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(_indvars, _depvars)
     return get_bounds(domains,bcs,dict_indvars,dict_depvars,strategy)
 end
 
@@ -716,7 +735,7 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ph
 
     # dimensionality of equation
     dim = length(domains)
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(pde_system.indvars, pde_system.depvars)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(pde_system.indvars, pde_system.depvars)
 
     chain = discretization.chain
     initθ = discretization.init_params
@@ -726,9 +745,15 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ph
     if !(eqs isa Array)
         eqs = [eqs]
     end
+    pde_indvars = if strategy isa QuadratureTraining
+         get_argument(eqs,dict_indvars,dict_depvars)
+    else
+         get_variables(eqs,dict_indvars,dict_depvars)
+    end
     symbolic_pde_loss_functions = [build_symbolic_loss_function(eq,indvars,depvars,
-                                                              dict_indvars,dict_depvars,
-                                                              phi, derivative,chain,initθ,strategy;eq_params=eq_params,param_estim=param_estim,default_p=default_p) for eq in eqs]
+                                                              dict_indvars,dict_depvars,dict_depvar_input,
+                                                              phi, derivative,chain,initθ,strategy;eq_params=eq_params,param_estim=param_estim,default_p=default_p,
+                                                              bc_indvars = pde_indvar) for (eq, pde_indvar) in zip(eqs,pde_indvars)]
 
     bc_indvars = if strategy isa QuadratureTraining
          get_argument(bcs,dict_indvars,dict_depvars)
@@ -736,7 +761,7 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ph
          get_variables(bcs,dict_indvars,dict_depvars)
     end
     symbolic_bc_loss_functions = [build_symbolic_loss_function(bc,indvars,depvars,
-                                                               dict_indvars,dict_depvars,
+                                                               dict_indvars,dict_depvars,dict_depvar_input,
                                                                phi, derivative,chain,initθ,strategy,eq_params=eq_params,param_estim=param_estim,default_p=default_p;
                                                                bc_indvars = bc_indvar) for (bc,bc_indvar) in zip(bcs,bc_indvars)]
     symbolic_pde_loss_functions,symbolic_bc_loss_functions
@@ -757,7 +782,7 @@ function SciMLBase.discretize(pde_system::PDESystem, discretization::PhysicsInfo
 
     # dimensionality of equation
     dim = length(domains)
-    depvars,indvars,dict_indvars,dict_depvars = get_vars(pde_system.indvars,pde_system.depvars)
+    depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = get_vars(pde_system.indvars,pde_system.depvars)
 
     chain = discretization.chain
     initθ = discretization.init_params
@@ -769,9 +794,15 @@ function SciMLBase.discretize(pde_system::PDESystem, discretization::PhysicsInfo
     if !(eqs isa Array)
         eqs = [eqs]
     end
+    pde_indvars = if strategy isa QuadratureTraining
+         get_argument(eqs,dict_indvars,dict_depvars)
+    else
+         get_variables(eqs,dict_indvars,dict_depvars)
+    end
     _pde_loss_functions = [build_loss_function(eq,indvars,depvars,
-                                             dict_indvars,dict_depvars,
-                                             phi, derivative,chain, initθ,strategy,eq_params=eq_params,param_estim=param_estim,default_p=default_p) for eq in eqs]
+                                             dict_indvars,dict_depvars,dict_depvar_input,
+                                             phi, derivative,chain, initθ,strategy,eq_params=eq_params,param_estim=param_estim,default_p=default_p,
+                                             bc_indvars = pde_indvar) for (eq, pde_indvar) in zip(eqs,pde_indvars)]
     bc_indvars = if strategy isa QuadratureTraining
          get_argument(bcs,dict_indvars,dict_depvars)
     else
@@ -779,7 +810,7 @@ function SciMLBase.discretize(pde_system::PDESystem, discretization::PhysicsInfo
     end
 
     _bc_loss_functions = [build_loss_function(bc,indvars,depvars,
-                                                  dict_indvars,dict_depvars,
+                                                  dict_indvars,dict_depvars,dict_depvar_input,
                                                   phi, derivative,chain, initθ, strategy,eq_params=eq_params,param_estim=param_estim,default_p=default_p;
                                                   bc_indvars = bc_indvar) for (bc,bc_indvar) in zip(bcs,bc_indvars)]
 
@@ -863,7 +894,7 @@ function SciMLBase.discretize(pde_system::PDESystem, discretization::PhysicsInfo
 
         if bl == 0
             _bc_loss_functions = [build_loss_function(bc,indvars,depvars,
-                                                          dict_indvars,dict_depvars,
+                                                          dict_indvars,dict_depvars,dict_depvar_input,
                                                           phi, get_numeric_derivative(),chain, initθ, GridTraining(0.1);
                                                           bc_indvars = bc_indvar) for (bc,bc_indvar) in zip(bcs,bc_indvars)]
             train_sets = generate_training_sets(domains,0.1,eqs,bcs,

--- a/test/NNPDE_tests.jl
+++ b/test/NNPDE_tests.jl
@@ -304,14 +304,15 @@ initθ = DiffEqFlux.initial_params(chain)
 
 indvars = [x,t]
 depvars = [u]
+_,_,_,_,dict_depvar_input = NeuralPDE.get_vars(indvars, depvars)
 dim = length(domains)
 quadrature_strategy = NeuralPDE.QuadratureTraining(quadrature_alg=CubatureJLh(),reltol= 1e-4,abstol= 1e-3,maxiters=10, batch=10)
 
-_pde_loss_function = NeuralPDE.build_loss_function(eq,indvars,depvars,phi, derivative,chain,initθ,quadrature_strategy)
+_pde_loss_function = NeuralPDE.build_loss_function(eq,indvars,depvars,dict_depvar_input,phi, derivative,chain,initθ,quadrature_strategy)
 _pde_loss_function(rand(2,10), initθ)
 
 bc_indvars = NeuralPDE.get_argument(bcs,indvars,depvars)
-_bc_loss_functions = [NeuralPDE.build_loss_function(bc,indvars,depvars, phi, derivative,chain,initθ,quadrature_strategy,
+_bc_loss_functions = [NeuralPDE.build_loss_function(bc,indvars,depvars,dict_depvar_input, phi, derivative,chain,initθ,quadrature_strategy,
                                               bc_indvars = bc_indvar) for (bc,bc_indvar) in zip(bcs,bc_indvars)]
 map(loss_f -> loss_f(rand(1,10), initθ),_bc_loss_functions)
 

--- a/test/NNPDE_tests_het.jl
+++ b/test/NNPDE_tests_het.jl
@@ -48,14 +48,14 @@ strategies = [stochastic_strategy, quadrature_strategy]
 strategy_ = strategies[1]
 
 #=
-println("Example 10, Simple Heterongenous input PDE comparison, strategy: $strategy_")
+println("Example 10, Simple Heterogeneous input PDE comparison, strategy: $strategy_")
 @parameters x y
 @variables r(..)
 Dx = Differential(x)
 Dy = Differential(y)
 
 # 2D PDE
-eq  = Dx(r(x, y)) + r(x, y) ~ 0
+eq  = Dx(r(x,y)) + r(x, y) ~ 0
 
 # Initial and boundary conditions
 bcs = [
@@ -73,14 +73,16 @@ discretization = NeuralPDE.PhysicsInformedNN(fastchains,
 
 pde_system = PDESystem(eq,bcs,domains,[x,y],[r(x,y)])
 end
-@run prob = NeuralPDE.discretize(pde_system,discretization)
+sym_prob = NeuralPDE.symbolic_discretize(pde_system,discretization)
 @run sym_prob = NeuralPDE.symbolic_discretize(pde_system,discretization)
+prob = NeuralPDE.discretize(pde_system,discretization)
 initθ = discretization.init_params
 initθvec = vcat(initθ...)
+prob.f(initθvec, [])
 @run prob.f(initθvec, [])
 =#
 
-println("Example 10, Simple Heterongenous input PDE, strategy: $strategy_")
+println("Example 10, Simple Heterogeneous input PDE, strategy: $strategy_")
 @parameters x y
 @variables p(..) q(..) r(..) s(..)
 Dx = Differential(x)
@@ -107,14 +109,14 @@ discretization = NeuralPDE.PhysicsInformedNN(fastchains,
                                                 strategy_)
 
 pde_system = PDESystem(eq,bcs,domains,[x,y],[p(x), q(y), r(x,y), s(y,x)])
-
-
-
-
 end
+
+
+
+
 sym_prob = NeuralPDE.symbolic_discretize(pde_system,discretization)
 @run sym_prob = NeuralPDE.symbolic_discretize(pde_system,discretization)
-@run prob = NeuralPDE.discretize(pde_system,discretization)
+prob = NeuralPDE.discretize(pde_system,discretization)
 initθ = discretization.init_params
 initθvec = vcat(initθ...)
 prob.f(initθvec, [])

--- a/test/NNPDE_tests_het.jl
+++ b/test/NNPDE_tests_het.jl
@@ -1,0 +1,164 @@
+begin
+push!(LOAD_PATH, "/home/zobot/.julia/dev/NeuralPDE.jl/src")
+using Revise
+using Flux
+println("NNPDE_tests_heterogeneous")
+using DiffEqFlux
+println("Starting Soon!")
+using ModelingToolkit
+using DiffEqBase
+using Test, NeuralPDE
+println("Starting Soon!")
+using GalacticOptim
+using Optim
+using Quadrature,Cubature, Cuba
+using QuasiMonteCarlo
+using SciMLBase
+using OrdinaryDiffEq
+
+using Random
+end
+
+begin
+Random.seed!(100)
+cb = function (p,l)
+    println("Current loss is: $l")
+    return false
+end
+
+## Example 1, 1D ode
+function test_heterogeneous_input(strategy_)
+end
+
+dx = 0.1
+grid_strategy = NeuralPDE.GridTraining(dx)
+stochastic_strategy = NeuralPDE.StochasticTraining(6) #points
+quadrature_strategy = NeuralPDE.QuadratureTraining(quadrature_alg=CubatureJLh(),
+                                                    reltol=1e-3,abstol=1e-3,
+                                                    maxiters =50, batch=100)
+quasirandom_strategy = NeuralPDE.QuasiRandomTraining(100; #points
+                                                     sampling_alg = UniformSample(),
+                                                     minibatch = 100)
+
+strategies = [grid_strategy, stochastic_strategy, quadrature_strategy,quasirandom_strategy]
+strategies = [stochastic_strategy]
+#for strategy_ in strategies
+    #test_heterogeneous_input(strategy_)
+#end
+strategy_ = strategies[1]
+
+#=
+println("Example 10, Simple Heterongenous input PDE comparison, strategy: $strategy_")
+@parameters x y
+@variables r(..)
+Dx = Differential(x)
+Dy = Differential(y)
+
+# 2D PDE
+eq  = Dx(r(x, y)) + r(x, y) ~ 0
+
+# Initial and boundary conditions
+bcs = [
+        r(x,-1) ~ 0.f0, r(1, y) ~ 0.0f0, 
+        ]
+# Space and time domains
+domains = [x ∈ IntervalDomain(0.0,1.0),
+            y ∈ IntervalDomain(-1.0,0.0)]
+
+# chain_ = FastChain(FastDense(2,12,Flux.σ),FastDense(12,12,Flux.σ),FastDense(12,1))
+numhid = 3
+fastchains = FastChain(FastDense(2,numhid,Flux.σ),FastDense(numhid,numhid,Flux.σ),FastDense(numhid,1))
+discretization = NeuralPDE.PhysicsInformedNN(fastchains,
+                                                strategy_)
+
+pde_system = PDESystem(eq,bcs,domains,[x,y],[r(x,y)])
+end
+@run prob = NeuralPDE.discretize(pde_system,discretization)
+@run sym_prob = NeuralPDE.symbolic_discretize(pde_system,discretization)
+initθ = discretization.init_params
+initθvec = vcat(initθ...)
+@run prob.f(initθvec, [])
+=#
+
+println("Example 10, Simple Heterongenous input PDE, strategy: $strategy_")
+@parameters x y
+@variables p(..) q(..) r(..) s(..)
+Dx = Differential(x)
+Dy = Differential(y)
+
+# 2D PDE
+eq  = p(x) + q(y) + r(x, y) + s(y, x) ~ 0
+#eq  = Dx(p(x)) + Dy(q(y)) + Dx(r(x, y)) + Dy(s(y, x)) + p(x) + q(y) + r(x, y) + s(y, x) ~ 0
+
+# Initial and boundary conditions
+bcs = [p(1) ~ 0.f0, q(-1) ~ 0.0f0,
+        r(x,-1) ~ 0.f0, r(1, y) ~ 0.0f0, 
+        s(y,1) ~ 0.0f0, s(-1, x) ~ 0.0f0]
+# Space and time domains
+domains = [x ∈ IntervalDomain(0.0,1.0),
+            y ∈ IntervalDomain(-1.0,0.0)]
+
+# chain_ = FastChain(FastDense(2,12,Flux.σ),FastDense(12,12,Flux.σ),FastDense(12,1))
+numhid = 3
+fastchains = [FastChain(FastDense(2,numhid,Flux.σ),FastDense(numhid,numhid,Flux.σ),FastDense(numhid,1)) for i in 1:4]
+discretization = NeuralPDE.PhysicsInformedNN(fastchains,
+                                                strategy_)
+
+pde_system = PDESystem(eq,bcs,domains,[x,y],[p(x), q(y), r(x,y), s(y,x)])
+
+
+
+
+end
+@run sym_prob = NeuralPDE.symbolic_discretize(pde_system,discretization)
+sym_prob = NeuralPDE.symbolic_discretize(pde_system,discretization)
+prob = NeuralPDE.discretize(pde_system,discretization)
+initθ = discretization.init_params
+initθvec = vcat(initθ...)
+@run prob.f(initθvec, [])
+#res = GalacticOptim.solve(prob, ADAM(0.1); cb = cb, maxiters=3)
+phi = discretization.phi
+eqs = pde_system.eqs
+bcs = pde_system.bcs
+
+domains = pde_system.domain
+eq_params = pde_system.ps
+defaults = pde_system.defaults
+default_p = eq_params == SciMLBase.NullParameters() ? nothing : [defaults[ep] for ep in eq_params]
+
+param_estim = discretization.param_estim
+additional_loss = discretization.additional_loss
+
+# dimensionality of equation
+dim = length(domains)
+depvars,indvars,dict_indvars,dict_depvars,dict_depvar_input = NeuralPDE.get_vars(pde_system.indvars,pde_system.depvars)
+
+chain = discretization.chain
+initθ = discretization.init_params
+flat_initθ = if (typeof(chain) <: AbstractVector) vcat(initθ...) else  initθ end
+flat_initθ = if param_estim == false flat_initθ else vcat(flat_initθ, adapt(DiffEqBase.parameterless_type(flat_initθ),default_p)) end
+phi = discretization.phi
+derivative = discretization.derivative
+strategy = discretization.strategy
+if !(eqs isa Array)
+    eqs = [eqs]
+end
+pde_indvars = if strategy isa QuadratureTraining
+        NeuralPDE.get_argument(eqs,dict_indvars,dict_depvars)
+else
+        NeuralPDE.get_variables(eqs,dict_indvars,dict_depvars)
+end
+_pde_loss_functions = [NeuralPDE.build_loss_function(eq,indvars,depvars,
+                                            dict_indvars,dict_depvars,dict_depvar_input,
+                                            phi, derivative,chain, initθ,strategy,eq_params=eq_params,param_estim=param_estim,default_p=default_p,
+                                            bc_indvars = pde_indvar) for (eq, pde_indvar) in zip(eqs,pde_indvars)]
+bc_indvars = if strategy isa QuadratureTraining
+        get_argument(bcs,dict_indvars,dict_depvars)
+else
+        get_variables(bcs,dict_indvars,dict_depvars)
+end
+
+_bc_loss_functions = [build_loss_function(bc,indvars,depvars,
+                                                dict_indvars,dict_depvars,dict_depvar_input,
+                                                phi, derivative,chain, initθ, strategy,eq_params=eq_params,param_estim=param_estim,default_p=default_p;
+                                                bc_indvars = bc_indvar) for (bc,bc_indvar) in zip(bcs,bc_indvars)]


### PR DESCRIPTION
Added better support for heterogeneous inputs via a new dictionary dict_depvar_input that contains for each dependent variable symbol: a list of the independent variables it depends on, in order.  This was added to support the SPM model.  This dictionary is created in get_vars by examining if a depvar is applied to variables such as Q(t) or Q(t, r) and then it populates the dict based off of those.  If a dependent variable isn't applied to independent variables then it populates the dictionary by the default of all the independent variables in order.

This makes the SPM model run, I need to verify that all the previous tests are unbroken and add docs/test for the new syntax.  This should in theory be backwards compatible for most models that aren't heterogeneous in input, but will likely break older heterogeneous models that don't include their input variables in the PDESystem dependent variable Nums.  There were a few issues, the biggest two being supporting dependent variables using different orderings of the independent variables than expected in dict_indvars, and also keeping track of substitutions for boundary conditions of these heterogeneous inputs.

Here is an example of the syntax now supported (on a bogus system, but illustrates the heterogeneity):
```julia
@parameters t x y
@variables Q(..) P(..) Z(..)
Dt = Differential(t)
Dx = Differential(x)
Dy = Differential(y)

eqs = [Dt(Q(t)) ~ 1,
           Dt(P(t, x)) ~ Dx(P(t, x)),
           Dt(Z(t, y)) ~ Dy(Z(t, y))]

ics_bcs = [Q(0) ~ 0,
                 P(0, x) ~ x,
                 Z(0, y) ~ y]

t_domain = IntervalDomain(0.0, 1.0)
x_domain = IntervalDomain(0.0, 1.0)
y_domain = IntervalDomain(0.0, 1.0)

ind_vars = [t, x, y]
dep_vars = [Q(t), P(t, x), Z(t,y)]
pde_system = PDESystem(eqs, ics_bcs, domains, ind_vars, dep_vars)
```