### PR TITLE
Array Variable interface [WIP]

### DIFF
--- a/src/symbolic_utilities.jl
+++ b/src/symbolic_utilities.jl
@@ -360,6 +360,7 @@ function get_vars(indvars_, depvars_)
 
     dict_indvars = get_dict_vars(indvars)
     dict_depvars = get_dict_vars(depvars)
+
     return depvars, indvars, dict_indvars, dict_depvars, dict_depvar_input
 end
 
@@ -403,14 +404,19 @@ function get_number(eqs, dict_indvars, dict_depvars)
 end
 
 function find_thing_in_expr(ex::Expr, thing; ans = [])
-    if thing in ex.args
-        push!(ans, ex)
+    for arg in ex.args
+        if isequal(thing, arg)
+            push!(ans, ex)
+        end
     end
     for e in ex.args
         if e isa Expr
-            if thing in e.args
-                push!(ans, e)
-            end
+           for arg in e.args
+                if isequal(thing, arg)
+                    push!(ans, e)
+                end
+           end
+
             find_thing_in_expr(e, thing; ans = ans)
         end
     end

--- a/src/symbolic_utilities.jl
+++ b/src/symbolic_utilities.jl
@@ -372,10 +372,32 @@ end
 
 function get_integration_variables(eqs, dict_indvars, dict_depvars)
     exprs = toexpr.(eqs)
-    vars = map(exprs) do expr
+   # vars = map(exprs) do expr
+   #     _vars = Symbol.(filter(indvar -> length(find_thing_in_expr(expr, indvar)) > 0,
+    #                           sort(collect(keys(dict_indvars)))))
+    # end
+    vars = Vector{Symbol}[]
+    println(typeof(vars))
+    for expr in exprs
+        sorted_dict_by_value = sort(collect(dict_indvars), by = x->x[2])
+        println(sorted_dict_by_value)
+        sorted_indvars = keys(sorted_dict_by_value) 
+        print(sorted_indvars)
+        _vars = Vector{Symbol}()
+        for indvar in sorted_indvars
+            if length(find_thing_in_expr(expr, indvar)) > 0 
+                push!(_vars, indvar)
+            end
+        end
+
         _vars = Symbol.(filter(indvar -> length(find_thing_in_expr(expr, indvar)) > 0,
-                               sort(collect(keys(dict_indvars)))))
+        sort(collect(keys(dict_indvars)))))
+        println(_vars)
+        println(typeof(_vars))
+        push!(vars, _vars)
     end
+    println(vars)
+    println(typeof(vars))
 end
 
 """

--- a/src/symbolic_utilities.jl
+++ b/src/symbolic_utilities.jl
@@ -66,7 +66,7 @@ Dict{Symbol,Int64} with 3 entries:
   :u1 => 1
   :u2 => 2
 """
-get_dict_vars(vars) = Dict([Symbol(v) .=> i for (i, v) in enumerate(vars)])
+get_dict_vars(vars) = Dict([Num(v) .=> i for (i, v) in enumerate(vars)])
 
 # Wrapper for _transform_expression
 function transform_expression(pinnrep::PINNRepresentation, ex; is_integral = false,
@@ -343,20 +343,18 @@ function pair(eq, depvars, dict_depvars, dict_depvar_input)
 end
 
 function get_vars(indvars_, depvars_)
-    indvars = ModelingToolkit.getname.(indvars_)
-    depvars = Symbol[]
-    dict_depvar_input = Dict{Symbol, Vector{Symbol}}()
+    depvars = Num[]
+    indvars = indvars_
+    dict_depvar_input = Dict{Num, Vector{Num}}()
     for d in depvars_
         if ModelingToolkit.value(d) isa Term
-            dname = ModelingToolkit.getname(d)
-            push!(depvars, dname)
+            push!(depvars, d)
             push!(dict_depvar_input,
-                  dname => [nameof(ModelingToolkit.value(argument))
+                  d => [argument
                             for argument in ModelingToolkit.value(d).arguments])
         else
-            dname = ModelingToolkit.getname(d)
-            push!(depvars, dname)
-            push!(dict_depvar_input, dname => indvars) # default to all inputs if not given
+            push!(depvars, d)
+            push!(dict_depvar_input, d => indvars) # default to all inputs if not given
         end
     end
 


### PR DESCRIPTION
The goal of this PR is to extend the interface to accept `PDESystem`s that are initialized with array variables (#574) The changes so far occur in `symbolic_utilities.jl` and I expect that there will be changes that need to occur in `discretize.jl` as well. 

To be more precise, currently in `symbolic_utilities.jl`, there is a function `get_vars()` that creates `Vector{Symbol}` for both the independent and dependent variables as well as dictionaries for both sets of variables that whose (key, value) pairs correspond to (variable name, order). These objects are constructed using the name of the symbolic variables via `get_name`. Most of the other functions in this file take the symbolic arrays or dictionaries generated by `get_vars` as inputs. For example, if the independent variables are initialized as 
```Julia 
@parameters t z1 z2
```
then the functions in symbolic utilities work with something like `indvars = [:t, :z1, :z2]`. 

If we want to initialize our independent or dependent variables as arrays of symbols, this breaks down since `get_name` does not return unique names for entries of a symbolic array. For example, if our independent variables are initialized as
```Julia 
@parameters t z[1:2]
```
then `get_vars()` would return `indvars = [:t, :z, :z]` which leads to errors in the other functions since the independent variables do not have unique names. 

The goal is to not use `get_name` at all and rework the functions in `symbolic_utilities.jl` to accept the symbolic variables directly, i.e. `get_vars()` should return something like `indvars = [t, z[1], z[2]]'. 