### PR TITLE
Add autodiff_derivative for higher precision derivatives

### DIFF
--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -107,7 +107,8 @@ export GridTraining, StochasticTraining, QuadratureTraining, QuasiRandomTraining
 
 export build_loss_function, get_loss_function,
        generate_training_sets, get_variables, get_argument, get_bounds,
-       get_numeric_integral, symbolic_discretize, vector_to_parameters
+       get_numeric_integral, symbolic_discretize, vector_to_parameters,
+       autodiff_derivative, numeric_derivative
 
 export AbstractAdaptiveLoss, NonAdaptiveLoss, GradientScaleAdaptiveLoss,
        MiniMaxAdaptiveLoss


### PR DESCRIPTION
## Summary

- Add `autodiff_derivative` function that uses ForwardDiff for spatial derivatives instead of finite differences
- Export both `autodiff_derivative` and `numeric_derivative` functions
- Keep `numeric_derivative` as default for Zygote compatibility

## Problem

When the loss function is differentiated through (e.g., for JVP/VJP computations during optimization), the finite difference step sizes used in `numeric_derivative` (computed as `eps^(1/(2+order))`) get amplified by `1/epsilon^order`, leading to significant precision loss:

- First-order derivatives: ~1e-10 precision instead of ~1e-16
- Second-order derivatives: ~1e-6 to 1e-7 precision instead of ~1e-16

This was observed in issue #931 where PDE residual JVPs had ~1e-8 precision while BC residuals (no derivatives) had ~1e-16 precision.

## Solution

The new `autodiff_derivative` function uses ForwardDiff directly for computing spatial derivatives, avoiding the numerical instability from finite differences. Testing shows:

```
numeric_derivative JVP error: ~4e-7
autodiff_derivative JVP error: ~1e-15
Improvement factor: ~430 million times better
```

## Usage

Users who need higher JVP/VJP precision can pass `derivative=autodiff_derivative` to PhysicsInformedNN when using ForwardDiff-based optimization backends:

```julia
pinn = PhysicsInformedNN(chain, strategy; derivative=NeuralPDE.autodiff_derivative)
```

## Test plan

- [x] Verified precision improvement locally (~430M times better JVP precision)
- [x] Tested with both Zygote and ForwardDiff backends
- [x] Ran package tests locally (50+ tests passed, 2 pre-existing failures unrelated to this change)
- [ ] Wait for CI to complete

Fixes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)