### PR TITLE
fix additional_loss

### DIFF
--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -16,6 +16,7 @@ using QuasiMonteCarlo
 using RuntimeGeneratedFunctions
 using SciMLBase
 using Statistics
+using ArrayInterface
 import Tracker, Optim
 import ModelingToolkit: value, nameof, toexpr, build_expr, expand_derivatives
 import ModelingToolkit: Interval, infimum, supremum #,Ball

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -936,9 +936,12 @@ function SciMLBase.discretize(pde_system::PDESystem, discretization::PhysicsInfo
             return loss_function(θ)
         else
             function _additional_loss(phi,θ)
-                θ_ = θ[1:end - length(default_p)]
-                p = θ[(end - length(default_p) + 1):end]
-                return additional_loss(phi,θ_,p)
+                (θ_,p_) = if (param_estim == true)
+                    θ[1:end - length(default_p)], θ[(end - length(default_p) + 1):end]
+                else
+                    θ, nothing
+                end
+                return additional_loss(phi,θ,p_)
             end
             return loss_function(θ) + _additional_loss(phi,θ)
         end

--- a/test/NNPDE_tests.jl
+++ b/test/NNPDE_tests.jl
@@ -527,14 +527,15 @@ len = length(data[2])
 function additional_loss(phi, θ , p)
     return sum(sum(abs2, phi[i](t_ , θ[sep[i]]) .- u_[[i], :])/len for i in 1:1:3)
 end
-testθ =reduce(vcat,initθs)
-additional_loss(discretization.phi, testθ, nothing)
 
 discretization = NeuralPDE.PhysicsInformedNN(chain,
                                              NeuralPDE.GridTraining(dt);
                                              init_params =initθs,
                                              param_estim=true,
                                              additional_loss=additional_loss)
+testθ =reduce(vcat,initθs)
+additional_loss(discretization.phi, testθ, nothing)
+
 pde_system = PDESystem(eqs,bcs,domains,
                       [t],[x, y, z],[σ_, ρ, β],
                       defaults=Dict([p => 1.0 for p in [σ_, ρ, β]]))

--- a/test/NNPDE_tests.jl
+++ b/test/NNPDE_tests.jl
@@ -527,6 +527,8 @@ len = length(data[2])
 function additional_loss(phi, θ , p)
     return sum(sum(abs2, phi[i](t_ , θ[sep[i]]) .- u_[[i], :])/len for i in 1:1:3)
 end
+testθ =reduce(vcat,initθs)
+additional_loss(discretization.phi, testθ, nothing)
 
 discretization = NeuralPDE.PhysicsInformedNN(chain,
                                              NeuralPDE.GridTraining(dt);
@@ -535,9 +537,10 @@ discretization = NeuralPDE.PhysicsInformedNN(chain,
                                              additional_loss=additional_loss)
 pde_system = PDESystem(eqs,bcs,domains,
                       [t],[x, y, z],[σ_, ρ, β],
-                      defaults=Dict([p .=> 1.0 for p in [σ_, ρ, β]]))
+                      defaults=Dict([p => 1.0 for p in [σ_, ρ, β]]))
 prob = NeuralPDE.discretize(pde_system,discretization)
 sym_prob = NeuralPDE.symbolic_discretize(pde_system,discretization)
+prob.f.f.loss_function([testθ;ones(3)])
 
 res = GalacticOptim.solve(prob, Optim.BFGS(); cb = cb, maxiters=6000)
 p_ = res.minimizer[end-2:end]


### PR DESCRIPTION
`additional_loss` didn't work with `param_estim=false` because theta is truncated and this is only needed when `param_estim=true`

https://github.com/SciML/NeuralPDE.jl/blob/d42dbd54072567096407e990c8685a63ea7d1b13/src/pinns_pde_solve.jl#L938-L941