### PR TITLE
Use dependent variable naming in the indexing 

### DIFF
--- a/docs/src/examples/linear_parabolic.md
+++ b/docs/src/examples/linear_parabolic.md
@@ -91,7 +91,8 @@ phi = discretization.phi
 
 # Analysis
 ts, xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
-minimizers_ = [res.u.depvar[Symbol(:depvar_,i)] for i in 1:length(chain)]
+depvars = [:u,:w]
+minimizers_ = [res.u.depvar[depvars[i]] for i in 1:length(chain)]
 
 analytic_sol_func(t,x) = [u_analytic(t, x), w_analytic(t, x)]
 u_real  = [[analytic_sol_func(t, x)[i] for t in ts for x in xs] for i in 1:2]

--- a/docs/src/examples/nonlinear_elliptic.md
+++ b/docs/src/examples/nonlinear_elliptic.md
@@ -109,7 +109,7 @@ phi = discretization.phi
 # Analysis
 xs, ys = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
 depvars = [:u,:w]
-minimizers_ = [res.u.depvar[depvars[i]] for i in 1:length(chain)]
+minimizers_ = [res.u.depvar[depvars[i]] for i in 1:2]
 
 analytic_sol_func(x,y) = [u_analytic(x, y), w_analytic(x, y)]
 u_real  = [[analytic_sol_func(x, y)[i] for x in xs for y in ys] for i in 1:2]

--- a/docs/src/examples/nonlinear_elliptic.md
+++ b/docs/src/examples/nonlinear_elliptic.md
@@ -108,8 +108,8 @@ phi = discretization.phi
 
 # Analysis
 xs, ys = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
-
-minimizers_ = [res.u.depvar[Symbol(:depvar_,i)] for i in 1:length(chain)]
+depvars = [:u,:w]
+minimizers_ = [res.u.depvar[depvars[i]] for i in 1:length(chain)]
 
 analytic_sol_func(x,y) = [u_analytic(x, y), w_analytic(x, y)]
 u_real  = [[analytic_sol_func(x, y)[i] for x in xs for y in ys] for i in 1:2]

--- a/docs/src/examples/nonlinear_hyperbolic.md
+++ b/docs/src/examples/nonlinear_hyperbolic.md
@@ -105,7 +105,8 @@ phi = discretization.phi
 
 # Analysis
 ts, xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
-minimizers_ = [res.u.depvar[Symbol(:depvar_,i)] for i in 1:length(chain)]
+depvars = [:u,:w]
+minimizers_ = [res.u.depvar[depvars[i]] for i in 1:length(chain)]
 
 analytic_sol_func(t,x) = [u_analytic(t, x), w_analytic(t, x)]
 u_real  = [[analytic_sol_func(t, x)[i] for t in ts for x in xs] for i in 1:2]

--- a/docs/src/examples/wave.md
+++ b/docs/src/examples/wave.md
@@ -177,7 +177,7 @@ analytic_sol_func(t,x) = sum([sin((k * π * x) / L) * exp(-v^2 * b * t / 2) * (a
 anim = @animate for t ∈ ts
     @info "Time $t..."
     sol =  [analytic_sol_func(t, x) for x in xs]
-    sol_p =  [first(phi([t,x], res.u.depvar.depvar_1)) for x in xs]
+    sol_p =  [first(phi([t,x], res.u.depvar.u)) for x in xs]
     plot(sol, label="analytic", ylims=[0, 0.1])
     title = @sprintf("t = %.3f", t)
     plot!(sol_p, label="predict", ylims=[0, 0.1], title=title)
@@ -186,7 +186,7 @@ gif(anim, "1Dwave_damped_adaptive.gif", fps=200)
 
 # Surface plot
 ts, xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
-u_predict = reshape([first(phi([t,x], res.u.depvar.depvar_1)) for 
+u_predict = reshape([first(phi([t,x], res.u.depvar.u)) for 
                         t in ts for x in xs], (length(ts), length(xs)))
 u_real = reshape([analytic_sol_func(t, x) for t in ts for x in xs], (length(ts), length(xs)))
 

--- a/docs/src/tutorials/derivative_neural_network.md
+++ b/docs/src/tutorials/derivative_neural_network.md
@@ -127,7 +127,7 @@ And some analysis:
 using Plots
 
 ts,xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
-minimizers_ = [res.u.depvar[Symbol(:depvar_,i)] for i in 1:length(chain)]
+minimizers_ = [res.u.depvar[sym_prob.depvars[i]] for i in 1:length(chain)]
 
 u1_real(t,x) = exp(-t)*sin(pi*x)
 u2_real(t,x) = exp(-t)*cos(pi*x)

--- a/docs/src/tutorials/low_level.md
+++ b/docs/src/tutorials/low_level.md
@@ -93,5 +93,3 @@ plot(p1,p2,p3)
 
 
 ![burgers2](https://user-images.githubusercontent.com/12683885/90984856-8c430b00-e580-11ea-9206-1a88ebd24ca0.png)
-
-[See low-level API](@ref Physics-Informed Neural Networks)

--- a/docs/src/tutorials/param_estim.md
+++ b/docs/src/tutorials/param_estim.md
@@ -76,12 +76,13 @@ three arguments:
 
 For a Lux neural network, the composed function will present itself as having θ as a
 [`ComponentArray`](https://github.com/jonniedie/ComponentArrays.jl)
-subsets `θ.depvar_i`, which can also be dereferenced like `θ[Symbol(:depvar_,i)]`. Thus the additional
+subsets `θ.x`, which can also be dereferenced like `θ[:x]`. Thus the additional
 loss looks like:
 
 ```@example param_estim
+depvars = [:x,:y,:z]
 function additional_loss(phi, θ , p)
-    return sum(sum(abs2, phi[i](t_ , θ[Symbol(:depvar_,i)]) .- u_[[i], :])/len for i in 1:1:3)
+    return sum(sum(abs2, phi[i](t_ , θ[depvars[i]]) .- u_[[i], :])/len for i in 1:1:3)
 end
 ```
 
@@ -121,7 +122,7 @@ p_ = res.u[end-2:end] # p_ = [9.93, 28.002, 2.667]
 And then finally some analyisis by plotting.
 
 ```@example param_estim
-minimizers = [res.u.depvar[Symbol(:depvar_,i)] for i in 1:3]
+minimizers = [res.u.depvar[depvars[i]] for i in 1:3]
 ts = [infimum(d.domain):dt/10:supremum(d.domain) for d in domains][1]
 u_predict  = [[discretization.phi[i]([t],minimizers[i])[1] for t in ts] for i in 1:3]
 plot(sol)

--- a/docs/src/tutorials/systems.md
+++ b/docs/src/tutorials/systems.md
@@ -166,7 +166,7 @@ using Plots
 phi = discretization.phi
 ts,xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
 
-minimizers_ = [res.u.depvar[Symbol(:depvar_,i)] for i in 1:3]
+minimizers_ = [res.u.depvar[sym_prob.depvars[i]] for i in 1:3]
 
 analytic_sol_func(t,x) = [exp(-t)*sin(pi*x), exp(-t)*cos(pi*x), (1+pi^2)*exp(-t)]
 u_real  = [[analytic_sol_func(t,x)[i] for t in ts for x in xs] for i in 1:3]
@@ -189,9 +189,11 @@ end
 
 Notice here that the solution is represented in the `OptimizationSolution` with `u` as
 the parameters for the trained neural network. But, for the case where the neural network
-is from Lux.jl, it's given as a `ComponentArray` where `res.u.depvar.depvar_i` corresponds to the result
-for the ith neural network, i.e. `res.u.depvar.depvar_1` are the trained parameters for `phi[1]`. For
-simpler indexing, you can use `res.u.depvar[:depvar_1]` or `res.u.depvar[Symbol(:depvar_,1)]` as shown here.
+is from Lux.jl, it's given as a `ComponentArray` where `res.u.depvar.x` corresponds to the result
+for the neural network corresponding to the dependent variable `x`, i.e. `res.u.depvar.u1` 
+are the trained parameters for `phi[1]` in our example. For simpler indexing, you can use 
+`res.u.depvar[:u1]` or `res.u.depvar[Symbol(:u,1)]` as shown here.
+
 Subsetting the array also works, but is inelegant.
 
 (If `param_estim == true`, then `res.u.p` are the fit parameters)

--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -405,6 +405,7 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem,
                                        discretization::PhysicsInformedNN)
     eqs = pde_system.eqs
     bcs = pde_system.bcs
+    chain = discretization.chain
 
     domains = pde_system.domain
     eq_params = pde_system.ps

--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -104,7 +104,6 @@ struct PhysicsInformedNN{T, P, PH, DER, PE, AL, ADA, LOG, K} <: AbstractPINN
                                            log_options = LogOptions(),
                                            iteration = nothing,
                                            kwargs...) where {iip}
-
         multioutput = typeof(chain) <: AbstractArray
 
         if phi === nothing

--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -78,6 +78,7 @@ methodology.
 * `kwargs`: Extra keyword arguments which are splatted to the `OptimizationProblem` on `solve`.
 """
 struct PhysicsInformedNN{T, P, PH, DER, PE, AL, ADA, LOG, K} <: AbstractPINN
+    chain::Any
     strategy::T
     init_params::P
     phi::PH
@@ -131,7 +132,8 @@ struct PhysicsInformedNN{T, P, PH, DER, PE, AL, ADA, LOG, K} <: AbstractPINN
 
         new{typeof(strategy), typeof(init_params), typeof(_phi), typeof(_derivative),
             typeof(param_estim),
-            typeof(additional_loss), typeof(adaptive_loss), typeof(logger), typeof(kwargs)}(strategy,
+            typeof(additional_loss), typeof(adaptive_loss), typeof(logger), typeof(kwargs)}(chain,
+                                                                                            strategy,
                                                                                             init_params,
                                                                                             _phi,
                                                                                             _derivative,

--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -104,54 +104,8 @@ struct PhysicsInformedNN{T, P, PH, DER, PE, AL, ADA, LOG, K} <: AbstractPINN
                                            log_options = LogOptions(),
                                            iteration = nothing,
                                            kwargs...) where {iip}
-        if init_params === nothing
-
-            # Use the initialization of the neural network framework
-            # But for Lux, default to Float64
-            # For Flux, default to the types matching the values in the neural network
-            # This is done because Float64 is almost always better for these applications
-            # But with Flux there's already a chosen type from the user
-
-            if chain isa AbstractArray
-                if chain[1] isa Flux.Chain
-                    init_params = map(chain) do x
-                        _x = Flux.destructure(x)[1]
-                    end
-                else
-                    x = map(chain) do x
-                        _x = ComponentArrays.ComponentArray(Lux.setup(Random.default_rng(),
-                                                                      x)[1])
-                        Float64.(_x) # No ComponentArray GPU support
-                    end
-                    names = ntuple(i -> Symbol("depvar_", i), length(chain))
-                    init_params = ComponentArrays.ComponentArray(NamedTuple{names}(i
-                                                                                   for i in x))
-                end
-            else
-                if chain isa Flux.Chain
-                    init_params = Flux.destructure(chain)[1]
-                    init_params = init_params isa Array ? Float64.(init_params) :
-                                  init_params
-                else
-                    init_params = Float64.(ComponentArrays.ComponentArray(Lux.setup(Random.default_rng(),
-                                                                                    chain)[1]))
-                end
-            end
-        else
-            init_params = init_params
-        end
 
         multioutput = typeof(chain) <: AbstractArray
-
-        type_init_params = if multioutput
-            if typeof(init_params) <: ComponentArrays.ComponentArray
-                Base.promote_typeof(init_params)
-            else
-                map(Base.promote_typeof, init_params)[1]
-            end
-        else
-            Base.promote_typeof(init_params)
-        end
 
         if phi === nothing
             if multioutput
@@ -167,14 +121,6 @@ struct PhysicsInformedNN{T, P, PH, DER, PE, AL, ADA, LOG, K} <: AbstractPINN
             _derivative = numeric_derivative
         else
             _derivative = derivative
-        end
-
-        if !(typeof(adaptive_loss) <: AbstractAdaptiveLoss)
-            floattype = eltype(type_init_params)
-            if floattype <: Vector
-                floattype = eltype(floattype)
-            end
-            adaptive_loss = NonAdaptiveLoss{floattype}()
         end
 
         if iteration isa Vector{Int64}
@@ -290,10 +236,12 @@ mutable struct PINNRepresentation
     The initial parameters as a flattened array. This is the array that is used in the
     construction of the OptimizationProblem. If a Lux.jl neural network is used, then this
     flattened form is a `ComponentArray`. If the equation is a system of equations, then
-    `flat_init_params.depvar.depvar_i` are the parameters for `phi[i]`. If `param_estim = true`, 
-    then `flat_init_params.p` are the parameters and `flat_init_params.depvar.depvar_i` are the neural 
-    network parameters, so `flat_init_params.depvar.depvar_1` would be the parameters of the 
-    first neural network if it's a system. If a Flux.jl neural network is used, this is 
+    `flat_init_params.depvar.x` are the parameters for the neural network corresponding
+    to the dependent variable `x`, and i.e. if `depvar[i] == :x` then for `phi[i]`. 
+    If `param_estim = true`, then `flat_init_params.p` are the parameters and 
+    `flat_init_params.depvar.x` are the neural network parameters, so 
+    `flat_init_params.depvar.x` would be the parameters of the neural network for the
+    dependent variable `x` if it's a system. If a Flux.jl neural network is used, this is 
     simply an `AbstractArray` to be indexed and the sizes from the chains must be 
     remembered/stored/used.
     """

--- a/test/IDE_tests.jl
+++ b/test/IDE_tests.jl
@@ -5,7 +5,7 @@ using DomainSets, Flux
 import Lux
 
 using Random
-Random.seed!(100)
+Random.seed!(110)
 
 callback = function (p, l)
     println("Current loss is: $l")

--- a/test/IDE_tests.jl
+++ b/test/IDE_tests.jl
@@ -158,8 +158,8 @@ res = Optimization.solve(prob, OptimizationOptimJL.BFGS(); callback = callback,
 xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
 phi = discretization.phi
 
-u_predict = [(phi[1]([x], res.u.depvar.depvar_1))[1] for x in xs]
-w_predict = [(phi[2]([x], res.u.depvar.depvar_2))[1] for x in xs]
+u_predict = [(phi[1]([x], res.u.depvar.u))[1] for x in xs]
+w_predict = [(phi[2]([x], res.u.depvar.w))[1] for x in xs]
 u_real = [x for x in xs]
 w_real = [1 / x^2 for x in xs]
 @test Flux.mse(u_real, u_predict) < 0.001

--- a/test/NNPDE_tests.jl
+++ b/test/NNPDE_tests.jl
@@ -416,7 +416,7 @@ phi = discretization.phi
 analytic_sol_func(x, y) = [1 / 3 * (6x - y), 1 / 2 * (6x - y)]
 xs, ys = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
 u_real = [[analytic_sol_func(x, y)[i] for x in xs for y in ys] for i in 1:2]
-depvars = [:u1,:u2]
+depvars = [:u1, :u2]
 
 u_predict = [[phi[i]([x, y], res.u.depvar[depvars[i]])[1] for x in xs for y in ys]
              for i in 1:2]

--- a/test/NNPDE_tests.jl
+++ b/test/NNPDE_tests.jl
@@ -229,11 +229,11 @@ p_real = [analytic_sol_func_[4](x, z) for x in xs for z in zs]
 
 real_ = [u_real, v_real, h_real, p_real]
 
-u_predict = [phi[1]([x, y, z], res.u.depvar.depvar_1)[1] for x in xs for y in ys
+u_predict = [phi[1]([x, y, z], res.u.depvar.u)[1] for x in xs for y in ys
              for z in zs]
-v_predict = [phi[2]([y, x], res.u.depvar.depvar_2)[1] for y in ys for x in xs]
-h_predict = [phi[3]([z], res.u.depvar.depvar_3)[1] for z in zs]
-p_predict = [phi[4]([x, z], res.u.depvar.depvar_4)[1] for x in xs for z in zs]
+v_predict = [phi[2]([y, x], res.u.depvar.v)[1] for y in ys for x in xs]
+h_predict = [phi[3]([z], res.u.depvar.h)[1] for z in zs]
+p_predict = [phi[4]([x, z], res.u.depvar.p)[1] for x in xs for z in zs]
 predict = [u_predict, v_predict, h_predict, p_predict]
 
 for i in 1:4
@@ -369,7 +369,7 @@ analytic_sol_func(x) = (π * x * (-x + (π^2) * (2 * x - 3) + 1) - sin(π * x)) 
 
 xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
 u_real = [analytic_sol_func(x) for x in xs]
-u_predict = [first(phi(x, res.u.depvar.depvar_1)) for x in xs]
+u_predict = [first(phi(x, res.u.depvar.u)) for x in xs]
 
 @test u_predict≈u_real atol=10^-4
 
@@ -416,8 +416,9 @@ phi = discretization.phi
 analytic_sol_func(x, y) = [1 / 3 * (6x - y), 1 / 2 * (6x - y)]
 xs, ys = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
 u_real = [[analytic_sol_func(x, y)[i] for x in xs for y in ys] for i in 1:2]
+depvars = [:u1,:u2]
 
-u_predict = [[phi[i]([x, y], res.u.depvar[Symbol(:depvar_, i)])[1] for x in xs for y in ys]
+u_predict = [[phi[i]([x, y], res.u.depvar[depvars[i]])[1] for x in xs for y in ys]
              for i in 1:2]
 
 @test u_predict[1]≈u_real[1] atol=0.1

--- a/test/additional_loss_tests.jl
+++ b/test/additional_loss_tests.jl
@@ -169,7 +169,7 @@ data = getData(sol)
 #Additional Loss Function
 init_params = [Float64.(ComponentArray(Lux.setup(Random.default_rng(), chain[i])[1]))
                for i in 1:3]
-names = (:x,:y,:z)
+names = (:x, :y, :z)
 flat_init_params = ComponentArray(NamedTuple{names}(i for i in init_params))
 
 acum = [0; accumulate(+, length.(init_params))]

--- a/test/additional_loss_tests.jl
+++ b/test/additional_loss_tests.jl
@@ -268,14 +268,14 @@ end
 discretization = NeuralPDE.PhysicsInformedNN(chain, strategy;
                                              additional_loss = additional_loss_)
 
-init_params = discretization.init_params
-phi = discretization.phi
-phi(xs, init_params)
-additional_loss_(phi, init_params, nothing)
-
 @named pde_system = PDESystem(eq, bc, domain, [x], [u(x)])
 prob = NeuralPDE.discretize(pde_system, discretization)
 sym_prob = NeuralPDE.symbolic_discretize(pde_system, discretization)
+
+flat_init_params = discretization.flat_init_params
+phi = discretization.phi
+phi(xs, flat_init_params)
+additional_loss_(phi, flat_init_params, nothing)
 
 res = Optimization.solve(prob, OptimizationOptimisers.Adam(0.01), maxiters = 500)
 prob = remake(prob, u0 = res.minimizer)

--- a/test/additional_loss_tests.jl
+++ b/test/additional_loss_tests.jl
@@ -169,7 +169,7 @@ data = getData(sol)
 #Additional Loss Function
 init_params = [Float64.(ComponentArray(Lux.setup(Random.default_rng(), chain[i])[1]))
                for i in 1:3]
-names = ntuple(i -> Symbol(:depvar_, i), length(init_params))
+names = (:x,:y,:z)
 flat_init_params = ComponentArray(NamedTuple{names}(i for i in init_params))
 
 acum = [0; accumulate(+, length.(init_params))]
@@ -178,7 +178,7 @@ sep = [(acum[i] + 1):acum[i + 1] for i in 1:(length(acum) - 1)]
 len = length(data[2])
 
 function additional_loss(phi, θ, p)
-    return sum(sum(abs2, phi[i](t_, getproperty(θ, Symbol(:depvar_, i))) .- u_[[i], :]) /
+    return sum(sum(abs2, phi[i](t_, getproperty(θ, names[i])) .- u_[[i], :]) /
                len
                for i in 1:1:3)
 end

--- a/test/additional_loss_tests.jl
+++ b/test/additional_loss_tests.jl
@@ -272,7 +272,7 @@ discretization = NeuralPDE.PhysicsInformedNN(chain, strategy;
 prob = NeuralPDE.discretize(pde_system, discretization)
 sym_prob = NeuralPDE.symbolic_discretize(pde_system, discretization)
 
-flat_init_params = discretization.flat_init_params
+flat_init_params = sym_prob.flat_init_params
 phi = discretization.phi
 phi(xs, flat_init_params)
 additional_loss_(phi, flat_init_params, nothing)


### PR DESCRIPTION
Changes from `depvar_1` for the ith neural network to `x` if it's `[x(t),y(t),z(t)]`. This should make it a lot easier to understand the indexing structure: `res.u.depvar.y` etc. 

This builds on https://github.com/SciML/NeuralPDE.jl/pull/565 and should be the last change for the v5 release.