### PR TITLE
Remove duplicated methods in BPINN as it causes methods overwrite

### DIFF
--- a/src/advancedHMC_MCMC.jl
+++ b/src/advancedHMC_MCMC.jl
@@ -351,27 +351,6 @@ function kernelchoice(Kernel, MCMCkwargs)
     end
 end
 
-function integratorchoice(Integratorkwargs, initial_ϵ)
-    Integrator = Integratorkwargs[:Integrator]
-    if Integrator == JitteredLeapfrog
-        jitter_rate = Integratorkwargs[:jitter_rate]
-        Integrator(initial_ϵ, jitter_rate)
-    elseif Integrator == TemperedLeapfrog
-        tempering_rate = Integratorkwargs[:tempering_rate]
-        Integrator(initial_ϵ, tempering_rate)
-    else
-        Integrator(initial_ϵ)
-    end
-end
-
-function adaptorchoice(Adaptor, mma, ssa)
-    if Adaptor != AdvancedHMC.NoAdaptation()
-        Adaptor(mma, ssa)
-    else
-        AdvancedHMC.NoAdaptation()
-    end
-end
-
 """
 ```julia
 ahmc_bayesian_pinn_ode(prob, chain; strategy = GridTraining,


### PR DESCRIPTION
These methods also exist in https://github.com/SciML/NeuralPDE.jl/blob/master/src/PDE_BPINN.jl#L191

Because of this, we get warnings during precompilation.

```julia
Precompiling project...
        Info Given NeuralPDE was explicitly requested, output will be shown live 
WARNING: Method definition integratorchoice(Any, Any) in module NeuralPDE at /Users/sathvik/oss/NeuralPDE.jl/src/advancedHMC_MCMC.jl:354 overwritten at /Users/sathvik/oss/NeuralPDE.jl/src/PDE_BPINN.jl:191.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
  ? NeuralPDE
```

cc: @AstitvaAggarwal 