### PR TITLE
Fix reduce bug in GPU

### DIFF
--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -1094,7 +1094,7 @@ function SciMLBase.discretize(pde_system::PDESystem, discretization::PhysicsInfo
 
     chain = discretization.chain
     initθ = discretization.init_params
-    flat_initθ = if (typeof(chain) <: AbstractVector) reduce(vcat,initθ) else  initθ end
+    flat_initθ = if (typeof(chain) <: AbstractVector) reshape(initθ, :) else  initθ end
     eltypeθ = eltype(flat_initθ)
     parameterless_type_θ =  DiffEqBase.parameterless_type(flat_initθ)
 

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -1031,7 +1031,7 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ph
 
     chain = discretization.chain
     initθ = discretization.init_params
-    flat_initθ = if (typeof(chain) <: AbstractVector) reduce(vcat,initθ) else initθ end
+    flat_initθ = if (typeof(chain) <: AbstractVector) reshape(initθ, :) else initθ end
     eltypeθ = eltype(flat_initθ)
     parameterless_type_θ =  DiffEqBase.parameterless_type(flat_initθ)
     phi = discretization.phi

--- a/src/pinns_pde_solve.jl
+++ b/src/pinns_pde_solve.jl
@@ -1031,7 +1031,7 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ph
 
     chain = discretization.chain
     initθ = discretization.init_params
-    flat_initθ = if (typeof(chain) <: AbstractVector) reshape(initθ, :) else initθ end
+    flat_initθ = if (typeof(chain) <: AbstractVector) vcat(initθ...) else initθ end
     eltypeθ = eltype(flat_initθ)
     parameterless_type_θ =  DiffEqBase.parameterless_type(flat_initθ)
     phi = discretization.phi
@@ -1094,7 +1094,7 @@ function SciMLBase.discretize(pde_system::PDESystem, discretization::PhysicsInfo
 
     chain = discretization.chain
     initθ = discretization.init_params
-    flat_initθ = if (typeof(chain) <: AbstractVector) reshape(initθ, :) else  initθ end
+    flat_initθ = if (typeof(chain) <: AbstractVector) vcat(initθ...) else  initθ end
     eltypeθ = eltype(flat_initθ)
     parameterless_type_θ =  DiffEqBase.parameterless_type(flat_initθ)
 


### PR DESCRIPTION
Right now `flat_initθ = if (typeof(chain) <: AbstractVector) reduce(vcat,initθ) else initθ end` is erroring when I run a system with a chain of type AbstractVector on the GPU. Tim helped me debug this here https://julialang.slack.com/archives/C689Y34LE/p1637573211277100

It's a small change but it should fix the problem. Here is an MWE

```julia
using CUDA

chain = [1]
initθ = cu(rand(40))
flat_initθ = if (typeof(chain) <: AbstractVector) reduce(vcat,initθ) else initθ end

# LoadError: GPUArrays.jl needs to know the neutral element for your operator `vcat`. Please pass it as an explicit argument to (if possible), or register it globally your operator by defining `GPUArrays.neutral_element(::typeof(vcat), T)`.
```

```julia
using CUDA

chain = [1]
initθ = cu(rand(40))
flat_initθ = if (typeof(chain) <: AbstractVector) reshape(initθ, :) else initθ end

# works
```