### PR TITLE
Fix warning admonition block syntax

### DIFF
--- a/src/BPINN_ode.jl
+++ b/src/BPINN_ode.jl
@@ -13,7 +13,7 @@ Algorithm for solving ordinary differential equations using a Bayesian neural ne
 is a specialization of the physics-informed neural network which is used as a solver for a
 standard `ODEProblem`.
 
-!!! warn
+!!! warning
 
     Note that BNNODE only supports ODEs which are written in the out-of-place form, i.e.
     `du = f(u,p,t)`, and not `f(du,u,p,t)`. If not declared out-of-place, then the BNNODE

--- a/src/advancedHMC_MCMC.jl
+++ b/src/advancedHMC_MCMC.jl
@@ -284,7 +284,7 @@ end
                            MCMCkwargs = (n_leapfrog = 30,), progress = false,
                            verbose = false)
 
-!!! warn
+!!! warning
 
     Note that `ahmc_bayesian_pinn_ode()` only supports ODEs which are written in the
     out-of-place form, i.e. `du = f(u,p,t)`, and not `f(du,u,p,t)`. If not declared


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Documenter.jl doesn't recognize `warn` as a synonym for `warning`