### PR TITLE
Fix multioutput `PhysicsInformedNN` construction

### DIFF
--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -124,7 +124,9 @@ function PhysicsInformedNN(
 
     phi = phi === nothing ?
         (multioutput ?
-            map(x -> Phi(x[1], x[2]), zip(chain, init_states)) :
+            (init_states === nothing ?
+                Phi.(chain) :
+                map(x -> Phi(x[1], x[2]), zip(chain, init_states))) :
             Phi(chain; init_states)) :
         phi
 

--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -125,8 +125,8 @@ function PhysicsInformedNN(
     phi = phi === nothing ?
         (multioutput ?
             (init_states === nothing ?
-                Phi.(chain) :
-                map(x -> Phi(x[1], x[2]), zip(chain, init_states))) :
+                map(x -> Phi(x; init_states), chain) :
+                map(x -> Phi(x[1]; init_states = x[2]), zip(chain, init_states))) :
             Phi(chain; init_states)) :
         phi
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fixes a bug I introduced in #955, which caused `PhysicsInformedNN` to fail to construct in the multioutput case.