### PR TITLE
Add TeX backticks to math symbols in integro_diff.md

### DIFF
--- a/docs/src/tutorials/integro_diff.md
+++ b/docs/src/tutorials/integro_diff.md
@@ -1,14 +1,12 @@
 # Solving Integro-Differential Equations with Physics-Informed Neural Networks (PINNs)
 
-The integral of function u(x),
+The integral of function ``u(x)``,
 
 ```math
 \int_{0}^{t}u(x)dx
 ```
 
-where x is variable of integral and t is variable of integro-differential equation,
-
-is defined as
+where ``x`` is variable of integral and ``t`` is variable of integro-differential equation, is defined as
 
 ```julia
 using ModelingToolkit


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
      (None applicable)
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fix up minor formatting
