### PR TITLE
Refactor internals so debugging is not sensitive to the internals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
@@ -57,6 +58,7 @@ SciMLBase = "1.38"
 StochasticDiffEq = "6.13"
 SymbolicUtils = "0.19"
 Symbolics = "4"
+UnPack = "1"
 Zygote = "0.6"
 julia = "1.6"
 

--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -26,6 +26,7 @@ import ModelingToolkit: Interval, infimum, supremum #,Ball
 import SciMLBase: @add_kwonly, parameterless_type
 using Flux: @nograd
 import Optimisers
+import UnPack: @unpack
 
 abstract type NeuralPDEAlgorithm <: DiffEqBase.AbstractODEAlgorithm end
 """

--- a/test/direct_function_tests.jl
+++ b/test/direct_function_tests.jl
@@ -118,7 +118,7 @@ discretization = NeuralPDE.PhysicsInformedNN(chain, strategy; initial_params = i
 prob = NeuralPDE.discretize(pde_system, discretization)
 symprob = NeuralPDE.symbolic_discretize(pde_system, discretization)
 discretized_functions = NeuralPDE.discretize_inner_functions(pde_system, discretization)
-discretized_functions.full_loss_function(initθ, Float64[])
+discretized_functions.full_loss_function(initθ, nothing)
 
 res = Optimization.solve(prob, ADAM(0.01), maxiters = 500)
 prob = remake(prob, u0 = res.minimizer)


### PR DESCRIPTION
There's still a whole bunch more to do, but this is a major step. The purpose of `symbolic_discretize` is that it's supposed to be the sole entry point for getting the "behind the scenes" of the problem being generated. Clearly that failed to occur in this repo's implementation, with an exhaustive "debugging" interface, which really should just be `symbolic_discretize` with sufficient documentation on its return. The issue also manifested in the fact that huge loads of arguments would get passed around to every function instead of just putting them in a type. This also meant that many functions were repeated, some were never callable, etc.

This fixes a large part of that, with more to be fixed in an upcoming PR. `discretize_inner_functions` is not part of the public API for example so it should show up in 0 documentation lines, but it does so that should be fixed. But since this is a huge step, I'm going to get this completed, tested, merged, and then move onto the next step.