### PR TITLE
Improve integrating_depvars so it works more generally

### DIFF
--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -292,20 +292,11 @@ function _transform_expression(ex,indvars,depvars,dict_indvars,dict_depvars,dict
                 end
 
                 integrating_depvars = []
-                for arg in _args[2].args
-                    if arg ∈ depvars
-                        push!(integrating_depvars,  arg)
-                    elseif arg isa Expr
-                        if arg.args[1] ∈ depvars
-                            push!(integrating_depvars,  arg.args[1])
-                        else
-                            for d in depvars
-                                d_ex = find_thing_in_expr(arg,d)
-                                if !isempty(d_ex)
-                                    push!(integrating_depvars,  d_ex[1].args[1])
-                                end
-                            end
-                        end
+                integrand_expr =_args[2]
+                for d in depvars
+                    d_ex = find_thing_in_expr(integrand_expr,d)
+                    if !isempty(d_ex)
+                        push!(integrating_depvars, d_ex[1].args[1])
                     end
                 end
  
@@ -483,7 +474,7 @@ Finds which dependent variables are being used in an equation.
 function pair(eq, depvars, dict_depvars, dict_depvar_input)
     expr = toexpr(eq)
     pair_ = map(depvars) do depvar
-if !isempty(find_thing_in_expr(expr,  depvar))
+        if !isempty(find_thing_in_expr(expr,  depvar))
             dict_depvars[depvar] => dict_depvar_input[depvar]
         end
     end
@@ -679,8 +670,11 @@ function get_number(eqs,dict_indvars,dict_depvars)
     bc_args = get_argument(eqs,dict_indvars,dict_depvars)
     return map(barg -> filter(x -> x isa Number, barg), bc_args)
 end
-            
-function find_thing_in_expr(ex::Expr, thing; ans = Expr[])
+
+function find_thing_in_expr(ex::Expr, thing; ans = [])
+    if thing in ex.args
+        push!(ans,ex)
+    end
     for e in ex.args
         if e isa Expr
             if thing in e.args

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -308,8 +308,7 @@ function _transform_expression(ex,indvars,depvars,dict_indvars,dict_depvars,dict
                         end
                     end
                 end
-                @show integrating_depvars
-
+ 
                 num_depvar = map(int_depvar -> dict_depvars[int_depvar], integrating_depvars)
                 integrand_ = transform_expression(_args[2],indvars,depvars,dict_indvars,dict_depvars,
                                                 dict_depvar_input, chain,eltypeθ,strategy,

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -292,17 +292,23 @@ function _transform_expression(ex,indvars,depvars,dict_indvars,dict_depvars,dict
                 end
 
                 integrating_depvars = []
-                if last(_args[2].args) isa Symbol
-                    push!(integrating_depvars,  first(_args[2].args))
-                else
-                    for dep in _args[2].args
-                        if dep isa Expr
-                            if dep.args[1] ∈ depvars
-                                push!(integrating_depvars, dep.args[1])
+                for arg in _args[2].args
+                    if arg ∈ depvars
+                        push!(integrating_depvars,  arg)
+                    elseif arg isa Expr
+                        if arg.args[1] ∈ depvars
+                            push!(integrating_depvars,  arg.args[1])
+                        else
+                            for d in depvars
+                                d_ex = find_thing_in_expr(arg,d)
+                                if !isempty(d_ex)
+                                    push!(integrating_depvars,  d_ex[1].args[1])
+                                end
                             end
                         end
                     end
                 end
+                @show integrating_depvars
 
                 num_depvar = map(int_depvar -> dict_depvars[int_depvar], integrating_depvars)
                 integrand_ = transform_expression(_args[2],indvars,depvars,dict_indvars,dict_depvars,


### PR DESCRIPTION
The previous way to get `integrating_depvars` was not working for all cases. This is an attempt to improve it.

this for example wouldn’t work in master but works here

```
@parameters x
@variables u(..) w(..)
Dx = Differential(x)
Ix = Integral(x in DomainSets.ClosedInterval(1, x))
Ii = Integral(x in DomainSets.ClosedInterval(0, 1))

eqs =  [Ix(u(x)*w(x)) ~ log(abs(x)),
        Dx(w(x)) ~ -2/(x^3),
        u(x) ~ x + Ix(u(x)/x)]

bcs = [u(1.) ~ 1.0, w(1.) ~ 1.0]
domains = [x ∈ Interval(1.0,2.0)]

chains = [FastChain(FastDense(1,15,Flux.σ),FastDense(15,1)) for _ in 1:2]
initθ = map(chain -> Float64.(DiffEqFlux.initial_params(chain)),chains)
strategy_ = NeuralPDE.GridTraining(0.1)
discretization = NeuralPDE.PhysicsInformedNN(chains,
                                             strategy_;
                                             init_params = initθ
                                             )
@named pde_system = PDESystem(eqs,bcs,domains,[x],[u(x), w(x)])
prob = NeuralPDE.discretize(pde_system,discretization)
```
