### PR TITLE
DiffEqFlux error 

### DIFF
--- a/docs/src/pinn/3rd.md
+++ b/docs/src/pinn/3rd.md
@@ -60,7 +60,7 @@ analytic_sol_func(x) = (π*x*(-x+(π^2)*(2*x-3)+1)-sin(π*x))/(π^3)
 dx = 0.05
 xs = [infimum(d.domain):dx/10:supremum(d.domain) for d in domains][1]
 u_real  = [analytic_sol_func(x) for x in xs]
-u_predict  = [first(phi(x,res.minimizer)) for x in xs]
+u_predict  = [first(phi([x],res.minimizer)) for x in xs]
 
 x_plot = collect(xs)
 plot(x_plot ,u_real,title = "real")

--- a/docs/src/pinn/fp.md
+++ b/docs/src/pinn/fp.md
@@ -99,7 +99,7 @@ analytic_sol_func(x) = C*exp((1/(2*_σ^2))*(2*α*x^2 - β*x^4))
 
 xs = [infimum(d.domain):dx:supremum(d.domain) for d in domains][1]
 u_real  = [analytic_sol_func(x) for x in xs]
-u_predict  = [first(phi(x,res.minimizer)) for x in xs]
+u_predict  = [first(phi([x],res.minimizer)) for x in xs]
 
 plot(xs ,u_real, label = "analytic")
 plot!(xs ,u_predict, label = "predict")

--- a/test/NNPDE_tests.jl
+++ b/test/NNPDE_tests.jl
@@ -64,8 +64,9 @@ function test_ode(strategy_)
     analytic_sol_func(t) = exp(-(t^2)/2)/(1+t+t^3) + t^2
     ts = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
     u_real  = [analytic_sol_func(t) for t in ts]
-    u_predict  = [first(phi(t,res.minimizer)) for t in ts]
 
+    u_predict  = [first(phi([t],res.minimizer)) for t in ts]
+	# phi(collect(ts)',res.minimizer)'
     @test u_predict ≈ u_real atol = 0.1
     # using Plots
     # t_plot = collect(ts)
@@ -376,7 +377,7 @@ analytic_sol_func(x) = (π*x*(-x+(π^2)*(2*x-3)+1)-sin(π*x))/(π^3)
 
 xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
 u_real  = [analytic_sol_func(x) for x in xs]
-u_predict  = [first(phi(x,res.minimizer)) for x in xs]
+u_predict  = [first(phi([x],res.minimizer)) for x in xs]
 
 @test u_predict ≈ u_real atol = 10^-4
 
@@ -667,7 +668,7 @@ C = 142.88418699042
 analytic_sol_func(x) = C*exp((1/(2*_σ^2))*(2*α*x^2 - β*x^4))
 xs = [infimum(d.domain):dx:supremum(d.domain) for d in domains][1]
 u_real  = [analytic_sol_func(x) for x in xs]
-u_predict  = [first(phi(x,res.u)) for x in xs]
+u_predict  = [first(phi([x],res.u)) for x in xs]
 
 @test u_predict ≈ u_real rtol = 1e-3
 


### PR DESCRIPTION
 deplecated (::FastDense)(::Number, ::Any)

```julia
julia> chain(1, initθ)
ERROR: MethodError: no method matching (::FastDense{typeof(sigmoid_fast), DiffEqFlux.var"#initial_params#94"{Vector{Float32}}, Nothing})(::Int64, ::Vector{Float64})
Closest candidates are:
  (::FastDense)(::AbstractMatrix, ::Any) at ~/.julia/packages/DiffEqFlux/WnJAX/src/fast_layers.jl:156
  (::FastDense)(::AbstractVector, ::Any) at ~/.julia/packages/DiffEqFlux/WnJAX/src/fast_layers.jl:76
Stacktrace:
 [1] applychain(fs::Tuple{FastDense{typeof(sigmoid_fast), DiffEqFlux.var"#initial_params#94"{Vector{Float32}}, Nothing}, FastDense{typeof(identity), DiffEqFlux.var"#initial_params#94"{Vector{Float32}}, Nothing}}, x::Int64, p::Vector{Float64})
   @ DiffEqFlux ~/.julia/packages/DiffEqFlux/WnJAX/src/fast_layers.jl:20
 [2] (::FastChain{Tuple{FastDense{typeof(sigmoid_fast), DiffEqFlux.var"#initial_params#94"{Vector{Float32}}, Nothing}, FastDense{typeof(identity), DiffEqFlux.var"#initial_params#94"{Vector{Float32}}, Nothing}}})(x::Int64, p::Vector{Float64})
   @ DiffEqFlux ~/.julia/packages/DiffEqFlux/WnJAX/src/fast_layers.jl:21
 [3] top-level scope
   @ none:1


julia> chain([1],initθ)
1-element Vector{Float64}:
 0.5823142109504285
```