### PR TITLE
Rename `samples` field of `WeightedIntervalTraining` to `points` and clean `tstops_loss` logic

### DIFF
--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -320,7 +320,7 @@ This training strategy can only be used with ODEs (`NNODE`).
 """
 struct WeightedIntervalTraining{T} <: AbstractTrainingStrategy
     weights::Vector{T}
-    points::Int64
+    points::Int
 end
 
 function WeightedIntervalTraining(weights, points)

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -312,7 +312,7 @@ such that the total number of sampled points is equivalent to the given samples
 ## Positional Arguments
 
 * `weights`: A vector of weights that should sum to 1, representing the proportion of samples at each interval.
-* `samples`: the total number of samples that we want, across the entire time span
+* `points`: the total number of samples that we want, across the entire time span
 
 ## Limitations
 
@@ -320,11 +320,11 @@ This training strategy can only be used with ODEs (`NNODE`).
 """
 struct WeightedIntervalTraining{T} <: AbstractTrainingStrategy
     weights::Vector{T}
-    samples::Int
+    points::Int64
 end
 
-function WeightedIntervalTraining(weights, samples)
-    WeightedIntervalTraining(weights, samples)
+function WeightedIntervalTraining(weights, points)
+    WeightedIntervalTraining(weights, points)
 end
 
 function get_loss_function(loss_function, train_set, eltypeθ,

--- a/test/NNODE_tests.jl
+++ b/test/NNODE_tests.jl
@@ -239,9 +239,9 @@ chain = Lux.Chain(Lux.Dense(1, N, func), Lux.Dense(N, N, func), Lux.Dense(N, N, 
 
 opt = Optimisers.Adam(0.01)
 weights = [0.7, 0.2, 0.1]
-samples = 200
+points = 200
 alg = NeuralPDE.NNODE(chain, opt, autodiff = false,
-                      strategy = NeuralPDE.WeightedIntervalTraining(weights, samples))
+                      strategy = NeuralPDE.WeightedIntervalTraining(weights, points))
 sol = solve(prob_oop, alg, verbose = true, maxiters = 100000, saveat = 0.01)
 
 @test abs(mean(sol) - mean(true_sol)) < 0.2

--- a/test/NNODE_tstops_test.jl
+++ b/test/NNODE_tstops_test.jl
@@ -27,7 +27,7 @@ threshold = 0.2
 
 #bad choices for weights, samples and dx so that the algorithm will fail without the added points
 weights = [0.3, 0.3, 0.4]
-samples = 3
+points = 3
 dx = 1.0
 
 #Grid Training without added points (difference between solutions should be high)
@@ -43,25 +43,25 @@ sol = solve(prob_oop, alg, verbose=true, maxiters = maxiters, saveat = saveat, t
 @test abs(mean(sol) - mean(true_sol)) < threshold
 
 #WeightedIntervalTraining without added points (difference between solutions should be high)
-alg = NeuralPDE.NNODE(chain, opt, autodiff = false, strategy = NeuralPDE.WeightedIntervalTraining(weights, samples))
+alg = NeuralPDE.NNODE(chain, opt, autodiff = false, strategy = NeuralPDE.WeightedIntervalTraining(weights, points))
 sol = solve(prob_oop, alg, verbose=true, maxiters = maxiters, saveat = saveat)
 
 @test abs(mean(sol) - mean(true_sol)) > threshold
 
 #WeightedIntervalTraining with added points (difference between solutions should be low)
-alg = NeuralPDE.NNODE(chain, opt, autodiff = false, strategy = NeuralPDE.WeightedIntervalTraining(weights, samples))
+alg = NeuralPDE.NNODE(chain, opt, autodiff = false, strategy = NeuralPDE.WeightedIntervalTraining(weights, points))
 sol = solve(prob_oop, alg, verbose=true, maxiters = maxiters, saveat = saveat, tstops = addedPoints)
 
 @test abs(mean(sol) - mean(true_sol)) < threshold
 
 #StochasticTraining without added points (difference between solutions should be high)
-alg = NeuralPDE.NNODE(chain, opt, autodiff = false, strategy = NeuralPDE.StochasticTraining(samples))
+alg = NeuralPDE.NNODE(chain, opt, autodiff = false, strategy = NeuralPDE.StochasticTraining(points))
 sol = solve(prob_oop, alg, verbose=true, maxiters = maxiters, saveat = saveat)
 
 @test abs(mean(sol) - mean(true_sol)) > threshold
 
 #StochasticTraining with added points (difference between solutions should be low)
-alg = NeuralPDE.NNODE(chain, opt, autodiff = false, strategy = NeuralPDE.StochasticTraining(samples))
+alg = NeuralPDE.NNODE(chain, opt, autodiff = false, strategy = NeuralPDE.StochasticTraining(points))
 sol = solve(prob_oop, alg, verbose=true, maxiters = maxiters, saveat = saveat, tstops = addedPoints)
 
 @test abs(mean(sol) - mean(true_sol)) < threshold


### PR DESCRIPTION
Renaming would be consistent with other strategies `StochasticTraining`, `QuasiRandomTraining` etc. as it contains the number of points.

Cleaning up `tstops_loss` to avoid redundant function evaluation.