### PR TITLE
Increase integral performance with map

### DIFF
--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -867,7 +867,7 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
                     end
                 end
 
-                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ),  eachcol(cord__), eachcol(lb_), eachcol(ub_))
+                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ),  eachcol(cord), eachcol(lb_), eachcol(ub_))
                 return reshape(integration_arr, :, length(integration_arr)) 
             end
 end

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -867,7 +867,7 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
                     end
                 end
 
-                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ), @view cord[:,1], eachcol(lb_), eachcol(ub_))
+                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ),  eachcol(cord__), eachcol(lb_), eachcol(ub_))
                 return reshape(integration_arr, :, length(integration_arr)) 
             end
 end

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -839,7 +839,7 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
             begin
                 flat_θ = if (typeof(chain) <: AbstractVector) reduce(vcat,θ) else θ end
                 function integration_(cord, lb, ub, flat_θ)
-                    cord_ = cord #vcat maybe
+                    cord_ = cord
                     function integrand_(x , p)
                         @Zygote.ignore @views(cord_[integrating_var_id]) .= x
                         return integrand_func(cord_, p, phi, derivative, nothing, u, nothing)
@@ -866,8 +866,7 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
                         @Zygote.ignore ub_[i, :] = u_(cord , flat_θ, phi, derivative, nothing, u, nothing)
                     end
                 end
-
-                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ),  eachcol(cord), eachcol(lb_), eachcol(ub_))
+                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ), @views(eachcol(cord)), @views(eachcol(lb_)), @views(eachcol(ub_)))
                 return reshape(integration_arr, :, length(integration_arr)) 
             end
 end

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -839,7 +839,7 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
             begin
                 flat_θ = if (typeof(chain) <: AbstractVector) reduce(vcat,θ) else θ end
                 function integration_(cord, lb, ub, flat_θ)
-                    cord_ = cord
+                    cord_ = cord #vcat maybe
                     function integrand_(x , p)
                         @Zygote.ignore @views(cord_[integrating_var_id]) .= x
                         return integrand_func(cord_, p, phi, derivative, nothing, u, nothing)
@@ -867,7 +867,8 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
                     end
                 end
 
-                return map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ), eachcol(cord), eachcol(lb_), eachcol(ub_))
+                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ), @view cord[:,1], eachcol(lb_), eachcol(ub_))
+                return reshape(integration_arr, :, length(integration_arr)) 
             end
 end
 

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -837,14 +837,14 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
     integral =
         (u, cord, phi, integrating_var_id, integrand_func, lb, ub, θ ;strategy=strategy, indvars=indvars, depvars=depvars, dict_indvars=dict_indvars, dict_depvars=dict_depvars)->
             begin
-                flat_θ = if (typeof(chain) <: AbstractVector) reduce(vcat,θ) else θ end
-                function integration_(cord, lb, ub, flat_θ)
+                
+                function integration_(cord, lb, ub, θ)
                     cord_ = cord
                     function integrand_(x , p)
                         @Zygote.ignore @views(cord_[integrating_var_id]) .= x
                         return integrand_func(cord_, p, phi, derivative, nothing, u, nothing)
                     end
-                    prob_ = QuadratureProblem(integrand_,lb, ub ,flat_θ)
+                    prob_ = QuadratureProblem(integrand_,lb, ub ,θ)
                     sol = solve(prob_,CubatureJLh(),reltol=1e-3,abstol=1e-3)[1]
                     return sol
                 end
@@ -856,18 +856,18 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
                     if l isa Number
                         @Zygote.ignore lb_[i, :] = fill(l, 1, size(cord)[2])
                     else
-                        @Zygote.ignore lb_[i, :] = l(cord , flat_θ, phi, derivative, nothing, u, nothing)
+                        @Zygote.ignore lb_[i, :] = l(cord , θ, phi, derivative, nothing, u, nothing)
                     end
                 end
                 for (i, u_) in enumerate(ub)
                     if u_ isa Number
                         @Zygote.ignore ub_[i, :] = fill(u_, 1, size(cord)[2])
                     else
-                        @Zygote.ignore ub_[i, :] = u_(cord , flat_θ, phi, derivative, nothing, u, nothing)
+                        @Zygote.ignore ub_[i, :] = u_(cord , θ, phi, derivative, nothing, u, nothing)
                     end
                 end
-                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ), eachcol(cord), eachcol(lb_), eachcol(ub_))
-                return reshape(integration_arr, :, length(integration_arr)) 
+                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,θ), eachcol(cord), eachcol(lb_), eachcol(ub_))
+                return reshape(integration_arr, :, length(integration_arr))
             end
 end
 

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -867,12 +867,7 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
                     end
                 end
 
-                for i in 1:size(cord)[2]
-                    ub__ = @Zygote.ignore getindex(ub_, :,  i)
-                    lb__ = @Zygote.ignore getindex(lb_, :,  i)
-                    integration_arr = hcat(integration_arr ,integration_(cord[:, i], lb__, ub__, flat_θ))
-                end
-                return integration_arr
+                return map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ), eachcol(cord), eachcol(lb_), eachcol(ub_))
             end
 end
 

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -866,11 +866,10 @@ function get_numeric_integral(strategy, _indvars, _depvars, chain, derivative)
                         @Zygote.ignore ub_[i, :] = u_(cord , flat_θ, phi, derivative, nothing, u, nothing)
                     end
                 end
-                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ), @views(eachcol(cord)), @views(eachcol(lb_)), @views(eachcol(ub_)))
+                integration_arr = map((cord__,lb__,ub__) -> integration_(cord__,lb__,ub__,flat_θ), eachcol(cord), eachcol(lb_), eachcol(ub_))
                 return reshape(integration_arr, :, length(integration_arr)) 
             end
 end
-
 
 function get_loss_function(loss_function, train_set, eltypeθ,parameterless_type_θ, strategy::GridTraining;τ=nothing)
     loss = (θ) -> mean(abs2,loss_function(train_set, θ))


### PR DESCRIPTION
https://github.com/SciML/NeuralPDE.jl/issues/390 I changed the loop into a map to improve integral performance. Nothing else is different since the map gives the same inputs to `integration_` (but hopefully it does so a bit more efficiently). If you think there are other quick wins here, let me know. Happy to help.

I will debug this a bit but wanted to open the PR now.