### PR TITLE
ci(buildkite): fix GPU tests not being run on Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,7 +41,6 @@ steps:
     # Don't run Buildkite if the commit message includes the text [skip tests]
     if: build.message !~ /\[skip tests\]/
 
-steps:
   - label: "Documentation"
     plugins:
       - JuliaCI/julia#v1:


### PR DESCRIPTION
Remove the extra `steps` that snuck in to run GPU tests on buildkite CI.

Fixes: 12ab042f ("ci: run Documentation builds on buildkite instead of GHA")