### PR TITLE
[Do not Merge] Try custom `frule`/`rrule` for `zero`

### DIFF
--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -34,6 +34,21 @@ import UnPack: @unpack
 import ChainRulesCore, Flux, Lux, ComponentArrays
 import ChainRulesCore: @non_differentiable
 
+function ChainRulesCore.frule((_, Δ1), ::typeof(zero), x)
+    var"∂f/∂x" = ChainRulesCore.ZeroTangent()
+    (zero(x), Δ1 * var"∂f/∂x")
+end
+
+function ChainRulesCore.rrule(::typeof(zero), x)
+    Ω = zero(x)
+    proj_x = ChainRulesCore.ProjectTo(x)
+    var"∂f/∂x" = ChainRulesCore.ZeroTangent()
+    pullback(Δ1) = (ChainRulesCore.NoTangent(), proj_x(conj(var"∂f/∂x") * Δ1))
+    (Ω, pullback)
+end
+
+
+
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
 abstract type AbstractPINN end


### PR DESCRIPTION
This is a test to see if this is how `zero` should be handled upstream in ChainRules itself.

If this works, I'd like to try putting this version of the rule in ChainRules.jl as an alternative to https://github.com/SciML/NeuralPDE.jl/pull/791 pirating it in.