### PR TITLE
Improve interface compliance for generic numeric types

### DIFF
--- a/src/advancedHMC_MCMC.jl
+++ b/src/advancedHMC_MCMC.jl
@@ -111,7 +111,7 @@ suggested extra loss function for ODE solver case
         physlogprob += logpdf(
             MvNormal((nnsol[i, :] .- deri_physsol[i, :]) .* quadrature_weights,
                 Diagonal(abs2.(T(phynewstd[i]) .* ones(T, length(t))))),
-            zeros(length(t))
+            zeros(T, length(t))
         )
     end
     return physlogprob

--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -310,8 +310,9 @@ function get_numeric_integral(pinnrep::PINNRepresentation)
             return sol
         end
 
-        lb_ = zeros(size(lb)[1], size(cord)[2])
-        ub_ = zeros(size(ub)[1], size(cord)[2])
+        T = eltype(cord)
+        lb_ = zeros(T, size(lb)[1], size(cord)[2])
+        ub_ = zeros(T, size(ub)[1], size(cord)[2])
         for (i, l) in enumerate(lb)
             if l isa Number
                 @ignore_derivatives lb_[i, :] .= l
@@ -328,7 +329,7 @@ function get_numeric_integral(pinnrep::PINNRepresentation)
                     nothing, u, nothing)
             end
         end
-        integration_arr = Matrix{Float64}(undef, 1, 0)
+        integration_arr = Matrix{T}(undef, 1, 0)
         for i in 1:size(cord, 2)
             integration_arr = hcat(integration_arr,
                 integration_(cord[:, i], lb_[:, i], ub_[:, i], θ))

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -105,8 +105,8 @@ function get_points_loss_functions(
     function loss(θ, std)
         logpdf(
             MvNormal(loss_function(train_set, θ)[1, :],
-                Diagonal(abs2.(std .* ones(size(train_set)[2])))),
-            zeros(size(train_set)[2]))
+                Diagonal(abs2.(std .* ones(eltypeθ, size(train_set)[2])))),
+            zeros(eltypeθ, size(train_set)[2]))
     end
 end
 


### PR DESCRIPTION
## Summary
- Replace hardcoded Float64 arrays with type-generic alternatives in three files
- Tested with Float64, Float32, and BigFloat to verify type genericity
- All changes maintain backward compatibility with existing Float64 usage

## Changes
- **discretize.jl**: Use `eltype(cord)` for `zeros()` and `Matrix` construction in `get_numeric_integral()` to support BigFloat and other numeric types
- **training_strategies.jl**: Use `eltypeθ` parameter in `get_points_loss_functions()` for `zeros()` and `ones()` to maintain type consistency
- **advancedHMC_MCMC.jl**: Use type parameter `T` in `zeros()` call for consistency with the rest of the function

## Interface Compliance Testing

Tested with JLArrays (GPU-like arrays) and ArrayInterface.jl to verify:
- `safe_get_device` correctly identifies device for JLArrays
- `EltypeAdaptor` works with different array types
- `fast_scalar_indexing` is respected (JLArrays return false)

Tested with BigFloat to verify:
- NNODE solver works with BigFloat inputs and outputs BigFloat solutions
- PhysicsInformedNN works with BigFloat domains
- No hardcoded Float64 prevents type propagation

## Test plan
- [x] Verified Float64, Float32, BigFloat work with NNODE
- [x] Verified Float64, Float32, BigFloat work with PhysicsInformedNN
- [x] Verified JLArray compatibility for device detection
- [x] Package still loads correctly after changes

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)