### PR TITLE
Specialize higher order derivatives 

### DIFF
--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -238,10 +238,15 @@ function numeric_derivative(phi, u, x, εs, order, θ)
     ε = εs[order]
     ε = adapt(parameterless_type(θ), ε)
     x = adapt(parameterless_type(θ), x)
-    if order > 4
-        return (numeric_derivative(phi, u, x .+ ε, εs, order - 1, θ)
+
+    # any(x->x!=εs[1],εs)
+    # εs is the epsilon for each order, if they are all the same then we use a fancy formula
+    # if order 1, this is trivially true
+
+    if order > 4 || any(x->x!=εs[1],εs)
+        return (numeric_derivative(phi, u, x .+ ε, @view(εs[1:end-1]), order - 1, θ)
                 .-
-                numeric_derivative(phi, u, x .- ε, εs, order - 1, θ)) .* _epsilon
+                numeric_derivative(phi, u, x .- ε, @view(εs[1:end-1]), order - 1, θ)) .* _epsilon ./ 2
     elseif order == 4
         return (u(x .+ 2 .* ε, θ, phi) .- 4 .* u(x .+ ε, θ, phi)
                 .+

--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -244,11 +244,14 @@ function numeric_derivative(phi, u, x, εs, order, θ)
                 numeric_derivative(phi, u, x .- ε, εs, order - 1, θ)) .* _epsilon
     elseif order == 4
         return (u(x .+ 2 .* ε, θ, phi) .- 4 .* u(x .+ ε, θ, phi)
-                .+ 6 .* u(x, θ, phi)
-                .- 4 .* u(x .- ε, θ, phi) .+ u(x .- 2 .* ε, θ, phi)) .* _epsilon^4
+                .+
+                6 .* u(x, θ, phi)
+                .-
+                4 .* u(x .- ε, θ, phi) .+ u(x .- 2 .* ε, θ, phi)) .* _epsilon^4
     elseif order == 3
         return (u(x .+ 2 .* ε, θ, phi) .- 2 .* u(x .+ ε, θ, phi) .+ 2 .* u(x .- ε, θ, phi)
-                - u(x .- 2 .* ε, θ, phi)) .* 2 .* _epsilon^3
+                -
+                u(x .- 2 .* ε, θ, phi)) .* 2 .* _epsilon^3
     elseif order == 2
         return (u(x .+ ε, θ, phi) .+ u(x .- ε, θ, phi) .- 2 .* u(x, θ, phi)) .* _epsilon^2
     elseif order == 1

--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -243,10 +243,11 @@ function numeric_derivative(phi, u, x, εs, order, θ)
     # εs is the epsilon for each order, if they are all the same then we use a fancy formula
     # if order 1, this is trivially true
 
-    if order > 4 || any(x->x!=εs[1],εs)
-        return (numeric_derivative(phi, u, x .+ ε, @view(εs[1:end-1]), order - 1, θ)
+    if order > 4 || any(x -> x != εs[1], εs)
+        return (numeric_derivative(phi, u, x .+ ε, @view(εs[1:(end - 1)]), order - 1, θ)
                 .-
-                numeric_derivative(phi, u, x .- ε, @view(εs[1:end-1]), order - 1, θ)) .* _epsilon ./ 2
+                numeric_derivative(phi, u, x .- ε, @view(εs[1:(end - 1)]), order - 1, θ)) .*
+               _epsilon ./ 2
     elseif order == 4
         return (u(x .+ 2 .* ε, θ, phi) .- 4 .* u(x .+ ε, θ, phi)
                 .+

--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -234,15 +234,26 @@ end
 
 # the method to calculate the derivative
 function numeric_derivative(phi, u, x, εs, order, θ)
-    _epsilon = one(eltype(θ)) / (2 * cbrt(eps(eltype(θ))))
+    _epsilon = one(eltype(θ)) / cbrt(eps(eltype(θ)))
     ε = εs[order]
     ε = adapt(parameterless_type(θ), ε)
     x = adapt(parameterless_type(θ), x)
-    if order > 1
+    if order > 4
         return (numeric_derivative(phi, u, x .+ ε, εs, order - 1, θ)
                 .-
                 numeric_derivative(phi, u, x .- ε, εs, order - 1, θ)) .* _epsilon
+    elseif order == 4
+        return (u(x .+ 2 .* ε, θ, phi) .- 4 .* u(x .+ ε, θ, phi)
+                .+ 6 .* u(x, θ, phi)
+                .- 4 .* u(x .- ε, θ, phi) .+ u(x .- 2 .* ε, θ, phi)) .* _epsilon^4
+    elseif order == 3
+        return (u(x .+ 2 .* ε, θ, phi) .- 2 .* u(x .+ ε, θ, phi) .+ 2 .* u(x .- ε, θ, phi)
+                - u(x .- 2 .* ε, θ, phi)) .* 2 .* _epsilon^3
+    elseif order == 2
+        return (u(x .+ ε, θ, phi) .+ u(x .- ε, θ, phi) .- 2 .* u(x, θ, phi)) .* _epsilon^2
+    elseif order == 1
+        return (u(x .+ ε, θ, phi) .- u(x .- ε, θ, phi)) .* 2 .* _epsilon
     else
-        return (u(x .+ ε, θ, phi) .- u(x .- ε, θ, phi)) .* _epsilon
+        error("This shouldn't happen!")
     end
 end

--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -251,11 +251,11 @@ function numeric_derivative(phi, u, x, εs, order, θ)
     elseif order == 3
         return (u(x .+ 2 .* ε, θ, phi) .- 2 .* u(x .+ ε, θ, phi) .+ 2 .* u(x .- ε, θ, phi)
                 -
-                u(x .- 2 .* ε, θ, phi)) .* 2 .* _epsilon^3
+                u(x .- 2 .* ε, θ, phi)) .* _epsilon^3 ./ 2
     elseif order == 2
         return (u(x .+ ε, θ, phi) .+ u(x .- ε, θ, phi) .- 2 .* u(x, θ, phi)) .* _epsilon^2
     elseif order == 1
-        return (u(x .+ ε, θ, phi) .- u(x .- ε, θ, phi)) .* 2 .* _epsilon
+        return (u(x .+ ε, θ, phi) .- u(x .- ε, θ, phi)) .* _epsilon ./ 2
     else
         error("This shouldn't happen!")
     end


### PR DESCRIPTION
This will help with both stability and performance. Also it makes the linear scaling of the derivative with numerical differentiation explicit, as opposed to the polynomial scaling of AD, so this should be the fast mode. This also then shows how to specialize for Diffractor in the near future.

Examples of improved stability:

```julia
using NeuralPDE, Flux, Optimization, OptimizationOptimJL, DiffEqFlux
import ModelingToolkit: Interval

@parameters x y
@variables u(..)
Dxx = Differential(x)^2
Dyy = Differential(y)^2

# 2D PDE
eq  = Dxx(u(x,y)) + Dyy(u(x,y)) ~ -sin(pi*x)*sin(pi*y)

# Boundary conditions
bcs = [u(0,y) ~ 0.0, u(1,y) ~ 0.0,
       u(x,0) ~ 0.0, u(x,1) ~ 0.0]
# Space and time domains
domains = [x ∈ Interval(0.0,1.0),
           y ∈ Interval(0.0,1.0)]

# Neural network
dim = 2 # number of dimensions
chain = FastChain(FastDense(dim,16,Flux.σ),FastDense(16,16,Flux.σ),FastDense(16,1))
# Initial parameters of Neural network
initθ = Float64.(DiffEqFlux.initial_params(chain))

# Discretization
dx = 0.05
discretization = PhysicsInformedNN(chain,GridTraining(dx),init_params =initθ)

@named pde_system = PDESystem(eq,bcs,domains,[x,y],[u(x, y)])
prob = discretize(pde_system,discretization)

#Optimizer
opt = OptimizationOptimJL.BFGS()

#Callback function
callback = function (p,l)
    println("Current loss is: $l")
    return false
end

res = Optimization.solve(prob, opt, callback = callback, maxiters=1000)


# Poisson before
# Current loss is: 0.00010414859757418942
# Poisson after
# Current loss is: 1.3629724527385549e-5
```

```julia
using NeuralPDE, Flux, ModelingToolkit, Optimization, OptimizationOptimJL, DiffEqFlux
import ModelingToolkit: Interval, infimum, supremum

@parameters x, t
@variables u(..)
Dt = Differential(t)
Dx = Differential(x)
Dx2 = Differential(x)^2
Dx3 = Differential(x)^3
Dx4 = Differential(x)^4

α = 1
β = 4
γ = 1
eq = Dt(u(x,t)) + u(x,t)*Dx(u(x,t)) + α*Dx2(u(x,t)) + β*Dx3(u(x,t)) + γ*Dx4(u(x,t)) ~ 0

u_analytic(x,t;z = -x/2+t) = 11 + 15*tanh(z) -15*tanh(z)^2 - 15*tanh(z)^3
du(x,t;z = -x/2+t) = 15/2*(tanh(z) + 1)*(3*tanh(z) - 1)*sech(z)^2

bcs = [u(x,0) ~ u_analytic(x,0),
       u(-10,t) ~ u_analytic(-10,t),
       u(10,t) ~ u_analytic(10,t),
       Dx(u(-10,t)) ~ du(-10,t),
       Dx(u(10,t)) ~ du(10,t)]

# Space and time domains
domains = [x ∈ Interval(-10.0,10.0),
           t ∈ Interval(0.0,1.0)]
# Discretization
dx = 0.4; dt = 0.2

# Neural network
chain = FastChain(FastDense(2,12,Flux.σ),FastDense(12,12,Flux.σ),FastDense(12,1))
initθ = Float64.(DiffEqFlux.initial_params(chain))

discretization = PhysicsInformedNN(chain, GridTraining([dx,dt]), init_params = initθ)
@named pde_system = PDESystem(eq,bcs,domains,[x,t],[u(x, t)])
prob = discretize(pde_system,discretization)

callback = function (p,l)
    println("Current loss is: $l")
    return false
end

opt = Flux.ADAM(0.01)
res = Optimization.solve(prob,opt; callback = callback, maxiters=2000)

# Before
# Current loss is: 3.943220504821983e10
# Current loss is: 7.783118061861078e7

# After
# Current loss is: 2.2046304911377054e7
# Current loss is: 3.1660156480399226e6
```