### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-annotate_untyped_fields_with_any = false

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-suggestions-on-pr.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,13 +9,17 @@ using Plots
 
 include("pages.jl")
 
-makedocs(sitename = "NeuralPDE.jl",
+makedocs(
+    sitename = "NeuralPDE.jl",
     authors = "#",
     modules = [NeuralPDE],
     clean = true, doctest = false, linkcheck = true,
     warnonly = [:missing_docs],
-    format = Documenter.HTML(assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/NeuralPDE/stable/"),
-    pages = pages)
+    format = Documenter.HTML(
+        assets = ["assets/favicon.ico"],
+        canonical = "https://docs.sciml.ai/NeuralPDE/stable/"
+    ),
+    pages = pages
+)
 
 deploydocs(repo = "github.com/SciML/NeuralPDE.jl.git"; push_preview = true)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,11 +1,13 @@
-pages = ["index.md",
-    "ODE PINN Tutorials" => Any["Introduction to NeuralPDE for ODEs" => "tutorials/ode.md",
+pages = [
+    "index.md",
+    "ODE PINN Tutorials" => Any[
+        "Introduction to NeuralPDE for ODEs" => "tutorials/ode.md",
         "Bayesian PINNs for Coupled ODEs" => "tutorials/Lotka_Volterra_BPINNs.md",
         "PINNs DAEs" => "tutorials/dae.md",
         "Parameter Estimation with PINNs for ODEs" => "tutorials/ode_parameter_estimation.md",
         "Improved PINNs for Inverse problems in ODEs" => "tutorials/data_collocation_Inverse.md",
         "Physics informed Neural Operator ODEs" => "tutorials/pino_ode.md",
-        "Deep Galerkin Method" => "tutorials/dgm.md"        #"examples/nnrode_example.md", # currently incorrect
+        "Deep Galerkin Method" => "tutorials/dgm.md",        #"examples/nnrode_example.md", # currently incorrect
     ],
     "PDE PINN Tutorials" => Any[
         "Introduction to NeuralPDE for PDEs" => "tutorials/pdesystem.md",
@@ -17,16 +19,20 @@ pages = ["index.md",
         "Optimising Parameters (Solving Inverse Problems)" => "tutorials/param_estim.md",
         "Solving Integro Differential Equations" => "tutorials/integro_diff.md",
         "Transfer Learning with Neural Adapter" => "tutorials/neural_adapter.md",
-        "The Derivative Neural Network Approximation" => "tutorials/derivative_neural_network.md"],
-    "Extended Examples" => Any["examples/wave.md",
+        "The Derivative Neural Network Approximation" => "tutorials/derivative_neural_network.md",
+    ],
+    "Extended Examples" => Any[
+        "examples/wave.md",
         "examples/3rd.md",
         "examples/ks.md",
         "examples/heterogeneous.md",
         "examples/linear_parabolic.md",
         "examples/nonlinear_elliptic.md",
         "examples/nonlinear_hyperbolic.md",
-        "examples/complex.md"],
-    "Manual" => Any["manual/ode.md",
+        "examples/complex.md",
+    ],
+    "Manual" => Any[
+        "manual/ode.md",
         "manual/dae.md",
         "manual/pinns.md",
         "manual/bpinns.md",
@@ -34,6 +40,7 @@ pages = ["index.md",
         "manual/adaptive_losses.md",
         "manual/logging.md",
         "manual/neural_adapters.md",
-        "manual/pino_ode.md"],
-    "Developer Documentation" => Any["developer/debugging.md"]
+        "manual/pino_ode.md",
+    ],
+    "Developer Documentation" => Any["developer/debugging.md"],
 ]

--- a/ext/NeuralPDETensorBoardLoggerExt.jl
+++ b/ext/NeuralPDETensorBoardLoggerExt.jl
@@ -3,15 +3,19 @@ module NeuralPDETensorBoardLoggerExt
 using NeuralPDE: NeuralPDE
 using TensorBoardLogger: TBLogger, log_value
 
-function NeuralPDE.logvector(logger::TBLogger, vector::AbstractVector{<:Real},
-        name::AbstractString, step::Integer)
-    foreach(enumerate(vector)) do (j, v)
+function NeuralPDE.logvector(
+        logger::TBLogger, vector::AbstractVector{<:Real},
+        name::AbstractString, step::Integer
+    )
+    return foreach(enumerate(vector)) do (j, v)
         log_value(logger, "$(name)/$(j)", v; step)
     end
 end
 
-function NeuralPDE.logscalar(logger::TBLogger, scalar::Real, name::AbstractString,
-        step::Integer)
+function NeuralPDE.logscalar(
+        logger::TBLogger, scalar::Real, name::AbstractString,
+        step::Integer
+    )
     log_value(logger, "$(name)", scalar; step)
     return nothing
 end

--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -28,8 +28,8 @@ using RecursiveArrayTools: DiffEqArray
 using Reexport: @reexport
 using RuntimeGeneratedFunctions: RuntimeGeneratedFunctions, @RuntimeGeneratedFunction
 using SciMLBase: SciMLBase, BatchIntegralFunction, IntegralProblem, NoiseProblem,
-                 OptimizationFunction, OptimizationProblem, ReturnCode, discretize,
-                 isinplace, solve, symbolic_discretize, ODEProblem, ODESolution
+    OptimizationFunction, OptimizationProblem, ReturnCode, discretize,
+    isinplace, solve, symbolic_discretize, ODEProblem, ODESolution
 using Statistics: Statistics, mean
 using QuasiMonteCarlo: QuasiMonteCarlo, LatinHypercubeSample
 using WeightInitializers: glorot_uniform, zeros32
@@ -38,14 +38,14 @@ using Zygote: Zygote
 # Symbolic Stuff
 using ModelingToolkit: ModelingToolkit, PDESystem, Differential, toexpr
 using Symbolics: Symbolics, unwrap, arguments, operation, build_expr, Num,
-                 expand_derivatives
+    expand_derivatives
 using SymbolicUtils: SymbolicUtils
 using SymbolicIndexingInterface: SymbolicIndexingInterface
 
 # Needed for the Bayesian Stuff
 using AdvancedHMC: AdvancedHMC, DiagEuclideanMetric, HMC, HMCDA, Hamiltonian,
-                   JitteredLeapfrog, Leapfrog, MassMatrixAdaptor, NUTS, StanHMCAdaptor,
-                   StepSizeAdaptor, TemperedLeapfrog, find_good_stepsize
+    JitteredLeapfrog, Leapfrog, MassMatrixAdaptor, NUTS, StanHMCAdaptor,
+    StepSizeAdaptor, TemperedLeapfrog, find_good_stepsize
 using Distributions: Distributions, Distribution, MvNormal, Normal, dim, logpdf
 using LogDensityProblems: LogDensityProblems
 using MCMCChains: MCMCChains, Chains, sample
@@ -103,14 +103,14 @@ export DeepGalerkin
 export neural_adapter
 
 export GridTraining, StochasticTraining, QuadratureTraining, QuasiRandomTraining,
-       WeightedIntervalTraining
+    WeightedIntervalTraining
 
 export build_loss_function, get_loss_function,
-       generate_training_sets, get_variables, get_argument, get_bounds,
-       get_numeric_integral, symbolic_discretize, vector_to_parameters
+    generate_training_sets, get_variables, get_argument, get_bounds,
+    get_numeric_integral, symbolic_discretize, vector_to_parameters
 
 export AbstractAdaptiveLoss, NonAdaptiveLoss, GradientScaleAdaptiveLoss,
-       MiniMaxAdaptiveLoss
+    MiniMaxAdaptiveLoss
 
 export LogOptions
 

--- a/src/adaptive_losses.jl
+++ b/src/adaptive_losses.jl
@@ -19,11 +19,14 @@ change during optimization
     additional_loss_weights::Vector{T}
 end
 
-function NonAdaptiveLoss{T}(; pde_loss_weights = 1.0, bc_loss_weights = 1.0,
-        additional_loss_weights = 1.0) where {T <: Real}
+function NonAdaptiveLoss{T}(;
+        pde_loss_weights = 1.0, bc_loss_weights = 1.0,
+        additional_loss_weights = 1.0
+    ) where {T <: Real}
     return NonAdaptiveLoss{T}(
         vectorify(pde_loss_weights, T), vectorify(bc_loss_weights, T),
-        vectorify(additional_loss_weights, T))
+        vectorify(additional_loss_weights, T)
+    )
 end
 
 NonAdaptiveLoss(; kwargs...) = NonAdaptiveLoss{Float64}(; kwargs...)
@@ -71,51 +74,71 @@ https://github.com/PredictiveIntelligenceLab/GradientPathologiesPINNs
     additional_loss_weights::Vector{T}
 end
 
-function GradientScaleAdaptiveLoss{T}(reweight_every::Int;
+function GradientScaleAdaptiveLoss{T}(
+        reweight_every::Int;
         weight_change_inertia = 0.9, pde_loss_weights = 1.0,
-        bc_loss_weights = 1.0, additional_loss_weights = 1.0) where {T <: Real}
-    return GradientScaleAdaptiveLoss{T}(reweight_every, weight_change_inertia,
+        bc_loss_weights = 1.0, additional_loss_weights = 1.0
+    ) where {T <: Real}
+    return GradientScaleAdaptiveLoss{T}(
+        reweight_every, weight_change_inertia,
         vectorify(pde_loss_weights, T), vectorify(bc_loss_weights, T),
-        vectorify(additional_loss_weights, T))
+        vectorify(additional_loss_weights, T)
+    )
 end
 
 function GradientScaleAdaptiveLoss(args...; kwargs...)
     return GradientScaleAdaptiveLoss{Float64}(args...; kwargs...)
 end
 
-function generate_adaptive_loss_function(pinnrep::PINNRepresentation,
-        adaloss::GradientScaleAdaptiveLoss, pde_loss_functions, bc_loss_functions)
+function generate_adaptive_loss_function(
+        pinnrep::PINNRepresentation,
+        adaloss::GradientScaleAdaptiveLoss, pde_loss_functions, bc_loss_functions
+    )
     weight_change_inertia = adaloss.weight_change_inertia
     iteration = pinnrep.iteration
     adaloss_T = eltype(adaloss.pde_loss_weights)
 
-    return (θ,
+    return (
+        θ,
         pde_losses,
-        bc_losses) -> begin
+        bc_losses,
+    ) -> begin
         if iteration[] % adaloss.reweight_every == 0
             # the paper assumes a single pde loss function, so here we grab the maximum of
             # the maximums of each pde loss function
-            pde_grads_maxes = [maximum(abs, only(Zygote.gradient(pde_loss_function, θ)))
-                               for pde_loss_function in pde_loss_functions]
+            pde_grads_maxes = [
+                maximum(abs, only(Zygote.gradient(pde_loss_function, θ)))
+                    for pde_loss_function in pde_loss_functions
+            ]
             pde_grads_max = maximum(pde_grads_maxes)
-            bc_grads_mean = [mean(abs, only(Zygote.gradient(bc_loss_function, θ)))
-                             for bc_loss_function in bc_loss_functions]
+            bc_grads_mean = [
+                mean(abs, only(Zygote.gradient(bc_loss_function, θ)))
+                    for bc_loss_function in bc_loss_functions
+            ]
 
-            nonzero_divisor_eps = adaloss_T isa Float64 ? 1e-11 : convert(adaloss_T, 1e-7)
+            nonzero_divisor_eps = adaloss_T isa Float64 ? 1.0e-11 : convert(adaloss_T, 1.0e-7)
             bc_loss_weights_proposed = pde_grads_max ./
-                                       (bc_grads_mean .+ nonzero_divisor_eps)
+                (bc_grads_mean .+ nonzero_divisor_eps)
             adaloss.bc_loss_weights .= weight_change_inertia .*
-                                       adaloss.bc_loss_weights .+
-                                       (1 .- weight_change_inertia) .*
-                                       bc_loss_weights_proposed
-            logscalar(pinnrep.logger, pde_grads_max, "adaptive_loss/pde_grad_max",
-                iteration[])
-            logvector(pinnrep.logger, pde_grads_maxes, "adaptive_loss/pde_grad_maxes",
-                iteration[])
-            logvector(pinnrep.logger, bc_grads_mean, "adaptive_loss/bc_grad_mean",
-                iteration[])
-            logvector(pinnrep.logger, adaloss.bc_loss_weights,
-                "adaptive_loss/bc_loss_weights", iteration[])
+                adaloss.bc_loss_weights .+
+                (1 .- weight_change_inertia) .*
+                bc_loss_weights_proposed
+            logscalar(
+                pinnrep.logger, pde_grads_max, "adaptive_loss/pde_grad_max",
+                iteration[]
+            )
+            logvector(
+                pinnrep.logger, pde_grads_maxes, "adaptive_loss/pde_grad_maxes",
+                iteration[]
+            )
+            logvector(
+                pinnrep.logger, bc_grads_mean, "adaptive_loss/bc_grad_mean",
+                iteration[]
+            )
+            logvector(
+                pinnrep.logger, adaloss.bc_loss_weights,
+                "adaptive_loss/bc_loss_weights", iteration[]
+            )
         end
         return nothing
     end
@@ -160,35 +183,50 @@ https://arxiv.org/abs/2009.04544
     additional_loss_weights::Vector{T}
 end
 
-function MiniMaxAdaptiveLoss{T}(reweight_every::Int; pde_max_optimiser = Adam(1e-4),
+function MiniMaxAdaptiveLoss{T}(
+        reweight_every::Int; pde_max_optimiser = Adam(1.0e-4),
         bc_max_optimiser = Adam(0.5), pde_loss_weights = 1.0, bc_loss_weights = 1.0,
-        additional_loss_weights = 1.0) where {T <: Real}
-    return MiniMaxAdaptiveLoss{T}(reweight_every, pde_max_optimiser, bc_max_optimiser,
+        additional_loss_weights = 1.0
+    ) where {T <: Real}
+    return MiniMaxAdaptiveLoss{T}(
+        reweight_every, pde_max_optimiser, bc_max_optimiser,
         vectorify(pde_loss_weights, T), vectorify(bc_loss_weights, T),
-        vectorify(additional_loss_weights, T))
+        vectorify(additional_loss_weights, T)
+    )
 end
 
 MiniMaxAdaptiveLoss(args...; kwargs...) = MiniMaxAdaptiveLoss{Float64}(args...; kwargs...)
 
-function generate_adaptive_loss_function(pinnrep::PINNRepresentation,
-        adaloss::MiniMaxAdaptiveLoss, _, __)
+function generate_adaptive_loss_function(
+        pinnrep::PINNRepresentation,
+        adaloss::MiniMaxAdaptiveLoss, _, __
+    )
     pde_max_optimiser_setup = Optimisers.setup(
-        adaloss.pde_max_optimiser, adaloss.pde_loss_weights)
+        adaloss.pde_max_optimiser, adaloss.pde_loss_weights
+    )
     bc_max_optimiser_setup = Optimisers.setup(
-        adaloss.bc_max_optimiser, adaloss.bc_loss_weights)
+        adaloss.bc_max_optimiser, adaloss.bc_loss_weights
+    )
     iteration = pinnrep.iteration
 
-    return (θ,
+    return (
+        θ,
         pde_losses,
-        bc_losses) -> begin
+        bc_losses,
+    ) -> begin
         if iteration[] % adaloss.reweight_every == 0
             Optimisers.update!(
-                pde_max_optimiser_setup, adaloss.pde_loss_weights, -pde_losses)
+                pde_max_optimiser_setup, adaloss.pde_loss_weights, -pde_losses
+            )
             Optimisers.update!(bc_max_optimiser_setup, adaloss.bc_loss_weights, -bc_losses)
-            logvector(pinnrep.logger, adaloss.pde_loss_weights,
-                "adaptive_loss/pde_loss_weights", iteration[])
-            logvector(pinnrep.logger, adaloss.bc_loss_weights,
-                "adaptive_loss/bc_loss_weights", iteration[])
+            logvector(
+                pinnrep.logger, adaloss.pde_loss_weights,
+                "adaptive_loss/pde_loss_weights", iteration[]
+            )
+            logvector(
+                pinnrep.logger, adaloss.bc_loss_weights,
+                "adaptive_loss/bc_loss_weights", iteration[]
+            )
         end
         return nothing
     end

--- a/src/neural_adapter.jl
+++ b/src/neural_adapter.jl
@@ -2,22 +2,29 @@ function generate_training_sets(domains, dx, eqs, eltypeθ)
     dxs = dx isa Array ? dx : fill(dx, length(domains))
     spans = [infimum(d.domain):dx:supremum(d.domain) for (d, dx) in zip(domains, dxs)]
     return reduce(hcat, vec(map(collect, Iterators.product(spans...)))) |>
-           EltypeAdaptor{eltypeθ}()
+        EltypeAdaptor{eltypeθ}()
 end
 
 function get_bounds_(domains, eqs, eltypeθ, dict_indvars, dict_depvars, _)
-    dict_span = Dict([Symbol(d.variables) => [infimum(d.domain), supremum(d.domain)]
-                      for d in domains])
+    dict_span = Dict(
+        [
+            Symbol(d.variables) => [infimum(d.domain), supremum(d.domain)]
+                for d in domains
+        ]
+    )
     args = get_argument(eqs, dict_indvars, dict_depvars)
 
-    bounds = first(map(args) do pd
-        return get.((dict_span,), pd, pd) |> EltypeAdaptor{eltypeθ}()
-    end)
+    bounds = first(
+        map(args) do pd
+            return get.((dict_span,), pd, pd) |> EltypeAdaptor{eltypeθ}()
+        end
+    )
     return first.(bounds), last.(bounds)
 end
 
 function get_loss_function_neural_adapter(
-        loss, init_params, pde_system, strategy::GridTraining)
+        loss, init_params, pde_system, strategy::GridTraining
+    )
     eqs = pde_system.eqs
     eqs isa Array || (eqs = [eqs])
     eltypeθ = recursive_eltype(init_params)
@@ -25,8 +32,10 @@ function get_loss_function_neural_adapter(
     return get_loss_function(init_params, loss, train_set, eltypeθ, strategy)
 end
 
-function get_loss_function_neural_adapter(loss, init_params, pde_system,
-        strategy::Union{StochasticTraining, QuasiRandomTraining})
+function get_loss_function_neural_adapter(
+        loss, init_params, pde_system,
+        strategy::Union{StochasticTraining, QuasiRandomTraining}
+    )
     eqs = pde_system.eqs
     eqs isa Array || (eqs = [eqs])
     domains = pde_system.domain
@@ -39,7 +48,8 @@ function get_loss_function_neural_adapter(loss, init_params, pde_system,
 end
 
 function get_loss_function_neural_adapter(
-        loss, init_params, pde_system, strategy::QuadratureTraining)
+        loss, init_params, pde_system, strategy::QuadratureTraining
+    )
     eqs = pde_system.eqs
     eqs isa Array || (eqs = [eqs])
     domains = pde_system.domain
@@ -67,9 +77,11 @@ function neural_adapter end
 
 function neural_adapter(loss, init_params, pde_system, strategy)
     loss_function = get_loss_function_neural_adapter(
-        loss, init_params, pde_system, strategy)
+        loss, init_params, pde_system, strategy
+    )
     return OptimizationProblem(
-        OptimizationFunction((θ, _) -> loss_function(θ), AutoZygote()), init_params)
+        OptimizationFunction((θ, _) -> loss_function(θ), AutoZygote()), init_params
+    )
 end
 
 function neural_adapter(losses::Array, init_params, pde_systems::Array, strategy)
@@ -78,5 +90,6 @@ function neural_adapter(losses::Array, init_params, pde_systems::Array, strategy
     end
     return OptimizationProblem(
         OptimizationFunction((θ, _) -> sum(l -> l(θ), loss_functions), AutoZygote()),
-        init_params)
+        init_params
+    )
 end

--- a/src/pinn_types.jl
+++ b/src/pinn_types.jl
@@ -111,7 +111,8 @@ function PhysicsInformedNN(
         chain, strategy; init_params = nothing, init_states = nothing, derivative = nothing,
         param_estim = false, phi::Union{Nothing, Phi, AbstractArray{<:Phi}} = nothing,
         additional_loss = nothing, adaptive_loss = nothing, logger = nothing,
-        log_options = LogOptions(), iteration = nothing, kwargs...)
+        log_options = LogOptions(), iteration = nothing, kwargs...
+    )
     multioutput = chain isa AbstractArray
     if multioutput
         chain = map(chain) do cᵢ
@@ -123,12 +124,16 @@ function PhysicsInformedNN(
     end
 
     phi = phi === nothing ?
-          (multioutput ?
-           (init_states === nothing ?
-            map(x -> Phi(x; init_states), chain) :
-            map(x -> Phi(x[1]; init_states = x[2]), zip(chain, init_states))) :
-           Phi(chain; init_states)) :
-          phi
+        (
+            multioutput ?
+            (
+                init_states === nothing ?
+                map(x -> Phi(x; init_states), chain) :
+                map(x -> Phi(x[1]; init_states = x[2]), zip(chain, init_states))
+            ) :
+            Phi(chain; init_states)
+        ) :
+        phi
 
     derivative = ifelse(derivative === nothing, numeric_derivative, derivative)
 
@@ -143,9 +148,11 @@ function PhysicsInformedNN(
         self_increment = true
     end
 
-    return PhysicsInformedNN(chain, strategy, init_params, init_states, phi, derivative,
+    return PhysicsInformedNN(
+        chain, strategy, init_params, init_states, phi, derivative,
         param_estim, additional_loss, adaptive_loss, logger, log_options, iteration,
-        self_increment, multioutput, kwargs)
+        self_increment, multioutput, kwargs
+    )
 end
 
 """
@@ -374,20 +381,26 @@ function numeric_derivative(phi, u, x, εs, order, θ)
     # if order 1, this is trivially true
 
     if order > 4 || any(x -> x != εs[1], εs)
-        return (numeric_derivative(phi, u, x .+ ε, @view(εs[1:(end - 1)]), order - 1, θ)
+        return (
+            numeric_derivative(phi, u, x .+ ε, @view(εs[1:(end - 1)]), order - 1, θ)
                 .-
-                numeric_derivative(phi, u, x .- ε, @view(εs[1:(end - 1)]), order - 1, θ)) .*
-               _epsilon ./ 2
+                numeric_derivative(phi, u, x .- ε, @view(εs[1:(end - 1)]), order - 1, θ)
+        ) .*
+            _epsilon ./ 2
     elseif order == 4
-        return (u(x .+ 2 .* ε, θ, phi) .- 4 .* u(x .+ ε, θ, phi)
+        return (
+            u(x .+ 2 .* ε, θ, phi) .- 4 .* u(x .+ ε, θ, phi)
                 .+
                 6 .* u(x, θ, phi)
                 .-
-                4 .* u(x .- ε, θ, phi) .+ u(x .- 2 .* ε, θ, phi)) .* _epsilon^4
+                4 .* u(x .- ε, θ, phi) .+ u(x .- 2 .* ε, θ, phi)
+        ) .* _epsilon^4
     elseif order == 3
-        return (u(x .+ 2 .* ε, θ, phi) .- 2 .* u(x .+ ε, θ, phi) .+ 2 .* u(x .- ε, θ, phi)
+        return (
+            u(x .+ 2 .* ε, θ, phi) .- 2 .* u(x .+ ε, θ, phi) .+ 2 .* u(x .- ε, θ, phi)
                 -
-                u(x .- 2 .* ε, θ, phi)) .* _epsilon^3 ./ 2
+                u(x .- 2 .* ε, θ, phi)
+        ) .* _epsilon^3 ./ 2
     elseif order == 2
         return (u(x .+ ε, θ, phi) .+ u(x .- ε, θ, phi) .- 2 .* u(x, θ, phi)) .* _epsilon^2
     elseif order == 1

--- a/src/transform_inf_integral.jl
+++ b/src/transform_inf_integral.jl
@@ -1,6 +1,7 @@
-
-function transform_inf_expr(integrating_depvars, dict_depvar_input, dict_depvars,
-        integrating_variables, transform)
+function transform_inf_expr(
+        integrating_depvars, dict_depvar_input, dict_depvars,
+        integrating_variables, transform
+    )
     τs = Symbolics.variables(:τ, 1:length(integrating_variables))
     τs = Symbol.(τs)
     dict_transformation_vars = Dict()
@@ -26,9 +27,12 @@ function transform_inf_expr(integrating_depvars, dict_depvar_input, dict_depvars
         dict_depvar_input_[depvar] = ans
     end
 
-    this_eq_pair = Dict(map(
-        intvars -> dict_depvars[intvars] => dict_depvar_input_[intvars],
-        integrating_depvars))
+    this_eq_pair = Dict(
+        map(
+            intvars -> dict_depvars[intvars] => dict_depvar_input_[intvars],
+            integrating_depvars
+        )
+    )
     this_eq_indvars = unique(vcat(values(this_eq_pair)...))
 
     return dict_transformation_vars, this_eq_indvars, integrating_var_transformation
@@ -54,8 +58,10 @@ function v_semiinf(t, a, upto_inf)
     end
 end
 
-function get_inf_transformation_jacobian(integrating_variable, _inf, _semiup, _semilw,
-        _num_semiup, _num_semilw)
+function get_inf_transformation_jacobian(
+        integrating_variable, _inf, _semiup, _semilw,
+        _num_semiup, _num_semilw
+    )
     j = []
     for var in integrating_variable
         if _inf[1]
@@ -70,10 +76,12 @@ function get_inf_transformation_jacobian(integrating_variable, _inf, _semiup, _s
     return j
 end
 
-function transform_inf_integral(lb, ub, integrating_ex, integrating_depvars,
+function transform_inf_integral(
+        lb, ub, integrating_ex, integrating_depvars,
         dict_depvar_input, dict_depvars, integrating_variable,
         eltypeθ; dict_transformation_vars = nothing,
-        transformation_vars = nothing)
+        transformation_vars = nothing
+    )
     lb_ = Symbolics.tosymbol.(lb)
     ub_ = Symbolics.tosymbol.(ub)
 
@@ -104,18 +112,21 @@ function transform_inf_integral(lb, ub, integrating_ex, integrating_depvars,
         end
 
         dict_transformation_vars, transformation_vars,
-        integrating_var_transformation = transform_inf_expr(
-            integrating_depvars, dict_depvar_input, dict_depvars, integrating_variable, transform_indvars)
+            integrating_var_transformation = transform_inf_expr(
+            integrating_depvars, dict_depvar_input, dict_depvars, integrating_variable, transform_indvars
+        )
 
         ϵ = 1 / 20 #cbrt(eps(eltypeθ))
 
-        lb = 0.00 .* _semiup + (-1.00 + ϵ) .* _inf + (-1.00 + ϵ) .* _semilw + _none .* lb +
-             lb ./ (1 .+ lb) .* _num_semiup + (-1.00 + ϵ) .* _num_semilw
-        ub = (1.00 - ϵ) .* _semiup + (1.00 - ϵ) .* _inf + 0.00 .* _semilw + _none .* ub +
-             (1.00 - ϵ) .* _num_semiup + ub ./ (1 .+ ub) .* _num_semilw
+        lb = 0.0 .* _semiup + (-1.0 + ϵ) .* _inf + (-1.0 + ϵ) .* _semilw + _none .* lb +
+            lb ./ (1 .+ lb) .* _num_semiup + (-1.0 + ϵ) .* _num_semilw
+        ub = (1.0 - ϵ) .* _semiup + (1.0 - ϵ) .* _inf + 0.0 .* _semilw + _none .* ub +
+            (1.0 - ϵ) .* _num_semiup + ub ./ (1 .+ ub) .* _num_semilw
 
-        j = get_inf_transformation_jacobian(integrating_var_transformation, _inf, _semiup,
-            _semilw, _num_semiup, _num_semilw)
+        j = get_inf_transformation_jacobian(
+            integrating_var_transformation, _inf, _semiup,
+            _semilw, _num_semiup, _num_semilw
+        )
 
         integrating_ex = Expr(:call, :*, integrating_ex, j...)
     end

--- a/test/BPINN_PDE_tests.jl
+++ b/test/BPINN_PDE_tests.jl
@@ -1,7 +1,7 @@
-@testitem "BPINN PDE I: 1D Periodic System" tags=[:pdebpinn] begin
+@testitem "BPINN PDE I: 1D Periodic System" tags = [:pdebpinn] begin
     using MCMCChains, Lux, ModelingToolkit, Distributions, OrdinaryDiffEq,
-          AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
-          ComponentArrays
+        AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
@@ -22,7 +22,8 @@
 
     sol1 = ahmc_bayesian_pinn_pde(
         pde_system, discretization; draw_samples = 1500, bcstd = [0.01],
-        phystd = [0.01], priorsNNw = (0.0, 1.0), saveats = [1 / 50.0])
+        phystd = [0.01], priorsNNw = (0.0, 1.0), saveats = [1 / 50.0]
+    )
 
     analytic_sol_func(u0, t) = u0 + sinpi(2t) / (2pi)
     ts = vec(sol1.timepoints[1])
@@ -30,13 +31,13 @@
     u_predict = pmean(sol1.ensemblesol[1])
 
     # absol tests
-    @test mean(abs, u_predict .- u_real) < 8e-2
+    @test mean(abs, u_predict .- u_real) < 8.0e-2
 end
 
-@testitem "BPINN PDE II: 1D ODE" tags=[:pdebpinn] begin
+@testitem "BPINN PDE II: 1D ODE" tags = [:pdebpinn] begin
     using MCMCChains, Lux, ModelingToolkit, Distributions, OrdinaryDiffEq,
-          AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
-          ComponentArrays
+        AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
@@ -47,8 +48,8 @@ end
 
     # 1D ODE
     eq = Dθ(u(θ)) ~
-         θ^3 + 2.0f0 * θ + (θ^2) * ((1.0f0 + 3 * (θ^2)) / (1.0f0 + θ + (θ^3))) -
-         u(θ) * (θ + ((1.0f0 + 3.0f0 * (θ^2)) / (1.0f0 + θ + θ^3)))
+        θ^3 + 2.0f0 * θ + (θ^2) * ((1.0f0 + 3 * (θ^2)) / (1.0f0 + θ + (θ^3))) -
+        u(θ) * (θ + ((1.0f0 + 3.0f0 * (θ^2)) / (1.0f0 + θ + θ^3)))
 
     # Initial and boundary conditions
     bcs = [u(0.0) ~ 1.0f0]
@@ -68,19 +69,20 @@ end
 
     sol1 = ahmc_bayesian_pinn_pde(
         pde_system, discretization; draw_samples = 500, bcstd = [0.1],
-        phystd = [0.05], priorsNNw = (0.0, 10.0), saveats = [1 / 100.0])
+        phystd = [0.05], priorsNNw = (0.0, 10.0), saveats = [1 / 100.0]
+    )
 
     analytic_sol_func(t) = exp(-(t^2) / 2) / (1 + t + t^3) + t^2
     ts = sol1.timepoints[1]
     u_real = vec([analytic_sol_func(t) for t in ts])
     u_predict = pmean(sol1.ensemblesol[1])
-    @test u_predict≈u_real atol=0.8
+    @test u_predict ≈ u_real atol = 0.8
 end
 
-@testitem "BPINN PDE III: 3rd Degree ODE" tags=[:pdebpinn] begin
+@testitem "BPINN PDE III: 3rd Degree ODE" tags = [:pdebpinn] begin
     using MCMCChains, Lux, ModelingToolkit, Distributions, OrdinaryDiffEq,
-          AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
-          ComponentArrays
+        AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
@@ -101,7 +103,7 @@ end
         u(1.0) ~ cospi(1.0),
         Dxu(1.0) ~ 1.0,
         Dxu(x) ~ Dx(u(x)) + ep * O1(x),
-        Dxxu(x) ~ Dx(Dxu(x)) + ep * O2(x)
+        Dxxu(x) ~ Dx(Dxu(x)) + ep * O2(x),
     ]
 
     # Space and time domains
@@ -113,30 +115,34 @@ end
         Chain(Dense(1, 10, tanh), Dense(10, 10, tanh), Dense(10, 1)),
         Chain(Dense(1, 10, tanh), Dense(10, 10, tanh), Dense(10, 1)),
         Chain(Dense(1, 4, tanh), Dense(4, 1)),
-        Chain(Dense(1, 4, tanh), Dense(4, 1))
+        Chain(Dense(1, 4, tanh), Dense(4, 1)),
     ]
 
     discretization = BayesianPINN(chain, GridTraining(0.01))
 
-    @named pde_system = PDESystem(eq, bcs, domains, [x],
-        [u(x), Dxu(x), Dxxu(x), O1(x), O2(x)])
+    @named pde_system = PDESystem(
+        eq, bcs, domains, [x],
+        [u(x), Dxu(x), Dxxu(x), O1(x), O2(x)]
+    )
 
-    sol1 = ahmc_bayesian_pinn_pde(pde_system, discretization; draw_samples = 200,
+    sol1 = ahmc_bayesian_pinn_pde(
+        pde_system, discretization; draw_samples = 200,
         bcstd = [0.01, 0.01, 0.01, 0.01, 0.01], phystd = [0.005],
-        priorsNNw = (0.0, 10.0), saveats = [1 / 100.0])
+        priorsNNw = (0.0, 10.0), saveats = [1 / 100.0]
+    )
 
     analytic_sol_func(x) = (π * x * (-x + (π^2) * (2 * x - 3) + 1) - sinpi(x)) / (π^3)
 
     u_predict = pmean(sol1.ensemblesol[1])
     xs = vec(sol1.timepoints[1])
     u_real = [analytic_sol_func(x) for x in xs]
-    @test u_predict≈u_real atol=0.5
+    @test u_predict ≈ u_real atol = 0.5
 end
 
-@testitem "BPINN PDE IV: 2D Poisson" tags=[:pdebpinn] begin
+@testitem "BPINN PDE IV: 2D Poisson" tags = [:pdebpinn] begin
     using MCMCChains, Lux, ModelingToolkit, Distributions, OrdinaryDiffEq,
-          AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
-          ComponentArrays
+        AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
@@ -154,7 +160,7 @@ end
         u(0, y) ~ 0.0,
         u(1, y) ~ 0.0,
         u(x, 0) ~ 0.0,
-        u(x, 1) ~ 0.0
+        u(x, 1) ~ 0.0,
     ]
 
     # Space and time domains
@@ -171,22 +177,24 @@ end
 
     @named pde_system = PDESystem(eq, bcs, domains, [x, y], [u(x, y)])
 
-    sol = ahmc_bayesian_pinn_pde(pde_system, discretization; draw_samples = 200,
+    sol = ahmc_bayesian_pinn_pde(
+        pde_system, discretization; draw_samples = 200,
         bcstd = [0.003, 0.003, 0.003, 0.003], phystd = [0.003],
-        priorsNNw = (0.0, 10.0), saveats = [1 / 100.0, 1 / 100.0])
+        priorsNNw = (0.0, 10.0), saveats = [1 / 100.0, 1 / 100.0]
+    )
 
     xs = sol.timepoints[1]
     analytic_sol_func(x, y) = (sinpi(x) * sinpi(y)) / (2pi^2)
 
     u_predict = pmean(sol.ensemblesol[1])
     u_real = [analytic_sol_func(xs[:, i][1], xs[:, i][2]) for i in 1:length(xs[1, :])]
-    @test u_predict≈u_real rtol=0.5
+    @test u_predict ≈ u_real rtol = 0.5
 end
 
-@testitem "BPINN PDE: Translating from Flux" tags=[:pdebpinn] begin
+@testitem "BPINN PDE: Translating from Flux" tags = [:pdebpinn] begin
     using MCMCChains, Lux, ModelingToolkit, Distributions, OrdinaryDiffEq,
-          AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
-          ComponentArrays
+        AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
     import Flux
 
@@ -198,8 +206,8 @@ end
 
     # 1D ODE
     eq = Dθ(u(θ)) ~
-         θ^3 + 2.0f0 * θ + (θ^2) * ((1.0f0 + 3 * (θ^2)) / (1.0f0 + θ + (θ^3))) -
-         u(θ) * (θ + ((1.0f0 + 3.0f0 * (θ^2)) / (1.0f0 + θ + θ^3)))
+        θ^3 + 2.0f0 * θ + (θ^2) * ((1.0f0 + 3 * (θ^2)) / (1.0f0 + θ + (θ^3))) -
+        u(θ) * (θ + ((1.0f0 + 3.0f0 * (θ^2)) / (1.0f0 + θ + θ^3)))
 
     # Initial and boundary conditions
     bcs = [u(0.0) ~ 1.0f0]
@@ -215,21 +223,23 @@ end
 
     @named pde_system = PDESystem(eq, bcs, domains, [θ], [u])
 
-    sol = ahmc_bayesian_pinn_pde(pde_system, discretization; draw_samples = 500,
-        bcstd = [0.1], phystd = [0.05], priorsNNw = (0.0, 10.0), saveats = [1 / 100.0])
+    sol = ahmc_bayesian_pinn_pde(
+        pde_system, discretization; draw_samples = 500,
+        bcstd = [0.1], phystd = [0.05], priorsNNw = (0.0, 10.0), saveats = [1 / 100.0]
+    )
 
     analytic_sol_func(t) = exp(-(t^2) / 2) / (1 + t + t^3) + t^2
     ts = sol.timepoints[1]
     u_real = vec([analytic_sol_func(t) for t in ts])
     u_predict = pmean(sol.ensemblesol[1])
 
-    @test u_predict≈u_real atol=0.8
+    @test u_predict ≈ u_real atol = 0.8
 end
 
-@testitem "BPINN PDE Inv I: 1D Periodic System" tags=[:pdebpinn] begin
+@testitem "BPINN PDE Inv I: 1D Periodic System" tags = [:pdebpinn] begin
     using MCMCChains, Lux, ModelingToolkit, Distributions, OrdinaryDiffEq,
-          AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
-          ComponentArrays
+        AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
@@ -245,13 +255,15 @@ end
     chainl = Lux.Chain(Lux.Dense(1, 6, tanh), Lux.Dense(6, 6, tanh), Lux.Dense(6, 1))
     initl, st = Lux.setup(Random.default_rng(), chainl)
 
-    @named pde_system = PDESystem(eqs,
+    @named pde_system = PDESystem(
+        eqs,
         bcs,
         domains,
         [t],
         [u(t)],
         [p],
-        defaults = Dict([p => 4.0]))
+        defaults = Dict([p => 4.0])
+    )
 
     analytic_sol_func1(u0, t) = u0 + sinpi(2t) / (2π)
     timepoints = collect(0.0:(1 / 100.0):2.0)
@@ -261,36 +273,40 @@ end
 
     # BPINNs are formulated with a mesh that must stay the same throughout sampling (as of now)
     @testset "$(nameof(typeof(strategy)))" for strategy in [
-    # StochasticTraining(200),
-    # QuasiRandomTraining(200),
-        GridTraining([0.02])
-    ]
-        discretization = BayesianPINN([chainl], strategy; param_estim = true,
-            dataset = [dataset, nothing])
+            # StochasticTraining(200),
+            # QuasiRandomTraining(200),
+            GridTraining([0.02]),
+        ]
+        discretization = BayesianPINN(
+            [chainl], strategy; param_estim = true,
+            dataset = [dataset, nothing]
+        )
 
-        sol1 = ahmc_bayesian_pinn_pde(pde_system,
+        sol1 = ahmc_bayesian_pinn_pde(
+            pde_system,
             discretization;
             draw_samples = 1500,
             bcstd = [0.02],
             phystd = [0.02], l2std = [0.02],
             priorsNNw = (0.0, 1.0),
             saveats = [1 / 50.0],
-            param = [LogNormal(6.0, 0.5)])
+            param = [LogNormal(6.0, 0.5)]
+        )
 
         param = 2 * π
         ts = vec(sol1.timepoints[1])
         u_real = [analytic_sol_func1(0.0, t) for t in ts]
         u_predict = pmean(sol1.ensemblesol[1])
 
-        @test mean(abs, u_predict .- u_real) < 8e-2
-        @test sol1.estimated_de_params[1]≈param rtol=0.1
+        @test mean(abs, u_predict .- u_real) < 8.0e-2
+        @test sol1.estimated_de_params[1] ≈ param rtol = 0.1
     end
 end
 
-@testitem "BPINN PDE Inv II: Lorenz System" tags=[:pdebpinn] begin
+@testitem "BPINN PDE Inv II: Lorenz System" tags = [:pdebpinn] begin
     using MCMCChains, Lux, ModelingToolkit, Distributions, OrdinaryDiffEq,
-          AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
-          ComponentArrays
+        AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
@@ -301,7 +317,7 @@ end
     eqs = [
         Dt(x(t)) ~ σ_ * (y(t) - x(t)),
         Dt(y(t)) ~ x(t) * (28.0 - z(t)) - y(t),
-        Dt(z(t)) ~ x(t) * y(t) - 8.0 / 3.0 * z(t)
+        Dt(z(t)) ~ x(t) * y(t) - 8.0 / 3.0 * z(t),
     ]
 
     bcs = [x(0) ~ 1.0, y(0) ~ 0.0, z(0) ~ 0.0]
@@ -312,7 +328,7 @@ end
     chain = [
         Chain(Dense(input_, n, tanh), Dense(n, n, tanh), Dense(n, 1)),
         Chain(Dense(input_, n, tanh), Dense(n, n, tanh), Dense(n, 1)),
-        Chain(Dense(input_, n, tanh), Dense(n, n, tanh), Dense(n, 1))
+        Chain(Dense(input_, n, tanh), Dense(n, n, tanh), Dense(n, 1)),
     ]
 
     # Generate Data
@@ -332,13 +348,18 @@ end
     ts_ = hcat(ts...)[1, :]
     dataset = [hcat(us[i, :], ts_) for i in 1:3]
 
-    discretization = BayesianPINN(chain, GridTraining([0.01]); param_estim = true,
-        dataset = [dataset, nothing])
+    discretization = BayesianPINN(
+        chain, GridTraining([0.01]); param_estim = true,
+        dataset = [dataset, nothing]
+    )
 
-    @named pde_system = PDESystem(eqs, bcs, domains,
-        [t], [x(t), y(t), z(t)], [σ_], defaults = Dict([p => 1.0 for p in [σ_]]))
+    @named pde_system = PDESystem(
+        eqs, bcs, domains,
+        [t], [x(t), y(t), z(t)], [σ_], defaults = Dict([p => 1.0 for p in [σ_]])
+    )
 
-    sol1 = ahmc_bayesian_pinn_pde(pde_system,
+    sol1 = ahmc_bayesian_pinn_pde(
+        pde_system,
         discretization;
         draw_samples = 50,
         bcstd = [0.3, 0.3, 0.3],
@@ -346,18 +367,19 @@ end
         l2std = [1, 1, 1],
         priorsNNw = (0.0, 1.0),
         saveats = [0.01],
-        param = [Normal(12.0, 2)])
+        param = [Normal(12.0, 2)]
+    )
 
     idealp = 10.0
     p_ = sol1.estimated_de_params[1]
-    @test sum(abs, pmean(p_) - 10.00) < 0.3 * idealp[1]
+    @test sum(abs, pmean(p_) - 10.0) < 0.3 * idealp[1]
     # @test sum(abs, pmean(p_[2]) - (8 / 3)) < 0.3 * idealp[2]
 end
 
-@testitem "BPINN PDE Inv III: Improved Parametric Kuromo-Sivashinsky Equation solve" tags=[:pdebpinn] begin
+@testitem "BPINN PDE Inv III: Improved Parametric Kuromo-Sivashinsky Equation solve" tags = [:pdebpinn] begin
     using MCMCChains, Lux, ModelingToolkit, Distributions, OrdinaryDiffEq,
-          AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
-          ComponentArrays
+        AdvancedHMC, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
@@ -394,20 +416,24 @@ end
     β = 4
     γ = 1
     eq = Dt(u(x, t)) + u(x, t) * Dx(u(x, t)) + α * Dx2(u(x, t)) + β * Dx3(u(x, t)) +
-         γ * Dx4(u(x, t)) ~ 0
+        γ * Dx4(u(x, t)) ~ 0
 
     u_analytic(x, t; z = -x / 2 + t) = 11 + 15 * tanh(z) - 15 * tanh(z)^2 - 15 * tanh(z)^3
     du(x, t; z = -x / 2 + t) = 15 / 2 * (tanh(z) + 1) * (3 * tanh(z) - 1) * sech(z)^2
 
-    bcs = [u(x, 0) ~ u_analytic(x, 0),
+    bcs = [
+        u(x, 0) ~ u_analytic(x, 0),
         u(-10, t) ~ u_analytic(-10, t),
         u(10, t) ~ u_analytic(10, t),
         Dx(u(-10, t)) ~ du(-10, t),
-        Dx(u(10, t)) ~ du(10, t)]
+        Dx(u(10, t)) ~ du(10, t),
+    ]
 
     # Space and time domains
-    domains = [x ∈ Interval(-10.0, 10.0),
-        t ∈ Interval(0.0, 1.0)]
+    domains = [
+        x ∈ Interval(-10.0, 10.0),
+        t ∈ Interval(0.0, 1.0),
+    ]
 
     # Discretization
     dx = 0.4
@@ -442,25 +468,31 @@ end
     # Adding Gaussian noise with a 0.8 std
     noisydataset_new = deepcopy(datasetpde_new)
     noisydataset_new[1][:, 1] = noisydataset_new[1][:, 1] .+
-                                (randn(size(noisydataset_new[1][:, 1])) .* 0.8)
+        (randn(size(noisydataset_new[1][:, 1])) .* 0.8)
 
     # Neural network
-    chain = Lux.Chain(Lux.Dense(2, 8, Lux.tanh),
+    chain = Lux.Chain(
+        Lux.Dense(2, 8, Lux.tanh),
         Lux.Dense(8, 8, Lux.tanh),
-        Lux.Dense(8, 1))
+        Lux.Dense(8, 1)
+    )
 
     # Discretization for old and new models
-    discretization = NeuralPDE.BayesianPINN([chain],
-        GridTraining([dx, dt]), param_estim = true, dataset = [noisydataset_new, nothing])
+    discretization = NeuralPDE.BayesianPINN(
+        [chain],
+        GridTraining([dx, dt]), param_estim = true, dataset = [noisydataset_new, nothing]
+    )
 
     # let α default to 2.0
-    @named pde_system = PDESystem(eq,
+    @named pde_system = PDESystem(
+        eq,
         bcs,
         domains,
         [x, t],
         [u(x, t)],
         [α],
-        defaults = Dict([α => 2.0]))
+        defaults = Dict([α => 2.0])
+    )
 
     # neccesarry for loss function construction (involves Operator masking)
     eqs = pde_system.eqs
@@ -480,43 +512,65 @@ end
     # choice of std for objectives is very important
     # pass in Dict_differentials, phystdnew arguments when using the new model
 
-    sol_new = ahmc_bayesian_pinn_pde(pde_system,
+    sol_new = ahmc_bayesian_pinn_pde(
+        pde_system,
         discretization;
         draw_samples = 150,
         bcstd = [0.1, 0.1, 0.1, 0.1, 0.1], phynewstd = [0.4],
         phystd = [0.2], l2std = [0.8], param = [Distributions.Normal(2.0, 2)],
         priorsNNw = (0.0, 1.0),
         saveats = [1 / 100.0, 1 / 100.0],
-        Dict_differentials = Dict_differentials)
+        Dict_differentials = Dict_differentials
+    )
 
-    sol_old = ahmc_bayesian_pinn_pde(pde_system,
+    sol_old = ahmc_bayesian_pinn_pde(
+        pde_system,
         discretization;
         draw_samples = 150,
         bcstd = [0.1, 0.1, 0.1, 0.1, 0.1],
         phystd = [0.2], l2std = [0.8], param = [Distributions.Normal(2.0, 2)],
         priorsNNw = (0.0, 1.0),
-        saveats = [1 / 100.0, 1 / 100.0])
+        saveats = [1 / 100.0, 1 / 100.0]
+    )
 
     phi = discretization.phi[1]
     xs,
-    ts = [infimum(d.domain):dx:supremum(d.domain)
-          for (d, dx) in zip(domains, [dx / 10, dt])]
+        ts = [
+        infimum(d.domain):dx:supremum(d.domain)
+            for (d, dx) in zip(domains, [dx / 10, dt])
+    ]
     u_real = [[u_analytic(x, t) for x in xs] for t in ts]
 
-    u_predict_new = [[first(pmean(phi([x, t], sol_new.estimated_nn_params[1]))) for x in xs]
-                     for t in ts]
+    u_predict_new = [
+        [first(pmean(phi([x, t], sol_new.estimated_nn_params[1]))) for x in xs]
+            for t in ts
+    ]
 
-    diff_u_new = [[abs(u_analytic(x, t) -
-                       first(pmean(phi([x, t], sol_new.estimated_nn_params[1]))))
-                   for x in xs]
-                  for t in ts]
+    diff_u_new = [
+        [
+                abs(
+                    u_analytic(x, t) -
+                    first(pmean(phi([x, t], sol_new.estimated_nn_params[1])))
+                )
+                for x in xs
+            ]
+            for t in ts
+    ]
 
-    u_predict_old = [[first(pmean(phi([x, t], sol_old.estimated_nn_params[1]))) for x in xs]
-                     for t in ts]
-    diff_u_old = [[abs(u_analytic(x, t) -
-                       first(pmean(phi([x, t], sol_old.estimated_nn_params[1]))))
-                   for x in xs]
-                  for t in ts]
+    u_predict_old = [
+        [first(pmean(phi([x, t], sol_old.estimated_nn_params[1]))) for x in xs]
+            for t in ts
+    ]
+    diff_u_old = [
+        [
+                abs(
+                    u_analytic(x, t) -
+                    first(pmean(phi([x, t], sol_old.estimated_nn_params[1])))
+                )
+                for x in xs
+            ]
+            for t in ts
+    ]
 
     unsafe_comparisons(true)
     @test all(all, [((diff_u_new[i]) .^ 2 .< 0.8) for i in 1:6]) == true

--- a/test/BPINN_tests.jl
+++ b/test/BPINN_tests.jl
@@ -1,6 +1,6 @@
-@testitem "BPINN ODE I: Without Param Estimation" tags=[:odebpinn] begin
+@testitem "BPINN ODE I: Without Param Estimation" tags = [:odebpinn] begin
     using MCMCChains, Distributions, OrdinaryDiffEq, OptimizationOptimisers, Lux,
-          AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
+        AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
 
     Random.seed!(100)
 
@@ -29,8 +29,9 @@
     θinit, st = Lux.setup(Random.default_rng(), chainlux)
 
     fh_mcmc_chain, fhsamples,
-    fhstats = ahmc_bayesian_pinn_ode(
-        prob, chainlux, draw_samples = 2500)
+        fhstats = ahmc_bayesian_pinn_ode(
+        prob, chainlux, draw_samples = 2500
+    )
 
     alg = BNNODE(chainlux, draw_samples = 2500)
     sol1lux = solve(prob, alg)
@@ -52,9 +53,9 @@
     @test mean(abs.(physsol0_1 .- pmean(sol1lux.ensemblesol[1]))) < 0.04
 end
 
-@testitem "BPINN ODE II: With Parameter Estimation" tags=[:odebpinn] begin
+@testitem "BPINN ODE II: With Parameter Estimation" tags = [:odebpinn] begin
     using MCMCChains, Distributions, OrdinaryDiffEq, OptimizationOptimisers, Lux,
-          AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
+        AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
 
     Random.seed!(100)
 
@@ -89,20 +90,25 @@ end
     θinit, st = Lux.setup(Random.default_rng(), chainlux1)
 
     fh_mcmc_chain, fhsamples,
-    fhstats = ahmc_bayesian_pinn_ode(
+        fhstats = ahmc_bayesian_pinn_ode(
         prob, chainlux1, dataset = dataset, draw_samples = 2500,
-        physdt = 1 / 50.0, priorsNNw = (0.0, 3.0), param = [LogNormal(9, 0.5)])
+        physdt = 1 / 50.0, priorsNNw = (0.0, 3.0), param = [LogNormal(9, 0.5)]
+    )
 
-    alg = BNNODE(chainlux1, dataset = dataset, draw_samples = 2500, physdt = 1 / 50.0,
-        priorsNNw = (0.0, 3.0), param = [LogNormal(9, 0.5)])
+    alg = BNNODE(
+        chainlux1, dataset = dataset, draw_samples = 2500, physdt = 1 / 50.0,
+        priorsNNw = (0.0, 3.0), param = [LogNormal(9, 0.5)]
+    )
 
     sol2lux = solve(prob, alg)
 
     # testing points
     t = time
     # Mean of last 500 sampled parameter's curves(flux and lux chains)[Ensemble predictions]
-    θ = [vector_to_parameters(fhsamples[i][1:(end - 1)], θinit)
-         for i in 2000:length(fhsamples)]
+    θ = [
+        vector_to_parameters(fhsamples[i][1:(end - 1)], θinit)
+            for i in 2000:length(fhsamples)
+    ]
     luxar = [chainlux1(t', θ[i], st)[1] for i in eachindex(θ)]
     luxmean = [mean(vcat(luxar...)[:, i]) for i in eachindex(t)]
     meanscurve = prob.u0 .+ (t .- prob.tspan[1]) .* luxmean
@@ -114,15 +120,15 @@ end
     @test abs(p - mean([fhsamples[i][23] for i in 2000:length(fhsamples)])) < abs(0.35 * p)
 
     #-------------------------- solve() call
-    @test mean(abs.(physsol1_1 .- pmean(sol2lux.ensemblesol[1]))) < 8e-2
+    @test mean(abs.(physsol1_1 .- pmean(sol2lux.ensemblesol[1]))) < 8.0e-2
 
     # ESTIMATED ODE PARAMETERS (NN1 AND NN2)
     @test abs(p - sol2lux.estimated_de_params[1]) < abs(0.15 * p)
 end
 
-@testitem "BPINN ODE III" tags=[:odebpinn] begin
+@testitem "BPINN ODE III" tags = [:odebpinn] begin
     using MCMCChains, Distributions, OrdinaryDiffEq, OptimizationOptimisers, Lux,
-          AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
+        AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
 
     Random.seed!(100)
 
@@ -151,16 +157,20 @@ end
 
     # this a forward solve
     fh_mcmc_chainlux12, fhsampleslux12,
-    fhstatslux12 = ahmc_bayesian_pinn_ode(
-        prob, chainlux12, draw_samples = 500, phystd = [0.01], priorsNNw = (0.0, 10.0))
+        fhstatslux12 = ahmc_bayesian_pinn_ode(
+        prob, chainlux12, draw_samples = 500, phystd = [0.01], priorsNNw = (0.0, 10.0)
+    )
 
     fh_mcmc_chainlux22, fhsampleslux22,
-    fhstatslux22 = ahmc_bayesian_pinn_ode(
+        fhstatslux22 = ahmc_bayesian_pinn_ode(
         prob, chainlux12, dataset = dataset, draw_samples = 500, l2std = [0.02],
-        phystd = [0.05], priorsNNw = (0.0, 10.0), param = [Normal(-7, 4)])
+        phystd = [0.05], priorsNNw = (0.0, 10.0), param = [Normal(-7, 4)]
+    )
 
-    alg = BNNODE(chainlux12, dataset = dataset, draw_samples = 500, l2std = [0.02],
-        phystd = [0.05], priorsNNw = (0.0, 10.0), param = [Normal(-7, 4)])
+    alg = BNNODE(
+        chainlux12, dataset = dataset, draw_samples = 500, l2std = [0.02],
+        phystd = [0.05], priorsNNw = (0.0, 10.0), param = [Normal(-7, 4)]
+    )
 
     sol3lux_pestim = solve(prob, alg)
 
@@ -168,20 +178,24 @@ end
     t = sol.t
     #------------------------------ ahmc_bayesian_pinn_ode() call
     # Mean of last 500 sampled parameter's curves(lux chains)[Ensemble predictions]
-    θ = [vector_to_parameters(fhsampleslux12[i], θinit)
-         for i in 400:length(fhsampleslux12)]
+    θ = [
+        vector_to_parameters(fhsampleslux12[i], θinit)
+            for i in 400:length(fhsampleslux12)
+    ]
     luxar = [chainlux12(t', θ[i], st)[1] for i in eachindex(θ)]
     luxmean = [mean(vcat(luxar...)[:, i]) for i in eachindex(t)]
     meanscurve2_1 = prob.u0 .+ (t .- prob.tspan[1]) .* luxmean
 
-    θ = [vector_to_parameters(fhsampleslux22[i][1:(end - 1)], θinit)
-         for i in 400:length(fhsampleslux22)]
+    θ = [
+        vector_to_parameters(fhsampleslux22[i][1:(end - 1)], θinit)
+            for i in 400:length(fhsampleslux22)
+    ]
     luxar = [chainlux12(t', θ[i], st)[1] for i in eachindex(θ)]
     luxmean = [mean(vcat(luxar...)[:, i]) for i in eachindex(t)]
     meanscurve2_2 = prob.u0 .+ (t .- prob.tspan[1]) .* luxmean
 
-    @test mean(abs, sol.u .- meanscurve2_1) < 1e-2
-    @test mean(abs, physsol1 .- meanscurve2_1) < 1e-2
+    @test mean(abs, sol.u .- meanscurve2_1) < 1.0e-2
+    @test mean(abs, physsol1 .- meanscurve2_1) < 1.0e-2
     @test mean(abs, sol.u .- meanscurve2_2) < 1.5
     @test mean(abs, physsol1 .- meanscurve2_2) < 1.5
 
@@ -190,9 +204,9 @@ end
     @test abs(param1 - p) < abs(0.5 * p)
 end
 
-@testitem "BPINN ODE: Translating from Flux" tags=[:odebpinn] begin
+@testitem "BPINN ODE: Translating from Flux" tags = [:odebpinn] begin
     using MCMCChains, Distributions, OrdinaryDiffEq, OptimizationOptimisers, Lux,
-          AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
+        AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
     import Flux
 
     Random.seed!(100)
@@ -219,16 +233,17 @@ end
     physsol0_1 = [linear_analytic(prob.u0, p, time1[i]) for i in eachindex(time1)]
     chainflux = Flux.Chain(Flux.Dense(1, 7, tanh), Flux.Dense(7, 1)) |> Flux.f64
     fh_mcmc_chain, fhsamples,
-    fhstats = ahmc_bayesian_pinn_ode(
-        prob, chainflux, draw_samples = 2500)
+        fhstats = ahmc_bayesian_pinn_ode(
+        prob, chainflux, draw_samples = 2500
+    )
     alg = BNNODE(chainflux, draw_samples = 2500)
     @test alg.chain isa AbstractLuxLayer
 end
 
-@testitem "BPINN ODE III: Inverse solve Improvement" tags=[:odebpinn] begin
+@testitem "BPINN ODE III: Inverse solve Improvement" tags = [:odebpinn] begin
     using MCMCChains, Distributions, OrdinaryDiffEq, OptimizationOptimisers, Lux,
-          AdvancedHMC, Statistics, Random, Functors, ComponentArrays,
-          MonteCarloMeasurements, FastGaussQuadrature
+        AdvancedHMC, Statistics, Random, Functors, ComponentArrays,
+        MonteCarloMeasurements, FastGaussQuadrature
     Random.seed!(100)
 
     # (original Improvement tests can be run with 100 training points, check solve call tests.)
@@ -269,50 +284,60 @@ end
 
     # you could always directly fit model to all data, but it ignores equation, overfits data.
     fh_mcmc_chainlux22, fhsampleslux22,
-    fhstatslux22 = ahmc_bayesian_pinn_ode(
+        fhstatslux22 = ahmc_bayesian_pinn_ode(
         prob, chainlux12,
         dataset = dataset,
         draw_samples = 2500,
         l2std = [0.1],
         phystd = [0.1],
         phynewstd = (p) -> [0.1 / p],
-        priorsNNw = (0.0,
-            1.0),
+        priorsNNw = (
+            0.0,
+            1.0,
+        ),
         param = [
-            Normal(-7, 3)
-        ], estim_collocate = true)
+            Normal(-7, 3),
+        ], estim_collocate = true
+    )
 
     fh_mcmc_chainlux12, fhsampleslux12,
-    fhstatslux12 = ahmc_bayesian_pinn_ode(
+        fhstatslux12 = ahmc_bayesian_pinn_ode(
         prob, chainlux12,
         dataset = dataset,
         draw_samples = 2500,
         l2std = [0.1],
         phystd = [0.1],
-        priorsNNw = (0.0,
-            1.0),
+        priorsNNw = (
+            0.0,
+            1.0,
+        ),
         param = [
-            Normal(-7, 3)
-        ])
+            Normal(-7, 3),
+        ]
+    )
 
     # testing timepoints
     t = sol.t
     #------------------------------ ahmc_bayesian_pinn_ode() call
     # Mean of last 100 sampled parameter's curves(lux chains)[Ensemble predictions]
-    θ = [vector_to_parameters(fhsampleslux12[i][1:(end - 1)], θinit)
-         for i in 2400:length(fhsampleslux12)]
+    θ = [
+        vector_to_parameters(fhsampleslux12[i][1:(end - 1)], θinit)
+            for i in 2400:length(fhsampleslux12)
+    ]
     luxar = [chainlux12(t', θ[i], st)[1] for i in eachindex(θ)]
     luxmean = [mean(vcat(luxar...)[:, i]) for i in eachindex(t)]
     meanscurve2_1 = prob.u0 .+ (t .- prob.tspan[1]) .* luxmean
 
-    θ = [vector_to_parameters(fhsampleslux22[i][1:(end - 1)], θinit)
-         for i in 2400:length(fhsampleslux22)]
+    θ = [
+        vector_to_parameters(fhsampleslux22[i][1:(end - 1)], θinit)
+            for i in 2400:length(fhsampleslux22)
+    ]
     luxar = [chainlux12(t', θ[i], st)[1] for i in eachindex(θ)]
     luxmean = [mean(vcat(luxar...)[:, i]) for i in eachindex(t)]
     meanscurve2_2 = prob.u0 .+ (t .- prob.tspan[1]) .* luxmean
 
-    @test mean(abs.(sol.u .- meanscurve2_2)) < 5e-2
-    @test mean(abs.(physsol1 .- meanscurve2_2)) < 5e-2
+    @test mean(abs.(sol.u .- meanscurve2_2)) < 5.0e-2
+    @test mean(abs.(physsol1 .- meanscurve2_2)) < 5.0e-2
     @test mean(abs.(sol.u .- meanscurve2_1)) > mean(abs.(sol.u .- meanscurve2_2))
     @test mean(abs.(physsol1 .- meanscurve2_1)) > mean(abs.(physsol1 .- meanscurve2_2))
 
@@ -324,9 +349,9 @@ end
     @test abs(param2 - p) < abs(param1 - p)
 end
 
-@testitem "BPINN ODE III: Inverse solve Improvement solve call" tags=[:odebpinn] begin
+@testitem "BPINN ODE III: Inverse solve Improvement solve call" tags = [:odebpinn] begin
     using MCMCChains, Distributions, OrdinaryDiffEq, OptimizationOptimisers, Lux,
-          AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
+        AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
 
     Random.seed!(100)
 
@@ -353,32 +378,36 @@ end
     chainlux12 = Lux.Chain(Lux.Dense(1, 6, tanh), Lux.Dense(6, 6, tanh), Lux.Dense(6, 1))
     θinit, st = Lux.setup(Random.default_rng(), chainlux12)
 
-    alg = BNNODE(chainlux12,
+    alg = BNNODE(
+        chainlux12,
         dataset = dataset,
         draw_samples = 1000,
         l2std = [0.1],
         phystd = [0.01],
         phynewstd = (p) -> [0.01],
-        priorsNNw = (0.0,
-            1.0),
+        priorsNNw = (
+            0.0,
+            1.0,
+        ),
         param = [
-            Normal(-7, 3)
+            Normal(-7, 3),
         ], numensemble = 200,
-        estim_collocate = true)
+        estim_collocate = true
+    )
 
     sol3lux_pestim = solve(prob, alg)
 
     #-------------------------- solve() call
-    @test mean(abs.(physsol2 .- pmean(sol3lux_pestim.ensemblesol[1]))) < 1e-2
+    @test mean(abs.(physsol2 .- pmean(sol3lux_pestim.ensemblesol[1]))) < 1.0e-2
 
     # estimated parameters
     param3 = sol3lux_pestim.estimated_de_params[1]
     @test abs(param3 - p) < abs(0.05 * p)
 end
 
-@testitem "BPINN ODE IV: Inverse solve Improvement" tags=[:odebpinn] begin
+@testitem "BPINN ODE IV: Inverse solve Improvement" tags = [:odebpinn] begin
     using MCMCChains, Distributions, OrdinaryDiffEq, OptimizationOptimisers, Lux,
-          AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
+        AdvancedHMC, Statistics, Random, Functors, ComponentArrays, MonteCarloMeasurements
     using FastGaussQuadrature
     Random.seed!(100)
 
@@ -418,10 +447,13 @@ end
     y = u[2, :] + (0.5 .* randn(length(u[2, :])))
     dataset = [x, y, times, W]
 
-    chain = Lux.Chain(Lux.Dense(1, 7, tanh), Lux.Dense(7, 7, tanh),
-        Lux.Dense(7, 2))
+    chain = Lux.Chain(
+        Lux.Dense(1, 7, tanh), Lux.Dense(7, 7, tanh),
+        Lux.Dense(7, 2)
+    )
 
-    alg1 = BNNODE(chain;
+    alg1 = BNNODE(
+        chain;
         dataset = dataset,
         draw_samples = 1000,
         l2std = [0.5, 0.5],
@@ -429,9 +461,12 @@ end
         priorsNNw = (0.0, 1.0),
         param = [
             Normal(-7, 2),
-            Normal(-7, 2)])
+            Normal(-7, 2),
+        ]
+    )
 
-    alg2 = BNNODE(chain;
+    alg2 = BNNODE(
+        chain;
         dataset = dataset,
         draw_samples = 1000,
         l2std = [0.5, 0.5],
@@ -440,7 +475,9 @@ end
         priorsNNw = (0.0, 1.0),
         param = [
             Normal(-7, 2),
-            Normal(-7, 2)], estim_collocate = true)
+            Normal(-7, 2),
+        ], estim_collocate = true
+    )
 
     dt = 0.05
     @time sol_pestim1 = solve(prob, alg1; saveat = dt)
@@ -451,16 +488,16 @@ end
 
     unsafe_comparisons(true)
     bitvec = abs.(p .- sol_pestim1.estimated_de_params) .>
-             abs.(p .- sol_pestim2.estimated_de_params)
+        abs.(p .- sol_pestim2.estimated_de_params)
     @test bitvec == ones(size(bitvec))
 
     @test mean(abs, u[1, :] .- pmean(sol_pestim1.ensemblesol[1])) >
-          mean(abs, u[1, :] .- pmean(sol_pestim2.ensemblesol[1]))
+        mean(abs, u[1, :] .- pmean(sol_pestim2.ensemblesol[1]))
     @test mean(abs, u[2, :] .- pmean(sol_pestim1.ensemblesol[2])) >
-          mean(abs, u[2, :] .- pmean(sol_pestim2.ensemblesol[2]))
+        mean(abs, u[2, :] .- pmean(sol_pestim2.ensemblesol[2]))
 
-    @test mean(abs2, u[1, :] .- pmean(sol_pestim2.ensemblesol[1])) < 5e-2
-    @test mean(abs2, u[2, :] .- pmean(sol_pestim2.ensemblesol[2])) < 2e-2
+    @test mean(abs2, u[1, :] .- pmean(sol_pestim2.ensemblesol[1])) < 5.0e-2
+    @test mean(abs2, u[2, :] .- pmean(sol_pestim2.ensemblesol[2])) < 2.0e-2
 
     @test abs(sol_pestim2.estimated_de_params[1] - p[1]) < 0.05p[1]
     @test abs(sol_pestim2.estimated_de_params[2] - p[2]) < 0.1p[2]

--- a/test/IDE_tests.jl
+++ b/test/IDE_tests.jl
@@ -11,7 +11,7 @@ export callback
 
 end
 
-@testitem "IntegroDiff Example 1 -- 1D" tags=[:integrodiff] setup=[IntegroDiffTestSetup] begin
+@testitem "IntegroDiff Example 1 -- 1D" tags = [:integrodiff] setup = [IntegroDiffTestSetup] begin
     using Optimization, Optimisers, DomainSets, Lux, Random, Statistics
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -20,28 +20,28 @@ end
 
     @parameters t
     @variables i(..)
-    Di=Differential(t)
-    Ii=Integral(t in DomainSets.ClosedInterval(0, t))
-    eq=Di(i(t))+2*i(t)+5*Ii(i(t))~1
-    bcs=[i(0.0)~0.0]
-    domains=[t ∈ Interval(0.0, 2.0)]
+    Di = Differential(t)
+    Ii = Integral(t in DomainSets.ClosedInterval(0, t))
+    eq = Di(i(t)) + 2 * i(t) + 5 * Ii(i(t)) ~ 1
+    bcs = [i(0.0) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 2.0)]
 
-    chain=Chain(Dense(1, 15, σ), Dense(15, 1))
-    strategy=GridTraining(0.1)
-    discretization=PhysicsInformedNN(chain, strategy)
+    chain = Chain(Dense(1, 15, σ), Dense(15, 1))
+    strategy = GridTraining(0.1)
+    discretization = PhysicsInformedNN(chain, strategy)
     @named pde_system = PDESystem(eq, bcs, domains, [t], [i(t)])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, BFGS(); callback, maxiters = 100)
-    ts=[infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
-    phi=discretization.phi
-    analytic_sol_func(t)=1/2*(exp(-t))*(sin(2*t))
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, BFGS(); callback, maxiters = 100)
+    ts = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
+    phi = discretization.phi
+    analytic_sol_func(t) = 1 / 2 * (exp(-t)) * (sin(2 * t))
 
-    u_real=[analytic_sol_func(t) for t in ts]
-    u_predict=[first(phi([t], res.u)) for t in ts]
+    u_real = [analytic_sol_func(t) for t in ts]
+    u_predict = [first(phi([t], res.u)) for t in ts]
     @test mean(abs2, u_real .- u_predict) < 0.02
 end
 
-@testitem "IntegroDiff Example 2 -- 1D" tags=[:integrodiff] setup=[IntegroDiffTestSetup] begin
+@testitem "IntegroDiff Example 2 -- 1D" tags = [:integrodiff] setup = [IntegroDiffTestSetup] begin
     using Optimization, Optimisers, DomainSets, Lux, Random, Statistics
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -50,27 +50,27 @@ end
 
     @parameters x
     @variables u(..)
-    Ix=Integral(x in DomainSets.ClosedInterval(0, x))
+    Ix = Integral(x in DomainSets.ClosedInterval(0, x))
 
-    eq=Ix(u(x)*cos(x))~(x^3)/3
-    bcs=[u(0.0)~0.0]
-    domains=[x ∈ Interval(0.0, 1.00)]
+    eq = Ix(u(x) * cos(x)) ~ (x^3) / 3
+    bcs = [u(0.0) ~ 0.0]
+    domains = [x ∈ Interval(0.0, 1.0)]
 
-    chain=Chain(Dense(1, 15, σ), Dense(15, 1))
-    strategy=GridTraining(0.1)
-    discretization=PhysicsInformedNN(chain, strategy)
+    chain = Chain(Dense(1, 15, σ), Dense(15, 1))
+    strategy = GridTraining(0.1)
+    discretization = PhysicsInformedNN(chain, strategy)
     @named pde_system = PDESystem(eq, bcs, domains, [x], [u(x)])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, BFGS(); callback, maxiters = 100)
-    xs=[infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
-    phi=discretization.phi
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, BFGS(); callback, maxiters = 100)
+    xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
+    phi = discretization.phi
 
-    u_real=[x^2/cos(x) for x in xs]
-    u_predict=[first(phi([x], res.u)) for x in xs]
+    u_real = [x^2 / cos(x) for x in xs]
+    u_predict = [first(phi([x], res.u)) for x in xs]
     @test mean(abs2, u_real .- u_predict) < 0.02
 end
 
-@testitem "IntegroDiff Example 3 -- 2 Inputs, 1 Output" tags=[:integrodiff] setup=[IntegroDiffTestSetup] begin
+@testitem "IntegroDiff Example 3 -- 2 Inputs, 1 Output" tags = [:integrodiff] setup = [IntegroDiffTestSetup] begin
     using Optimization, Optimisers, DomainSets, Lux, Random, Statistics
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -79,31 +79,31 @@ end
 
     @parameters x, y
     @variables u(..)
-    Dx=Differential(x)
-    Dy=Differential(y)
-    Ix=Integral((x, y) in DomainSets.UnitSquare())
+    Dx = Differential(x)
+    Dy = Differential(y)
+    Ix = Integral((x, y) in DomainSets.UnitSquare())
 
-    eq=Ix(u(x, y))~1/3
-    bcs=[u(0.0, 0.0)~1, Dx(u(x, y))~-2*x, Dy(u(x, y))~-2*y]
-    domains=[x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
+    eq = Ix(u(x, y)) ~ 1 / 3
+    bcs = [u(0.0, 0.0) ~ 1, Dx(u(x, y)) ~ -2 * x, Dy(u(x, y)) ~ -2 * y]
+    domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
 
-    chain=Chain(Dense(2, 15, σ), Dense(15, 1))
-    strategy=GridTraining(0.1)
-    discretization=PhysicsInformedNN(chain, strategy)
+    chain = Chain(Dense(2, 15, σ), Dense(15, 1))
+    strategy = GridTraining(0.1)
+    discretization = PhysicsInformedNN(chain, strategy)
     @named pde_system = PDESystem(eq, bcs, domains, [x, y], [u(x, y)])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, BFGS(); callback, maxiters = 100)
-    phi=discretization.phi
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, BFGS(); callback, maxiters = 100)
+    phi = discretization.phi
 
-    xs=0.0:0.01:1.0
-    ys=0.0:0.01:1.0
+    xs = 0.0:0.01:1.0
+    ys = 0.0:0.01:1.0
 
-    u_real=collect(1-x^2-y^2 for y in ys, x in xs)
-    u_predict=collect(Array(phi([x, y], res.u))[1] for y in ys, x in xs)
+    u_real = collect(1 - x^2 - y^2 for y in ys, x in xs)
+    u_predict = collect(Array(phi([x, y], res.u))[1] for y in ys, x in xs)
     @test mean(abs2, u_real .- u_predict) < 0.001
 end
 
-@testitem "IntegroDiff Example 4 -- 2 Inputs, 1 Output" tags=[:integrodiff] setup=[IntegroDiffTestSetup] begin
+@testitem "IntegroDiff Example 4 -- 2 Inputs, 1 Output" tags = [:integrodiff] setup = [IntegroDiffTestSetup] begin
     using Optimization, Optimisers, DomainSets, Lux, Random, Statistics
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -112,31 +112,31 @@ end
 
     @parameters x, y
     @variables u(..)
-    Dx=Differential(x)
-    Dy=Differential(y)
-    Ix=Integral((x, y) in DomainSets.ProductDomain(UnitInterval(), ClosedInterval(0, x)))
+    Dx = Differential(x)
+    Dy = Differential(y)
+    Ix = Integral((x, y) in DomainSets.ProductDomain(UnitInterval(), ClosedInterval(0, x)))
 
-    eq=Ix(u(x, y))~5/12
-    bcs=[u(0.0, 0.0)~0, Dy(u(x, y))~2*y, u(x, 0)~x]
-    domains=[x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
+    eq = Ix(u(x, y)) ~ 5 / 12
+    bcs = [u(0.0, 0.0) ~ 0, Dy(u(x, y)) ~ 2 * y, u(x, 0) ~ x]
+    domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
 
-    chain=Chain(Dense(2, 15, σ), Dense(15, 1))
-    strategy=GridTraining(0.1)
-    discretization=PhysicsInformedNN(chain, strategy)
+    chain = Chain(Dense(2, 15, σ), Dense(15, 1))
+    strategy = GridTraining(0.1)
+    discretization = PhysicsInformedNN(chain, strategy)
     @named pde_system = PDESystem(eq, bcs, domains, [x, y], [u(x, y)])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, BFGS(); callback, maxiters = 100)
-    phi=discretization.phi
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, BFGS(); callback, maxiters = 100)
+    phi = discretization.phi
 
-    xs=0.0:0.01:1.0
-    ys=0.0:0.01:1.0
+    xs = 0.0:0.01:1.0
+    ys = 0.0:0.01:1.0
 
-    u_real=collect(x+y^2 for y in ys, x in xs)
-    u_predict=collect(Array(phi([x, y], res.u))[1] for y in ys, x in xs)
+    u_real = collect(x + y^2 for y in ys, x in xs)
+    u_predict = collect(Array(phi([x, y], res.u))[1] for y in ys, x in xs)
     @test mean(abs2, u_real .- u_predict) < 0.02
 end
 
-@testitem "IntegroDiff Example 5 -- 1 Input, 2 Outputs" tags=[:integrodiff] setup=[IntegroDiffTestSetup] begin
+@testitem "IntegroDiff Example 5 -- 1 Input, 2 Outputs" tags = [:integrodiff] setup = [IntegroDiffTestSetup] begin
     using Optimization, Optimisers, DomainSets, Lux, Random, Statistics
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -145,32 +145,32 @@ end
 
     @parameters x
     @variables u(..) w(..)
-    Dx=Differential(x)
-    Ix=Integral(x in DomainSets.ClosedInterval(1, x))
+    Dx = Differential(x)
+    Ix = Integral(x in DomainSets.ClosedInterval(1, x))
 
-    eqs=[Ix(u(x)*w(x))~log(abs(x)), Dx(w(x))~-2/(x^3), u(x)~x]
-    bcs=[u(1.0)~1.0, w(1.0)~1.0]
-    domains=[x ∈ Interval(1.0, 2.0)]
+    eqs = [Ix(u(x) * w(x)) ~ log(abs(x)), Dx(w(x)) ~ -2 / (x^3), u(x) ~ x]
+    bcs = [u(1.0) ~ 1.0, w(1.0) ~ 1.0]
+    domains = [x ∈ Interval(1.0, 2.0)]
 
-    chains=[Chain(Dense(1, 15, σ), Dense(15, 1)) for _ in 1:2]
-    strategy=GridTraining(0.1)
-    discretization=PhysicsInformedNN(chains, strategy)
+    chains = [Chain(Dense(1, 15, σ), Dense(15, 1)) for _ in 1:2]
+    strategy = GridTraining(0.1)
+    discretization = PhysicsInformedNN(chains, strategy)
     @named pde_system = PDESystem(eqs, bcs, domains, [x], [u(x), w(x)])
-    prob=discretize(pde_system, discretization)
+    prob = discretize(pde_system, discretization)
 
-    res=solve(prob, BFGS(); callback, maxiters = 200)
-    xs=[infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
-    phi=discretization.phi
-    u_predict=[(phi[1]([x], res.u.depvar.u))[1] for x in xs]
-    w_predict=[(phi[2]([x], res.u.depvar.w))[1] for x in xs]
-    u_real=[x for x in xs]
-    w_real=[1/x^2 for x in xs]
+    res = solve(prob, BFGS(); callback, maxiters = 200)
+    xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
+    phi = discretization.phi
+    u_predict = [(phi[1]([x], res.u.depvar.u))[1] for x in xs]
+    w_predict = [(phi[2]([x], res.u.depvar.w))[1] for x in xs]
+    u_real = [x for x in xs]
+    w_real = [1 / x^2 for x in xs]
 
     @test mean(abs2, u_real .- u_predict) < 0.001
     @test mean(abs2, w_real .- w_predict) < 0.001
 end
 
-@testitem "IntegroDiff Example 6: Infinity" tags=[:integrodiff] setup=[IntegroDiffTestSetup] begin
+@testitem "IntegroDiff Example 6: Infinity" tags = [:integrodiff] setup = [IntegroDiffTestSetup] begin
     using Optimization, Optimisers, DomainSets, Lux, Random, Statistics
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -179,26 +179,26 @@ end
 
     @parameters x
     @variables u(..)
-    I=Integral(x in ClosedInterval(1, x))
-    Iinf=Integral(x in ClosedInterval(1, Inf))
+    I = Integral(x in ClosedInterval(1, x))
+    Iinf = Integral(x in ClosedInterval(1, Inf))
 
-    eqs=[I(u(x))~Iinf(u(x))-1/x]
-    bcs=[u(1)~1]
-    domains=[x ∈ Interval(1.0, 2.0)]
+    eqs = [I(u(x)) ~ Iinf(u(x)) - 1 / x]
+    bcs = [u(1) ~ 1]
+    domains = [x ∈ Interval(1.0, 2.0)]
 
-    chain=Chain(Dense(1, 10, σ), Dense(10, 1))
-    discretization=PhysicsInformedNN(chain, NeuralPDE.GridTraining(0.1))
+    chain = Chain(Dense(1, 10, σ), Dense(10, 1))
+    discretization = PhysicsInformedNN(chain, NeuralPDE.GridTraining(0.1))
     @named pde_system = PDESystem(eqs, bcs, domains, [x], [u(x)])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, BFGS(); callback, maxiters = 200)
-    xs=[infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
-    phi=discretization.phi
-    u_predict=[first(phi([x], res.u)) for x in xs]
-    u_real=[1/x^2 for x in xs]
-    @test u_real≈u_predict rtol=0.1
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, BFGS(); callback, maxiters = 200)
+    xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
+    phi = discretization.phi
+    u_predict = [first(phi([x], res.u)) for x in xs]
+    u_real = [1 / x^2 for x in xs]
+    @test u_real ≈ u_predict rtol = 0.1
 end
 
-@testitem "IntegroDiff Example 7: Infinity" tags=[:integrodiff] setup=[IntegroDiffTestSetup] begin
+@testitem "IntegroDiff Example 7: Infinity" tags = [:integrodiff] setup = [IntegroDiffTestSetup] begin
     using Optimization, Optimisers, DomainSets, Lux, Random, Statistics
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -207,19 +207,19 @@ end
 
     @parameters x
     @variables u(..)
-    I=Integral(x in ClosedInterval(x, Inf))
+    I = Integral(x in ClosedInterval(x, Inf))
 
-    eq=I(u(x))~1/x
-    domains=[x ∈ Interval(1.0, 2.0)]
-    bcs=[u(1)~1]
-    chain=Chain(Dense(1, 12, tanh), Dense(12, 1))
-    discretization=PhysicsInformedNN(chain, GridTraining(0.1))
+    eq = I(u(x)) ~ 1 / x
+    domains = [x ∈ Interval(1.0, 2.0)]
+    bcs = [u(1) ~ 1]
+    chain = Chain(Dense(1, 12, tanh), Dense(12, 1))
+    discretization = PhysicsInformedNN(chain, GridTraining(0.1))
     @named pde_system = PDESystem(eq, bcs, domains, [x], [u(x)])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, BFGS(); callback, maxiters = 300)
-    xs=[infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
-    phi=discretization.phi
-    u_predict=[first(phi([x], res.u)) for x in xs]
-    u_real=[1/x^2 for x in xs]
-    @test u_real≈u_predict rtol=0.02
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, BFGS(); callback, maxiters = 300)
+    xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
+    phi = discretization.phi
+    u_predict = [first(phi([x], res.u)) for x in xs]
+    u_real = [1 / x^2 for x in xs]
+    @test u_real ≈ u_predict rtol = 0.02
 end

--- a/test/NNDAE_tests.jl
+++ b/test/NNDAE_tests.jl
@@ -1,4 +1,4 @@
-@testitem "DAE Case I" tags=[:nnode] begin
+@testitem "DAE Case I" tags = [:nnode] begin
     using Random, OrdinaryDiffEq, Statistics, Lux, Optimisers
 
     Random.seed!(100)
@@ -11,13 +11,15 @@
 
     u₀ = [1.0, -1.0]
     du₀ = [0.0, 0.0]
-    M = [1.0 0.0
-         0.0 0.0]
+    M = [
+        1.0 0.0
+        0.0 0.0
+    ]
     f = ODEFunction(example1, mass_matrix = M)
     tspan = (0.0f0, 1.0f0)
 
     prob_mm = ODEProblem(f, u₀, tspan)
-    ground_sol = solve(prob_mm, Rodas5(), reltol = 1e-8, abstol = 1e-8)
+    ground_sol = solve(prob_mm, Rodas5(), reltol = 1.0e-8, abstol = 1.0e-8)
 
     example = (du, u, p, t) -> [cos(2pi * t) - du[1], u[2] + cos(2pi * t) - du[2]]
     prob = DAEProblem(example, du₀, u₀, tspan; differential_vars = [true, false])
@@ -25,12 +27,13 @@
     alg = NNDAE(chain, Adam(0.01); autodiff = false)
 
     sol = solve(
-        prob, alg; verbose = false, dt = 1 / 100.0f0, maxiters = 3000, abstol = 1.0f-10)
+        prob, alg; verbose = false, dt = 1 / 100.0f0, maxiters = 3000, abstol = 1.0f-10
+    )
 
-    @test ground_sol(0:(1 / 100):1)≈sol atol=0.4
+    @test ground_sol(0:(1 / 100):1) ≈ sol atol = 0.4
 end
 
-@testitem "DAE Case II" tags=[:nnode] begin
+@testitem "DAE Case II" tags = [:nnode] begin
     using Random, OrdinaryDiffEq, Statistics, Lux, Optimisers
 
     Random.seed!(100)
@@ -41,14 +44,16 @@ end
         nothing
     end
 
-    M = [0.0 0.0
-         0.0 1.0]
+    M = [
+        0.0 0.0
+        0.0 1.0
+    ]
     u₀ = [0.0, 0.0]
     du₀ = [0.0, 0.0]
     tspan = (0.0f0, pi / 2.0f0)
     f = ODEFunction(example2, mass_matrix = M)
     prob_mm = ODEProblem(f, u₀, tspan)
-    ground_sol = solve(prob_mm, Rodas5(), reltol = 1e-8, abstol = 1e-8)
+    ground_sol = solve(prob_mm, Rodas5(), reltol = 1.0e-8, abstol = 1.0e-8)
 
     example = (du, u, p, t) -> [u[1] - t - du[1], u[2] - t - du[2]]
     differential_vars = [false, true]
@@ -56,8 +61,10 @@ end
     chain = Chain(Dense(1, 15, σ), Dense(15, 2))
     alg = NNDAE(chain, Adam(0.1); autodiff = false)
 
-    sol = solve(prob,
-        alg, verbose = false, dt = 1 / 100.0f0, maxiters = 3000, abstol = 1.0f-10)
+    sol = solve(
+        prob,
+        alg, verbose = false, dt = 1 / 100.0f0, maxiters = 3000, abstol = 1.0f-10
+    )
 
-    @test ground_sol(0:(1 / 100):(pi / 2))≈sol atol=0.4
+    @test ground_sol(0:(1 / 100):(pi / 2)) ≈ sol atol = 0.4
 end

--- a/test/NNODE_tests.jl
+++ b/test/NNODE_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Scalar" tags=[:nnode] begin
+@testitem "Scalar" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers
     using OptimizationOptimJL: BFGS
 
@@ -11,22 +11,23 @@
     luxchain = Chain(Dense(1, 5, σ), Dense(5, 1))
 
     @testset "$(nameof(typeof(opt))) -- $(autodiff)" for opt in [BFGS(), Adam(0.1)],
-        autodiff in [false, true]
+            autodiff in [false, true]
 
         if autodiff
             @test_throws ArgumentError solve(
-                prob, NNODE(luxchain, opt; autodiff); maxiters = 200, dt = 1 / 20.0f0)
+                prob, NNODE(luxchain, opt; autodiff); maxiters = 200, dt = 1 / 20.0f0
+            )
             continue
         end
 
-        @testset for (dt, abstol) in [(1 / 20.0f0, 1e-10), (nothing, 1e-6)]
+        @testset for (dt, abstol) in [(1 / 20.0f0, 1.0e-10), (nothing, 1.0e-6)]
             kwargs = (; verbose = false, dt, abstol, maxiters = 200)
             sol = solve(prob, NNODE(luxchain, opt; autodiff); kwargs...)
         end
     end
 end
 
-@testitem "Vector" tags=[:nnode] begin
+@testitem "Vector" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers
     using OptimizationOptimJL: BFGS
 
@@ -39,10 +40,11 @@ end
     luxchain = Chain(Dense(1, 5, σ), Dense(5, 1))
 
     @testset "$(nameof(typeof(opt))) -- $(autodiff)" for opt in [BFGS(), Adam(0.1)],
-        autodiff in [false, true]
+            autodiff in [false, true]
 
         sol = solve(
-            prob, NNODE(luxchain, opt); verbose = false, maxiters = 200, abstol = 1e-6)
+            prob, NNODE(luxchain, opt); verbose = false, maxiters = 200, abstol = 1.0e-6
+        )
 
         @test sol(0.5) isa Vector
         @test sol(0.5; idxs = 1) isa Number
@@ -50,16 +52,19 @@ end
     end
 end
 
-@testitem "ODE I" tags=[:nnode] begin
+@testitem "ODE I" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers
 
-    linear = (u,
+    linear = (
+        u,
         p,
-        t) -> @. t^3 + 2 * t + (t^2) * ((1 + 3 * (t^2)) / (1 + t + (t^3))) -
-                 u * (t + ((1 + 3 * (t^2)) / (1 + t + t^3)))
+        t,
+    ) -> @. t^3 + 2 * t + (t^2) * ((1 + 3 * (t^2)) / (1 + t + (t^3))) -
+        u * (t + ((1 + 3 * (t^2)) / (1 + t + t^3)))
     linear_analytic = (u0, p, t) -> [exp(-(t^2) / 2) / (1 + t + t^3) + t^2]
     prob = ODEProblem(
-        ODEFunction(linear; analytic = linear_analytic), [1.0f0], (0.0f0, 1.0f0))
+        ODEFunction(linear; analytic = linear_analytic), [1.0f0], (0.0f0, 1.0f0)
+    )
     luxchain = Chain(Dense(1, 128, σ), Dense(128, 1))
     opt = Adam(0.01)
 
@@ -67,12 +72,13 @@ end
 
         sol = solve(
             prob, NNODE(luxchain, opt; batch, strategy); verbose = false, maxiters = 200,
-            abstol = 1e-6)
+            abstol = 1.0e-6
+        )
         @test sol.errors[:l2] < 0.5
     end
 end
 
-@testitem "ODE Example 2" tags=[:nnode] begin
+@testitem "ODE Example 2" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers
 
     Random.seed!(100)
@@ -80,7 +86,8 @@ end
     linear = (u, p, t) -> -u / 5 + exp(-t / 5) .* cos(t)
     linear_analytic = (u0, p, t) -> exp(-t / 5) * (u0 + sin(t))
     prob = ODEProblem(
-        ODEFunction(linear; analytic = linear_analytic), 0.0f0, (0.0f0, 1.0f0))
+        ODEFunction(linear; analytic = linear_analytic), 0.0f0, (0.0f0, 1.0f0)
+    )
     luxchain = Chain(Dense(1, 5, σ), Dense(5, 1))
 
     @testset for batch in [false, true], strategy in [StochasticTraining(100), nothing]
@@ -88,12 +95,13 @@ end
         opt = Adam(0.1)
         sol = solve(
             prob, NNODE(luxchain, opt; batch, strategy); verbose = false, maxiters = 200,
-            abstol = 1e-6)
+            abstol = 1.0e-6
+        )
         @test sol.errors[:l2] < 0.5
     end
 end
 
-@testitem "ODE Example 3" tags=[:nnode] begin
+@testitem "ODE Example 3" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers
 
     Random.seed!(100)
@@ -109,12 +117,13 @@ end
     alg = NNODE(luxchain, opt; autodiff = false)
 
     sol = solve(
-        prob, alg; verbose = false, maxiters = 1000, abstol = 1e-6, saveat = 0.01)
+        prob, alg; verbose = false, maxiters = 1000, abstol = 1.0e-6, saveat = 0.01
+    )
 
     @test sol.errors[:l2] < 0.5
 end
 
-@testitem "Training Strategy: WeightedIntervalTraining" tags=[:nnode] begin
+@testitem "Training Strategy: WeightedIntervalTraining" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers, Statistics
 
     Random.seed!(100)
@@ -128,17 +137,20 @@ end
     true_sol = solve(prob_oop, Tsit5(); saveat = 0.01)
 
     N = 64
-    chain = Chain(Dense(1, N, gelu), Dense(N, N, gelu), Dense(N, N, gelu),
-        Dense(N, N, gelu), Dense(N, length(u0)))
+    chain = Chain(
+        Dense(1, N, gelu), Dense(N, N, gelu), Dense(N, N, gelu),
+        Dense(N, N, gelu), Dense(N, length(u0))
+    )
 
     alg = NNODE(
-        chain, Adam(0.01); strategy = WeightedIntervalTraining([0.7, 0.2, 0.1], 200))
+        chain, Adam(0.01); strategy = WeightedIntervalTraining([0.7, 0.2, 0.1], 200)
+    )
 
     sol = solve(prob_oop, alg; verbose = false, maxiters = 5000, saveat = 0.01)
     @test abs(mean(sol) - mean(true_sol)) < 0.2
 end
 
-@testitem "Training Strategy: Others" tags=[:nnode] begin
+@testitem "Training Strategy: Others" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers, Integrals
 
     Random.seed!(100)
@@ -160,27 +172,31 @@ end
     end
 
     @testset "$(nameof(typeof(strategy)))" for strategy in [
-        GridTraining(0.01),
-        StochasticTraining(1000),
-        QuadratureTraining(reltol = 1e-3, abstol = 1e-6, maxiters = 50,
-            batch = 100, quadrature_alg = QuadGKJL())
-    ]
+            GridTraining(0.01),
+            StochasticTraining(1000),
+            QuadratureTraining(
+                reltol = 1.0e-3, abstol = 1.0e-6, maxiters = 50,
+                batch = 100, quadrature_alg = QuadGKJL()
+            ),
+        ]
         alg = NNODE(luxchain, opt; additional_loss, strategy)
         @test begin
-            sol = solve(prob, alg; verbose = false, maxiters = 500, abstol = 1e-6)
+            sol = solve(prob, alg; verbose = false, maxiters = 500, abstol = 1.0e-6)
             sol.errors[:l2] < 0.5
         end
     end
 end
 
-@testitem "ODE Parameter Estimation" tags=[:nnode] begin
+@testitem "ODE Parameter Estimation" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, OptimizationOptimJL, LineSearches
     Random.seed!(100)
 
     function lorenz(u, p, t)
-        return [p[1] * (u[2] - u[1]),
+        return [
+            p[1] * (u[2] - u[1]),
             u[1] * (p[2] - u[3]) - u[2],
-            u[1] * u[2] - p[3] * u[3]]
+            u[1] * u[2] - p[3] * u[3],
+        ]
     end
     tspan = (0.0, 1.0)
     prob = ODEProblem(lorenz, [1.0, 0.0, 0.0], tspan, [1.0, 1.0, 1.0])
@@ -197,24 +213,28 @@ end
     u3_ = [u_[i][3] for i in eachindex(t_)]
     dataset = [u1_, u2_, u3_, t_, ones(length(t_))]
 
-    alg = NNODE(luxchain, BFGS(linesearch = BackTracking());
+    alg = NNODE(
+        luxchain, BFGS(linesearch = BackTracking());
         strategy = GridTraining(0.01), dataset = dataset,
-        param_estim = true)
-    sol = solve(prob, alg; verbose = false, abstol = 1e-8, maxiters = 1000, saveat = t_)
+        param_estim = true
+    )
+    sol = solve(prob, alg; verbose = false, abstol = 1.0e-8, maxiters = 1000, saveat = t_)
 
-    @test sol.k.u.p≈true_p atol=1e-2
-    @test reduce(hcat, sol.u)≈sol_points atol=1e-2
+    @test sol.k.u.p ≈ true_p atol = 1.0e-2
+    @test reduce(hcat, sol.u) ≈ sol_points atol = 1.0e-2
 end
 
-@testitem "ODE Parameter Estimation Improvement" tags=[:nnode] begin
+@testitem "ODE Parameter Estimation Improvement" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, OptimizationOptimJL, LineSearches
     using FastGaussQuadrature
     Random.seed!(100)
 
     function lorenz(u, p, t)
-        return [p[1] * (u[2] - u[1]),
+        return [
+            p[1] * (u[2] - u[1]),
             u[1] * (p[2] - u[3]) - u[2],
-            u[1] * u[2] - p[3] * u[3]]
+            u[1] * u[2] - p[3] * u[3],
+        ]
     end
     tspan = (0.0, 5.0)
     prob = ODEProblem(lorenz, [1.0, 0.0, 0.0], tspan, [-10.0, -10.0, -10.0])
@@ -244,17 +264,22 @@ end
     u3_ = [u_[i][3] for i in eachindex(t_)]
     dataset = [u1_, u2_, u3_, t_, W]
 
-    alg_old = NNODE(luxchain, BFGS(linesearch = BackTracking());
+    alg_old = NNODE(
+        luxchain, BFGS(linesearch = BackTracking());
         strategy = GridTraining(0.01), dataset = dataset,
-        param_estim = true)
+        param_estim = true
+    )
     sol_old = solve(
-        prob, alg_old; verbose = false, abstol = 1e-12, maxiters = 2000, saveat = 0.01)
+        prob, alg_old; verbose = false, abstol = 1.0e-12, maxiters = 2000, saveat = 0.01
+    )
 
     alg_new = NNODE(
         luxchain, BFGS(linesearch = BackTracking()); strategy = GridTraining(0.01),
-        param_estim = true, dataset = dataset, estim_collocate = true)
+        param_estim = true, dataset = dataset, estim_collocate = true
+    )
     sol_new = solve(
-        prob, alg_new; verbose = false, abstol = 1e-12, maxiters = 2000, saveat = 0.01)
+        prob, alg_new; verbose = false, abstol = 1.0e-12, maxiters = 2000, saveat = 0.01
+    )
 
     sol = solve(prob2, Tsit5(); saveat = 0.01)
     sol_points = hcat(sol.u...)
@@ -264,11 +289,11 @@ end
     @test !isapprox(sol_old.k.u.p, true_p; atol = 10)
     @test !isapprox(sol_old_points, sol_points; atol = 10)
 
-    @test sol_new.k.u.p≈true_p atol=1e-2
-    @test sol_new_points≈sol_points atol=3e-2
+    @test sol_new.k.u.p ≈ true_p atol = 1.0e-2
+    @test sol_new_points ≈ sol_points atol = 3.0e-2
 end
 
-@testitem "ODE Complex Numbers" tags=[:nnode] begin
+@testitem "ODE Complex Numbers" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers
 
     Random.seed!(100)
@@ -277,10 +302,12 @@ end
         Ω, Δ, Γ = p
         γ = Γ / 2
         ρ₁₁, ρ₂₂, ρ₁₂, ρ₂₁ = u
-        d̢ρ = [im * Ω * (ρ₁₂ - ρ₂₁) + Γ * ρ₂₂;
-               -im * Ω * (ρ₁₂ - ρ₂₁) - Γ * ρ₂₂;
-               -(γ + im * Δ) * ρ₁₂ - im * Ω * (ρ₂₂ - ρ₁₁);
-               conj(-(γ + im * Δ) * ρ₁₂ - im * Ω * (ρ₂₂ - ρ₁₁))]
+        d̢ρ = [
+            im * Ω * (ρ₁₂ - ρ₂₁) + Γ * ρ₂₂;
+            -im * Ω * (ρ₁₂ - ρ₂₁) - Γ * ρ₂₂;
+            -(γ + im * Δ) * ρ₁₂ - im * Ω * (ρ₂₂ - ρ₁₁);
+            conj(-(γ + im * Δ) * ρ₁₂ - im * Ω * (ρ₂₂ - ρ₁₁))
+        ]
         return d̢ρ
     end
 
@@ -302,21 +329,22 @@ end
     strategies = [
         StochasticTraining(500),
         GridTraining(0.01),
-        WeightedIntervalTraining([0.1, 0.4, 0.4, 0.1], 500)
+        WeightedIntervalTraining([0.1, 0.4, 0.4, 0.1], 500),
     ]
 
     @testset "$(nameof(typeof(strategy)))" for strategy in strategies
         alg = NNODE(chain, Adam(0.01); strategy)
         sol = solve(problem, alg; verbose = false, maxiters = 5000, saveat = 0.01)
-        @test sol.u≈ground_truth.u rtol=1e-1
+        @test sol.u ≈ ground_truth.u rtol = 1.0e-1
     end
 
     alg = NNODE(chain, Adam(0.01); strategy = QuadratureTraining())
     @test_throws ErrorException solve(
-        problem, alg; verbose = false, maxiters = 5000, saveat = 0.01)
+        problem, alg; verbose = false, maxiters = 5000, saveat = 0.01
+    )
 end
 
-@testitem "NNODE: Translating from Flux" tags=[:nnode] begin
+@testitem "NNODE: Translating from Flux" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers
     import Flux
 
@@ -328,7 +356,8 @@ end
     dt = (tspan[2] - tspan[1]) / 99
     ts = collect(tspan[1]:dt:tspan[2])
     prob = ODEProblem(
-        ODEFunction(linear; analytic = linear_analytic), 0.0f0, (0.0f0, 1.0f0))
+        ODEFunction(linear; analytic = linear_analytic), 0.0f0, (0.0f0, 1.0f0)
+    )
 
     u_analytical(x) = (1 / (2pi)) .* sinpi.(2x)
     fluxchain = Flux.Chain(Flux.Dense(1, 5, Flux.σ), Flux.Dense(5, 1))
@@ -336,11 +365,11 @@ end
 
     alg = NNODE(fluxchain, opt)
     @test alg.chain isa Lux.AbstractLuxLayer
-    sol = solve(prob, alg; verbose = false, abstol = 1e-10, maxiters = 200)
+    sol = solve(prob, alg; verbose = false, abstol = 1.0e-10, maxiters = 200)
     @test sol.errors[:l2] < 0.5
 end
 
-@testitem "Training Strategy with `tstops`" tags=[:nnode] begin
+@testitem "Training Strategy with `tstops`" tags = [:nnode] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers, Statistics
 
     Random.seed!(100)
@@ -362,16 +391,18 @@ end
     prob_oop = ODEProblem{false}(f, u0, tspan, p)
     true_sol = solve(prob_oop, Tsit5(); saveat)
     N = 16
-    chain = Chain(Dense(1 => N, σ), Dense(N => N, σ), Dense(N => N, σ), Dense(N => N, σ),
-        Dense(N => length(u0)))
+    chain = Chain(
+        Dense(1 => N, σ), Dense(N => N, σ), Dense(N => N, σ), Dense(N => N, σ),
+        Dense(N => length(u0))
+    )
 
     threshold = 0.2
 
     @testset "$(nameof(typeof(strategy)))" for strategy in [
-        GridTraining(1.0),
-        WeightedIntervalTraining([0.3, 0.3, 0.4], 3),
-        StochasticTraining(3)
-    ]
+            GridTraining(1.0),
+            WeightedIntervalTraining([0.3, 0.3, 0.4], 3),
+            StochasticTraining(3),
+        ]
         alg = NNODE(chain, Adam(0.01); strategy, tstops = addedPoints)
 
         @testset "Without added points" begin
@@ -380,8 +411,10 @@ end
         end
 
         @testset "With added points" begin
-            sol = solve(prob_oop, alg; verbose = false,
-                maxiters = 10000, saveat, tstops = addedPoints)
+            sol = solve(
+                prob_oop, alg; verbose = false,
+                maxiters = 10000, saveat, tstops = addedPoints
+            )
             @test abs(mean(sol) - mean(true_sol)) < threshold
         end
     end

--- a/test/NNPDE_cuda_tests.jl
+++ b/test/NNPDE_cuda_tests.jl
@@ -15,7 +15,7 @@ export gpud, callback
 
 end
 
-@testitem "1D ODE - CUDA" tags=[:cuda] setup=[CUDATestSetup] begin
+@testitem "1D ODE - CUDA" tags = [:cuda] setup = [CUDATestSetup] begin
     using Lux, Optimization, OptimizationOptimisers, Random, ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
@@ -23,43 +23,45 @@ end
 
     @parameters θ
     @variables u(..)
-    Dθ=Differential(θ)
+    Dθ = Differential(θ)
 
     # 1D ODE
-    eq=Dθ(u(θ))~θ^3+2.0f0*θ+(θ^2)*((1.0f0+3*(θ^2))/(1.0f0+θ+(θ^3)))-
-    u(θ)*(θ+((1.0f0+3.0f0*(θ^2))/(1.0f0+θ+θ^3)))
+    eq = Dθ(u(θ)) ~ θ^3 + 2.0f0 * θ + (θ^2) * ((1.0f0 + 3 * (θ^2)) / (1.0f0 + θ + (θ^3))) -
+        u(θ) * (θ + ((1.0f0 + 3.0f0 * (θ^2)) / (1.0f0 + θ + θ^3)))
 
     # Initial and boundary conditions
-    bcs=[u(0.0)~1.0f0]
+    bcs = [u(0.0) ~ 1.0f0]
 
     # Space and time domains
-    domains=[θ ∈ Interval(0.0f0, 1.0f0)]
+    domains = [θ ∈ Interval(0.0f0, 1.0f0)]
 
     # Discretization
-    dt=0.1f0
+    dt = 0.1f0
 
     # Neural network
-    inner=20
-    chain=Chain(Dense(1, inner, σ), Dense(inner, inner, σ), Dense(inner, inner, σ),
-        Dense(inner, inner, σ), Dense(inner, inner, σ), Dense(inner, 1))
+    inner = 20
+    chain = Chain(
+        Dense(1, inner, σ), Dense(inner, inner, σ), Dense(inner, inner, σ),
+        Dense(inner, inner, σ), Dense(inner, inner, σ), Dense(inner, 1)
+    )
 
-    strategy=GridTraining(dt)
-    ps=Lux.initialparameters(Random.default_rng(), chain)|>ComponentArray|>gpud
-    discretization=PhysicsInformedNN(chain, strategy; init_params = ps)
+    strategy = GridTraining(dt)
+    ps = Lux.initialparameters(Random.default_rng(), chain) |> ComponentArray |> gpud
+    discretization = PhysicsInformedNN(chain, strategy; init_params = ps)
 
     @named pde_system = PDESystem(eq, bcs, domains, [θ], [u(θ)])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, Adam(1e-2); maxiters = 2000)
-    phi=discretization.phi
-    analytic_sol_func(t)=exp(-(t^2)/2)/(1+t+t^3)+t^2
-    ts=[infimum(d.domain):(dt / 10):supremum(d.domain) for d in domains][1]
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, Adam(1.0e-2); maxiters = 2000)
+    phi = discretization.phi
+    analytic_sol_func(t) = exp(-(t^2) / 2) / (1 + t + t^3) + t^2
+    ts = [infimum(d.domain):(dt / 10):supremum(d.domain) for d in domains][1]
 
-    u_real=[analytic_sol_func(t) for t in ts]
-    u_predict=[first(Array(phi([t], res.u))) for t in ts]
-    @test u_predict≈u_real atol=0.2
+    u_real = [analytic_sol_func(t) for t in ts]
+    u_predict = [first(Array(phi([t], res.u))) for t in ts]
+    @test u_predict ≈ u_real atol = 0.2
 end
 
-@testitem "1D PDE Dirichlet BC - CUDA" tags=[:cuda] setup=[CUDATestSetup] begin
+@testitem "1D PDE Dirichlet BC - CUDA" tags = [:cuda] setup = [CUDATestSetup] begin
     using Lux, Optimization, OptimizationOptimisers, Random, ComponentArrays
     import DomainSets: Interval, infimum, supremum
     import Boltz.Layers: PeriodicEmbedding
@@ -68,98 +70,103 @@ end
 
     @parameters t x
     @variables u(..)
-    Dt=Differential(t)
-    Dxx=Differential(x)^2
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
 
-    eq=Dt(u(t, x))~Dxx(u(t, x))
-    bcs=[
-        u(0, x)~cos(x),
-        u(t, 0)~exp(-t),
-        u(t, 2π)~exp(-t)
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+    bcs = [
+        u(0, x) ~ cos(x),
+        u(t, 0) ~ exp(-t),
+        u(t, 2π) ~ exp(-t),
     ]
 
-    domains=[t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 2π)]
+    domains = [t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 2π)]
 
     @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
 
-    inner=30
-    chain=Chain(PeriodicEmbedding([2], [2π]), Dense(3, inner, σ), Dense(inner, inner, σ),
+    inner = 30
+    chain = Chain(
+        PeriodicEmbedding([2], [2π]), Dense(3, inner, σ), Dense(inner, inner, σ),
         Dense(inner, inner, σ), Dense(inner, inner, σ),
-        Dense(inner, inner, σ), Dense(inner, inner, σ), Dense(inner, 1))
+        Dense(inner, inner, σ), Dense(inner, inner, σ), Dense(inner, 1)
+    )
 
-    strategy=StochasticTraining(1000)
-    ps, st=Lux.setup(Random.default_rng(), chain)
-    ps=ps|>ComponentArray|>gpu_device()|>f64
-    st=st|>gpu_device()|>f64
+    strategy = StochasticTraining(1000)
+    ps, st = Lux.setup(Random.default_rng(), chain)
+    ps = ps |> ComponentArray |> gpu_device() |> f64
+    st = st |> gpu_device() |> f64
 
-    discretization=PhysicsInformedNN(chain, strategy; init_params = ps, init_states = st)
-    prob=discretize(pdesys, discretization)
-    res=solve(prob, Adam(0.01); maxiters = 1000)
-    prob=remake(prob, u0 = res.u)
-    res=solve(prob, Adam(0.001); maxiters = 1000)
-    phi=discretization.phi
-    u_exact=(t, x)->exp.(-t)*cos.(x)
-    ts, xs=[infimum(d.domain):0.01:supremum(d.domain) for d in domains]
+    discretization = PhysicsInformedNN(chain, strategy; init_params = ps, init_states = st)
+    prob = discretize(pdesys, discretization)
+    res = solve(prob, Adam(0.01); maxiters = 1000)
+    prob = remake(prob, u0 = res.u)
+    res = solve(prob, Adam(0.001); maxiters = 1000)
+    phi = discretization.phi
+    u_exact = (t, x) -> exp.(-t) * cos.(x)
+    ts, xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
 
-    u_predict=[first(Array(phi([t, x], res.u))) for t in ts for x in xs]
-    u_real=[u_exact(t, x) for t in ts for x in xs]
-    diff_u=abs.(u_predict .- u_real)
+    u_predict = [first(Array(phi([t, x], res.u))) for t in ts for x in xs]
+    u_real = [u_exact(t, x) for t in ts for x in xs]
+    diff_u = abs.(u_predict .- u_real)
 
-    @test u_predict≈u_real atol=1.0
+    @test u_predict ≈ u_real atol = 1.0
 end
 
-@testitem "1D PDE Neumann BC - CUDA" tags=[:cuda] setup=[CUDATestSetup] begin
+@testitem "1D PDE Neumann BC - CUDA" tags = [:cuda] setup = [CUDATestSetup] begin
     using Lux, Optimization, OptimizationOptimisers, Random, QuasiMonteCarlo,
-          ComponentArrays
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
 
     @parameters t x
     @variables u(..)
-    Dt=Differential(t)
-    Dx=Differential(x)
-    Dxx=Differential(x)^2
+    Dt = Differential(t)
+    Dx = Differential(x)
+    Dxx = Differential(x)^2
 
     # 1D PDE and boundary conditions
-    eq=Dt(u(t, x))~Dxx(u(t, x))
-    bcs=[
-        u(0, x)~cos(x),
-        Dx(u(t, 0))~0.0,
-        Dx(u(t, 1))~-exp(-t)*sin(1.0)
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+    bcs = [
+        u(0, x) ~ cos(x),
+        Dx(u(t, 0)) ~ 0.0,
+        Dx(u(t, 1)) ~ -exp(-t) * sin(1.0),
     ]
 
     # Space and time domains
-    domains=[t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0)]
+    domains = [t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0)]
 
     # PDE system
     @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
 
-    inner=20
-    chain=Chain(Dense(2, inner, σ), Dense(inner, inner, σ),
-        Dense(inner, inner, σ), Dense(inner, inner, σ), Dense(inner, 1))
+    inner = 20
+    chain = Chain(
+        Dense(2, inner, σ), Dense(inner, inner, σ),
+        Dense(inner, inner, σ), Dense(inner, inner, σ), Dense(inner, 1)
+    )
 
-    strategy=QuasiRandomTraining(
-        500; sampling_alg = SobolSample(), resampling = false, minibatch = 30)
-    ps=Lux.initialparameters(Random.default_rng(), chain)|>ComponentArray|>gpud|>f64
+    strategy = QuasiRandomTraining(
+        500; sampling_alg = SobolSample(), resampling = false, minibatch = 30
+    )
+    ps = Lux.initialparameters(Random.default_rng(), chain) |> ComponentArray |> gpud |> f64
 
-    discretization=PhysicsInformedNN(chain, strategy; init_params = ps)
-    prob=discretize(pdesys, discretization)
-    res=solve(prob, Adam(0.1); maxiters = 2000)
-    prob=remake(prob, u0 = res.u)
-    res=solve(prob, Adam(0.01); maxiters = 2000)
-    phi=discretization.phi
-    u_exact=(t, x)->exp(-t)*cos(x)
-    ts, xs=[infimum(d.domain):0.01:supremum(d.domain) for d in domains]
+    discretization = PhysicsInformedNN(chain, strategy; init_params = ps)
+    prob = discretize(pdesys, discretization)
+    res = solve(prob, Adam(0.1); maxiters = 2000)
+    prob = remake(prob, u0 = res.u)
+    res = solve(prob, Adam(0.01); maxiters = 2000)
+    phi = discretization.phi
+    u_exact = (t, x) -> exp(-t) * cos(x)
+    ts, xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
 
-    u_predict=[first(Array(phi([t, x], res.u))) for t in ts for x in xs]
-    u_real=[u_exact(t, x) for t in ts for x in xs]
-    diff_u=abs.(u_predict .- u_real)
+    u_predict = [first(Array(phi([t, x], res.u))) for t in ts for x in xs]
+    u_real = [u_exact(t, x) for t in ts for x in xs]
+    diff_u = abs.(u_predict .- u_real)
 
-    @test u_predict≈u_real atol=1.0
+    @test u_predict ≈ u_real atol = 1.0
 end
 
-@testitem "2D PDE - CUDA" tags=[:cuda] setup=[CUDATestSetup] begin
+@testitem "2D PDE - CUDA" tags = [:cuda] setup = [CUDATestSetup] begin
     using Lux, Optimization, OptimizationOptimisers, Random, ComponentArrays
     import DomainSets: Interval, infimum, supremum
 
@@ -167,52 +174,56 @@ end
 
     @parameters t x y
     @variables u(..)
-    Dxx=Differential(x)^2
-    Dyy=Differential(y)^2
-    Dt=Differential(t)
+    Dxx = Differential(x)^2
+    Dyy = Differential(y)^2
+    Dt = Differential(t)
 
-    t_min, t_max, x_min, x_max, y_min, y_max=0.0, 2.0, 0.0, 2.0, 0.0, 2.0
+    t_min, t_max, x_min, x_max, y_min, y_max = 0.0, 2.0, 0.0, 2.0, 0.0, 2.0
 
-    eq=Dt(u(t, x, y))~Dxx(u(t, x, y))+Dyy(u(t, x, y))
+    eq = Dt(u(t, x, y)) ~ Dxx(u(t, x, y)) + Dyy(u(t, x, y))
 
-    analytic_sol_func(t, x, y)=exp(x+y)*cos(x+y+4t)
+    analytic_sol_func(t, x, y) = exp(x + y) * cos(x + y + 4t)
 
     # Initial and boundary conditions
-    bcs=[
-        u(t_min, x, y)~analytic_sol_func(t_min, x, y),
-        u(t, x_min, y)~analytic_sol_func(t, x_min, y),
-        u(t, x_max, y)~analytic_sol_func(t, x_max, y),
-        u(t, x, y_min)~analytic_sol_func(t, x, y_min),
-        u(t, x, y_max)~analytic_sol_func(t, x, y_max)
+    bcs = [
+        u(t_min, x, y) ~ analytic_sol_func(t_min, x, y),
+        u(t, x_min, y) ~ analytic_sol_func(t, x_min, y),
+        u(t, x_max, y) ~ analytic_sol_func(t, x_max, y),
+        u(t, x, y_min) ~ analytic_sol_func(t, x, y_min),
+        u(t, x, y_max) ~ analytic_sol_func(t, x, y_max),
     ]
 
     # Space and time domains
-    domains=[
+    domains = [
         t ∈ Interval(t_min, t_max),
         x ∈ Interval(x_min, x_max),
-        y ∈ Interval(y_min, y_max)
+        y ∈ Interval(y_min, y_max),
     ]
 
     # Neural network
-    inner=25
-    chain=Chain(Dense(3, inner, σ), Dense(inner, inner, σ),
-        Dense(inner, inner, σ), Dense(inner, inner, σ), Dense(inner, 1))
+    inner = 25
+    chain = Chain(
+        Dense(3, inner, σ), Dense(inner, inner, σ),
+        Dense(inner, inner, σ), Dense(inner, inner, σ), Dense(inner, 1)
+    )
 
-    strategy=GridTraining(0.05)
-    ps=Lux.initialparameters(Random.default_rng(), chain)|>ComponentArray|>gpud|>f64
+    strategy = GridTraining(0.05)
+    ps = Lux.initialparameters(Random.default_rng(), chain) |> ComponentArray |> gpud |> f64
 
-    discretization=PhysicsInformedNN(chain, strategy; init_params = ps)
+    discretization = PhysicsInformedNN(chain, strategy; init_params = ps)
     @named pde_system = PDESystem(eq, bcs, domains, [t, x, y], [u(t, x, y)])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, Adam(0.01); maxiters = 2500)
-    prob=remake(prob, u0 = res.u)
-    res=solve(prob, Adam(0.001); maxiters = 2500)
-    phi=discretization.phi
-    ts, xs, ys=[infimum(d.domain):0.1:supremum(d.domain) for d in domains]
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, Adam(0.01); maxiters = 2500)
+    prob = remake(prob, u0 = res.u)
+    res = solve(prob, Adam(0.001); maxiters = 2500)
+    phi = discretization.phi
+    ts, xs, ys = [infimum(d.domain):0.1:supremum(d.domain) for d in domains]
 
-    u_real=[analytic_sol_func(t, x, y) for t in ts for x in xs for y in ys]
-    u_predict=[first(Array(phi([t, x, y], res.u))) for t in ts for x in xs
-               for y in ys]
+    u_real = [analytic_sol_func(t, x, y) for t in ts for x in xs for y in ys]
+    u_predict = [
+        first(Array(phi([t, x, y], res.u))) for t in ts for x in xs
+            for y in ys
+    ]
 
-    @test u_predict≈u_real rtol=0.2
+    @test u_predict ≈ u_real rtol = 0.2
 end

--- a/test/NNPDE_tests.jl
+++ b/test/NNPDE_tests.jl
@@ -7,7 +7,8 @@ using NeuralPDE, Cubature, Integrals, QuasiMonteCarlo
 @variables u(..)
 
 NeuralPDE.generate_training_sets(
-    [x ∈ (-1.0, 1.0)], 0.1, [u(x) ~ x], [0.0 ~ 0.0], Float64, [x], [:u])
+    [x ∈ (-1.0, 1.0)], 0.1, [u(x) ~ x], [0.0 ~ 0.0], Float64, [x], [:u]
+)
 
 function callback(p, l)
     if p.iter == 1 || p.iter % 250 == 0
@@ -17,64 +18,70 @@ function callback(p, l)
 end
 
 grid_strategy = GridTraining(0.1)
-quadrature_strategy = QuadratureTraining(quadrature_alg = CubatureJLh(),
-    reltol = 1e3, abstol = 1e-3, maxiters = 50, batch = 100)
+quadrature_strategy = QuadratureTraining(
+    quadrature_alg = CubatureJLh(),
+    reltol = 1.0e3, abstol = 1.0e-3, maxiters = 50, batch = 100
+)
 stochastic_strategy = StochasticTraining(100; bcs_points = 50)
-quasirandom_strategy = QuasiRandomTraining(100; sampling_alg = LatinHypercubeSample(),
-    resampling = false, minibatch = 100)
-quasirandom_strategy_resampling = QuasiRandomTraining(100; bcs_points = 50,
-    sampling_alg = LatticeRuleSample(), resampling = true, minibatch = 0)
+quasirandom_strategy = QuasiRandomTraining(
+    100; sampling_alg = LatinHypercubeSample(),
+    resampling = false, minibatch = 100
+)
+quasirandom_strategy_resampling = QuasiRandomTraining(
+    100; bcs_points = 50,
+    sampling_alg = LatticeRuleSample(), resampling = true, minibatch = 0
+)
 
 strategies = [
     grid_strategy,
     stochastic_strategy,
     quasirandom_strategy,
     quasirandom_strategy_resampling,
-    quadrature_strategy
+    quadrature_strategy,
 ]
 
 export callback, strategies
 
 end
 
-@testitem "Test Heterogeneous ODE" tags=[:nnpde1] setup=[NNPDE1TestSetup] begin
+@testitem "Test Heterogeneous ODE" tags = [:nnpde1] setup = [NNPDE1TestSetup] begin
     using Cubature, Integrals, QuasiMonteCarlo, DomainSets, Lux, Random, Optimisers
 
     function simple_1d_ode(strategy)
         @parameters θ
         @variables u(..)
-        Dθ=Differential(θ)
+        Dθ = Differential(θ)
 
         # 1D ODE
-        eq=Dθ(u(θ))~θ^3+2.0f0*θ+
-                    (θ^2)*((1.0f0+3*(θ^2))/(1.0f0+θ+(θ^3)))-
-        u(θ)*(θ+((1.0f0+3.0f0*(θ^2))/(1.0f0+θ+θ^3)))
+        eq = Dθ(u(θ)) ~ θ^3 + 2.0f0 * θ +
+            (θ^2) * ((1.0f0 + 3 * (θ^2)) / (1.0f0 + θ + (θ^3))) -
+            u(θ) * (θ + ((1.0f0 + 3.0f0 * (θ^2)) / (1.0f0 + θ + θ^3)))
 
         # Initial and boundary conditions
-        bcs=[u(0.0)~1.0f0]
+        bcs = [u(0.0) ~ 1.0f0]
 
         # Space and time domains
-        domains=[θ ∈ Interval(0.0f0, 1.0f0)]
+        domains = [θ ∈ Interval(0.0f0, 1.0f0)]
 
         # Neural network
-        chain=Chain(Dense(1, 12, σ), Dense(12, 1))
+        chain = Chain(Dense(1, 12, σ), Dense(12, 1))
 
-        discretization=PhysicsInformedNN(chain, strategy)
+        discretization = PhysicsInformedNN(chain, strategy)
         @named pde_system = PDESystem(eq, bcs, domains, [θ], [u])
-        prob=discretize(pde_system, discretization)
+        prob = discretize(pde_system, discretization)
 
-        res=solve(prob, Adam(0.1); maxiters = 1000)
-        prob=remake(prob, u0 = res.u)
-        res=solve(prob, Adam(0.01); maxiters = 500)
-        prob=remake(prob, u0 = res.u)
-        res=solve(prob, Adam(0.001); maxiters = 500)
-        phi=discretization.phi
+        res = solve(prob, Adam(0.1); maxiters = 1000)
+        prob = remake(prob, u0 = res.u)
+        res = solve(prob, Adam(0.01); maxiters = 500)
+        prob = remake(prob, u0 = res.u)
+        res = solve(prob, Adam(0.001); maxiters = 500)
+        phi = discretization.phi
 
-        analytic_sol_func(t)=exp(-(t^2)/2)/(1+t+t^3)+t^2
-        ts=[infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
-        u_real=[analytic_sol_func(t) for t in ts]
-        u_predict=[first(phi([t], res.u)) for t in ts]
-        @test u_predict≈u_real atol=0.8
+        analytic_sol_func(t) = exp(-(t^2) / 2) / (1 + t + t^3) + t^2
+        ts = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
+        u_real = [analytic_sol_func(t) for t in ts]
+        u_predict = [first(phi([t], res.u)) for t in ts]
+        @test u_predict ≈ u_real atol = 0.8
     end
 
     @testset "$(nameof(typeof(strategy)))" for strategy in strategies
@@ -82,316 +89,340 @@ end
     end
 end
 
-@testitem "PDE I: Heterogeneous system" tags=[:nnpde1] setup=[NNPDE1TestSetup] begin
+@testitem "PDE I: Heterogeneous system" tags = [:nnpde1] setup = [NNPDE1TestSetup] begin
     using DomainSets, Lux, Random, Optimisers, Integrals
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
 
     @parameters x, y, z
     @variables u(..), v(..), h(..), p(..)
-    Dz=Differential(z)
-    eqs=[
-        u(x, y, z)~x+y+z,
-        v(y, x)~x^2+y^2,
-        h(z)~cos(z),
-        p(x, z)~exp(x)*exp(z),
-        u(x, y, z)+v(y, x)*Dz(h(z))-p(x, z)~x+y+z-(x^2+y^2)*sin(z)-
-        exp(x)*exp(z)
+    Dz = Differential(z)
+    eqs = [
+        u(x, y, z) ~ x + y + z,
+        v(y, x) ~ x^2 + y^2,
+        h(z) ~ cos(z),
+        p(x, z) ~ exp(x) * exp(z),
+        u(x, y, z) + v(y, x) * Dz(h(z)) - p(x, z) ~ x + y + z - (x^2 + y^2) * sin(z) -
+            exp(x) * exp(z),
     ]
 
-    bcs=[u(0.0, 0.0, 0.0)~0.0]
+    bcs = [u(0.0, 0.0, 0.0) ~ 0.0]
 
-    domains=[x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0), z ∈ Interval(0.0, 1.0)]
+    domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0), z ∈ Interval(0.0, 1.0)]
 
-    chain=[
+    chain = [
         Chain(Dense(3, 12, tanh), Dense(12, 12, tanh), Dense(12, 1)),
         Chain(Dense(2, 12, tanh), Dense(12, 12, tanh), Dense(12, 1)),
         Chain(Dense(1, 12, tanh), Dense(12, 12, tanh), Dense(12, 1)),
-        Chain(Dense(2, 12, tanh), Dense(12, 12, tanh), Dense(12, 1))
+        Chain(Dense(2, 12, tanh), Dense(12, 12, tanh), Dense(12, 1)),
     ]
 
-    grid_strategy=GridTraining(0.1)
-    quadrature_strategy=QuadratureTraining(quadrature_alg = CubatureJLh(),
-        reltol = 1e-3, abstol = 1e-3, maxiters = 50, batch = 100)
+    grid_strategy = GridTraining(0.1)
+    quadrature_strategy = QuadratureTraining(
+        quadrature_alg = CubatureJLh(),
+        reltol = 1.0e-3, abstol = 1.0e-3, maxiters = 50, batch = 100
+    )
 
-    discretization=PhysicsInformedNN(chain, grid_strategy)
+    discretization = PhysicsInformedNN(chain, grid_strategy)
 
-    @named pde_system = PDESystem(eqs, bcs, domains, [x, y, z],
-        [u(x, y, z), v(y, x), h(z), p(x, z)])
+    @named pde_system = PDESystem(
+        eqs, bcs, domains, [x, y, z],
+        [u(x, y, z), v(y, x), h(z), p(x, z)]
+    )
 
-    prob=discretize(pde_system, discretization)
+    prob = discretize(pde_system, discretization)
 
-    res=solve(prob, BFGS(); maxiters = 2000, callback)
+    res = solve(prob, BFGS(); maxiters = 2000, callback)
 
-    phi=discretization.phi
+    phi = discretization.phi
 
-    analytic_sol_func_=[
-        (x, y, z)->x+y+z,
-        (x, y)->x^2+y^2,
-        (z)->cos(z),
-        (x, z)->exp(x)*exp(z)
+    analytic_sol_func_ = [
+        (x, y, z) -> x + y + z,
+        (x, y) -> x^2 + y^2,
+        (z) -> cos(z),
+        (x, z) -> exp(x) * exp(z),
     ]
 
-    xs, ys, zs=[infimum(d.domain):0.1:supremum(d.domain) for d in domains]
+    xs, ys, zs = [infimum(d.domain):0.1:supremum(d.domain) for d in domains]
 
-    u_real=[analytic_sol_func_[1](x, y, z) for x in xs for y in ys for z in zs]
-    v_real=[analytic_sol_func_[2](y, x) for y in ys for x in xs]
-    h_real=[analytic_sol_func_[3](z) for z in zs]
-    p_real=[analytic_sol_func_[4](x, z) for x in xs for z in zs]
+    u_real = [analytic_sol_func_[1](x, y, z) for x in xs for y in ys for z in zs]
+    v_real = [analytic_sol_func_[2](y, x) for y in ys for x in xs]
+    h_real = [analytic_sol_func_[3](z) for z in zs]
+    p_real = [analytic_sol_func_[4](x, z) for x in xs for z in zs]
 
-    real_=[u_real, v_real, h_real, p_real]
+    real_ = [u_real, v_real, h_real, p_real]
 
-    u_predict=[phi[1]([x, y, z], res.u.depvar.u)[1] for x in xs for y in ys
-               for z in zs]
-    v_predict=[phi[2]([y, x], res.u.depvar.v)[1] for y in ys for x in xs]
-    h_predict=[phi[3]([z], res.u.depvar.h)[1] for z in zs]
-    p_predict=[phi[4]([x, z], res.u.depvar.p)[1] for x in xs for z in zs]
+    u_predict = [
+        phi[1]([x, y, z], res.u.depvar.u)[1] for x in xs for y in ys
+            for z in zs
+    ]
+    v_predict = [phi[2]([y, x], res.u.depvar.v)[1] for y in ys for x in xs]
+    h_predict = [phi[3]([z], res.u.depvar.h)[1] for z in zs]
+    p_predict = [phi[4]([x, z], res.u.depvar.p)[1] for x in xs for z in zs]
 
-    predict=[u_predict, v_predict, h_predict, p_predict]
+    predict = [u_predict, v_predict, h_predict, p_predict]
 
     for i in 1:4
-        @test predict[i]≈real_[i] rtol=10^-2
+        @test predict[i] ≈ real_[i] rtol = 10^-2
     end
 end
 
-@testitem "PDE II: 2D Poisson" tags=[:nnpde1] setup=[NNPDE1TestSetup] begin
+@testitem "PDE II: 2D Poisson" tags = [:nnpde1] setup = [NNPDE1TestSetup] begin
     using Lux, Random, Optimisers, DomainSets, Cubature, QuasiMonteCarlo, Integrals
     import DomainSets: Interval, infimum, supremum
 
     function test_2d_poisson_equation(chain, strategy)
         @parameters x y
         @variables u(..)
-        Dxx=Differential(x)^2
-        Dyy=Differential(y)^2
+        Dxx = Differential(x)^2
+        Dyy = Differential(y)^2
 
         # 2D PDE
-        eq=Dxx(u(x, y))+Dyy(u(x, y))~-sin(pi*x)*sin(pi*y)
+        eq = Dxx(u(x, y)) + Dyy(u(x, y)) ~ -sin(pi * x) * sin(pi * y)
 
         # Boundary conditions
-        bcs=[
-            u(0, y)~0.0,
-            u(1, y)~0.0,
-            u(x, 0)~0.0,
-            u(x, 1)~0.0
+        bcs = [
+            u(0, y) ~ 0.0,
+            u(1, y) ~ 0.0,
+            u(x, 0) ~ 0.0,
+            u(x, 1) ~ 0.0,
         ]
 
         # Space and time domains
-        domains=[x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
+        domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
 
-        ps=Lux.initialparameters(Random.default_rng(), chain)
+        ps = Lux.initialparameters(Random.default_rng(), chain)
 
-        discretization=PhysicsInformedNN(chain, strategy; init_params = ps)
+        discretization = PhysicsInformedNN(chain, strategy; init_params = ps)
         @named pde_system = PDESystem(eq, bcs, domains, [x, y], [u(x, y)])
-        prob=discretize(pde_system, discretization)
-        res=solve(prob, Adam(0.1); maxiters = 500, callback)
-        phi=discretization.phi
+        prob = discretize(pde_system, discretization)
+        res = solve(prob, Adam(0.1); maxiters = 500, callback)
+        phi = discretization.phi
 
-        xs, ys=[infimum(d.domain):0.01:supremum(d.domain) for d in domains]
-        analytic=(x, y)->(sinpi(x)*sinpi(y))/(2pi^2)
+        xs, ys = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
+        analytic = (x, y) -> (sinpi(x) * sinpi(y)) / (2pi^2)
 
-        u_predict=[first(phi([x, y], res.u)) for x in xs for y in ys]
-        u_real=[analytic(x, y) for x in xs for y in ys]
+        u_predict = [first(phi([x, y], res.u)) for x in xs for y in ys]
+        u_real = [analytic(x, y) for x in xs for y in ys]
 
-        @test u_predict≈u_real atol=2.0
+        @test u_predict ≈ u_real atol = 2.0
     end
 
-    chain=Chain(Dense(2, 12, σ), Dense(12, 12, σ), Dense(12, 1))
+    chain = Chain(Dense(2, 12, σ), Dense(12, 12, σ), Dense(12, 1))
 
     @testset "$(nameof(typeof(strategy)))" for strategy in strategies
         test_2d_poisson_equation(chain, strategy)
     end
 
-    algs=[CubatureJLp()]
+    algs = [CubatureJLp()]
     @testset "$(nameof(typeof(alg)))" for alg in algs
-        strategy = QuadratureTraining(quadrature_alg = alg, reltol = 1e-4,
-            abstol = 1e-3, maxiters = 30, batch = 10)
+        strategy = QuadratureTraining(
+            quadrature_alg = alg, reltol = 1.0e-4,
+            abstol = 1.0e-3, maxiters = 30, batch = 10
+        )
         test_2d_poisson_equation(chain, strategy)
     end
 end
 
-@testitem "PDE III: 3rd-order ODE" tags=[:nnpde1] setup=[NNPDE1TestSetup] begin
+@testitem "PDE III: 3rd-order ODE" tags = [:nnpde1] setup = [NNPDE1TestSetup] begin
     using Lux, Random, Optimisers, DomainSets, Cubature, QuasiMonteCarlo, Integrals
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
 
     @parameters x
     @variables u(..), Dxu(..), Dxxu(..), O1(..), O2(..)
-    Dxxx=Differential(x)^3
-    Dx=Differential(x)
+    Dxxx = Differential(x)^3
+    Dx = Differential(x)
 
     # ODE
-    eq=Dx(Dxxu(x))~cospi(x)
+    eq = Dx(Dxxu(x)) ~ cospi(x)
 
     # Initial and boundary conditions
-    bcs_=[
-        u(0.0)~0.0,
-        u(1.0)~cospi(1.0),
-        Dxu(1.0)~1.0
+    bcs_ = [
+        u(0.0) ~ 0.0,
+        u(1.0) ~ cospi(1.0),
+        Dxu(1.0) ~ 1.0,
     ]
-    ep=(cbrt(eps(eltype(Float64))))^2/6
+    ep = (cbrt(eps(eltype(Float64))))^2 / 6
 
-    der=[
-        Dxu(x)~Dx(u(x))+ep*O1(x),
-        Dxxu(x)~Dx(Dxu(x))+ep*O2(x)
+    der = [
+        Dxu(x) ~ Dx(u(x)) + ep * O1(x),
+        Dxxu(x) ~ Dx(Dxu(x)) + ep * O2(x),
     ]
 
-    bcs=[bcs_; der]
+    bcs = [bcs_; der]
 
     # Space and time domains
-    domains=[x ∈ Interval(0.0, 1.0)]
+    domains = [x ∈ Interval(0.0, 1.0)]
 
     # Neural network
-    chain=[[Chain(Dense(1, 12, tanh), Dense(12, 12, tanh), Dense(12, 1)) for _ in 1:3]
-           [Chain(Dense(1, 4, tanh), Dense(4, 1)) for _ in 1:2]]
-    quasirandom_strategy=QuasiRandomTraining(100; sampling_alg = LatinHypercubeSample())
+    chain = [
+        [Chain(Dense(1, 12, tanh), Dense(12, 12, tanh), Dense(12, 1)) for _ in 1:3]
+        [Chain(Dense(1, 4, tanh), Dense(4, 1)) for _ in 1:2]
+    ]
+    quasirandom_strategy = QuasiRandomTraining(100; sampling_alg = LatinHypercubeSample())
 
-    discretization=PhysicsInformedNN(chain, quasirandom_strategy)
+    discretization = PhysicsInformedNN(chain, quasirandom_strategy)
 
-    @named pde_system = PDESystem(eq, bcs, domains, [x],
-        [u(x), Dxu(x), Dxxu(x), O1(x), O2(x)])
+    @named pde_system = PDESystem(
+        eq, bcs, domains, [x],
+        [u(x), Dxu(x), Dxxu(x), O1(x), O2(x)]
+    )
 
-    prob=discretize(pde_system, discretization)
-    sym_prob=symbolic_discretize(pde_system, discretization)
+    prob = discretize(pde_system, discretization)
+    sym_prob = symbolic_discretize(pde_system, discretization)
 
-    pde_inner_loss_functions=sym_prob.loss_functions.pde_loss_functions
-    bcs_inner_loss_functions=sym_prob.loss_functions.bc_loss_functions
+    pde_inner_loss_functions = sym_prob.loss_functions.pde_loss_functions
+    bcs_inner_loss_functions = sym_prob.loss_functions.bc_loss_functions
 
-    callback=function (p, l)
-        if p.iter%100==0||p.iter==1
+    callback = function (p, l)
+        if p.iter % 100 == 0||p.iter == 1
             println("loss: ", l)
-            println("pde_losses: ", map(l_->l_(p.u), pde_inner_loss_functions))
-            println("bcs_losses: ", map(l_->l_(p.u), bcs_inner_loss_functions))
+            println("pde_losses: ", map(l_ -> l_(p.u), pde_inner_loss_functions))
+            println("bcs_losses: ", map(l_ -> l_(p.u), bcs_inner_loss_functions))
         end
         return false
     end
 
-    res=solve(prob, BFGS(); maxiters = 1000, callback)
-    phi=discretization.phi[1]
+    res = solve(prob, BFGS(); maxiters = 1000, callback)
+    phi = discretization.phi[1]
 
-    analytic_sol_func(x)=(π*x*(-x+(π^2)*(2*x-3)+1)-sin(π*x))/(π^3)
+    analytic_sol_func(x) = (π * x * (-x + (π^2) * (2 * x - 3) + 1) - sin(π * x)) / (π^3)
 
-    xs=[infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
-    u_real=[analytic_sol_func(x) for x in xs]
-    u_predict=[first(phi(x, res.u.depvar.u)) for x in xs]
+    xs = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
+    u_real = [analytic_sol_func(x) for x in xs]
+    u_predict = [first(phi(x, res.u.depvar.u)) for x in xs]
 
-    @test u_predict≈u_real atol=10^-4
+    @test u_predict ≈ u_real atol = 10^-4
 end
 
-@testitem "PDE IV: System of PDEs" tags=[:nnpde1] setup=[NNPDE1TestSetup] begin
+@testitem "PDE IV: System of PDEs" tags = [:nnpde1] setup = [NNPDE1TestSetup] begin
     using Lux, Random, Optimisers, DomainSets, Cubature, QuasiMonteCarlo, Integrals
     import DomainSets: Interval, infimum, supremum
 
     @parameters x, y
     @variables u1(..), u2(..)
-    Dx=Differential(x)
-    Dy=Differential(y)
+    Dx = Differential(x)
+    Dy = Differential(y)
 
     # System of pde
-    eqs=[
-        Dx(u1(x, y))+4*Dy(u2(x, y))~0,
-        Dx(u2(x, y))+9*Dy(u1(x, y))~0
+    eqs = [
+        Dx(u1(x, y)) + 4 * Dy(u2(x, y)) ~ 0,
+        Dx(u2(x, y)) + 9 * Dy(u1(x, y)) ~ 0,
     ]
 
     # Initial and boundary conditions
-    bcs=[
-        u1(x, 0)~2*x,
-        u2(x, 0)~3*x
+    bcs = [
+        u1(x, 0) ~ 2 * x,
+        u2(x, 0) ~ 3 * x,
     ]
 
     # Space and time domains
-    domains=[x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
+    domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
 
     # Neural network
-    chain1=Chain(Dense(2, 15, tanh), Dense(15, 1))
-    chain2=Chain(Dense(2, 15, tanh), Dense(15, 1))
+    chain1 = Chain(Dense(2, 15, tanh), Dense(15, 1))
+    chain2 = Chain(Dense(2, 15, tanh), Dense(15, 1))
 
-    quadrature_strategy=QuadratureTraining(quadrature_alg = CubatureJLh(),
-        reltol = 1e-3, abstol = 1e-3, maxiters = 50, batch = 100)
-    chain=[chain1, chain2]
+    quadrature_strategy = QuadratureTraining(
+        quadrature_alg = CubatureJLh(),
+        reltol = 1.0e-3, abstol = 1.0e-3, maxiters = 50, batch = 100
+    )
+    chain = [chain1, chain2]
 
-    discretization=PhysicsInformedNN(chain, quadrature_strategy)
+    discretization = PhysicsInformedNN(chain, quadrature_strategy)
 
     @named pde_system = PDESystem(eqs, bcs, domains, [x, y], [u1(x, y), u2(x, y)])
 
-    prob=discretize(pde_system, discretization)
+    prob = discretize(pde_system, discretization)
 
-    res=solve(prob, Adam(0.01); maxiters = 2000, callback)
-    phi=discretization.phi
+    res = solve(prob, Adam(0.01); maxiters = 2000, callback)
+    phi = discretization.phi
 
-    analytic_sol_func(x, y)=[1/3*(6x-y), 1/2*(6x-y)]
-    xs, ys=[infimum(d.domain):0.01:supremum(d.domain) for d in domains]
-    u_real=[[analytic_sol_func(x, y)[i] for x in xs for y in ys] for i in 1:2]
-    depvars=[:u1, :u2]
+    analytic_sol_func(x, y) = [1 / 3 * (6x - y), 1 / 2 * (6x - y)]
+    xs, ys = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
+    u_real = [[analytic_sol_func(x, y)[i] for x in xs for y in ys] for i in 1:2]
+    depvars = [:u1, :u2]
 
-    u_predict=[[phi[i]([x, y], res.u.depvar[depvars[i]])[1] for x in xs for y in ys]
-               for i in 1:2]
+    u_predict = [
+        [phi[i]([x, y], res.u.depvar[depvars[i]])[1] for x in xs for y in ys]
+            for i in 1:2
+    ]
 
-    @test u_predict[1]≈u_real[1] atol=0.3 norm=Base.Fix1(maximum, abs)
-    @test u_predict[2]≈u_real[2] atol=0.3 norm=Base.Fix1(maximum, abs)
+    @test u_predict[1] ≈ u_real[1] atol = 0.3 norm = Base.Fix1(maximum, abs)
+    @test u_predict[2] ≈ u_real[2] atol = 0.3 norm = Base.Fix1(maximum, abs)
 end
 
-@testitem "PDE V: 2D Wave Equation" tags=[:nnpde1] setup=[NNPDE1TestSetup] begin
+@testitem "PDE V: 2D Wave Equation" tags = [:nnpde1] setup = [NNPDE1TestSetup] begin
     using Lux, Random, Optimisers, DomainSets, Cubature, QuasiMonteCarlo, Integrals,
-          LineSearches, Integrals
+        LineSearches, Integrals
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
 
     @parameters x, t
     @variables u(..)
-    Dxx=Differential(x)^2
-    Dtt=Differential(t)^2
-    Dt=Differential(t)
+    Dxx = Differential(x)^2
+    Dtt = Differential(t)^2
+    Dt = Differential(t)
 
     # 2D PDE
-    C=1
-    eq=Dtt(u(x, t))~C^2*Dxx(u(x, t))
+    C = 1
+    eq = Dtt(u(x, t)) ~ C^2 * Dxx(u(x, t))
 
     # Initial and boundary conditions
-    bcs=[
-        u(0, t)~0.0,           # for all t > 0
-        u(1, t)~0.0,           # for all t > 0
-        u(x, 0)~x*(1.0-x), # for all 0 < x < 1
-        Dt(u(x, 0))~0.0        # for all  0 < x < 1]
+    bcs = [
+        u(0, t) ~ 0.0,           # for all t > 0
+        u(1, t) ~ 0.0,           # for all t > 0
+        u(x, 0) ~ x * (1.0 - x), # for all 0 < x < 1
+        Dt(u(x, 0)) ~ 0.0,        # for all  0 < x < 1]
     ]
 
     # Space and time domains
-    domains=[x ∈ Interval(0.0, 1.0),
-        t ∈ Interval(0.0, 1.0)]
+    domains = [
+        x ∈ Interval(0.0, 1.0),
+        t ∈ Interval(0.0, 1.0),
+    ]
     @named pde_system = PDESystem(eq, bcs, domains, [x, t], [u(x, t)])
 
     # Neural network
-    chain=Chain(Dense(2, 16, σ), Dense(16, 16, σ), Dense(16, 1))
-    phi=NeuralPDE.Phi(chain)
-    derivative=NeuralPDE.numeric_derivative
+    chain = Chain(Dense(2, 16, σ), Dense(16, 16, σ), Dense(16, 1))
+    phi = NeuralPDE.Phi(chain)
+    derivative = NeuralPDE.numeric_derivative
 
-    quadrature_strategy=QuadratureTraining(quadrature_alg = CubatureJLh(),
-        reltol = 1e-3, abstol = 1e-3, maxiters = 50, batch = 100)
+    quadrature_strategy = QuadratureTraining(
+        quadrature_alg = CubatureJLh(),
+        reltol = 1.0e-3, abstol = 1.0e-3, maxiters = 50, batch = 100
+    )
 
-    discretization=PhysicsInformedNN(chain, quadrature_strategy)
-    prob=discretize(pde_system, discretization)
+    discretization = PhysicsInformedNN(chain, quadrature_strategy)
+    prob = discretize(pde_system, discretization)
 
-    cb_=function (p, l)
+    cb_ = function (p, l)
         println("loss: ", l)
-        println("losses: ", map(l->l(p.u), loss_functions))
+        println("losses: ", map(l -> l(p.u), loss_functions))
         return false
     end
 
-    res=solve(prob, BFGS(linesearch = BackTracking()); maxiters = 500, callback)
+    res = solve(prob, BFGS(linesearch = BackTracking()); maxiters = 500, callback)
 
-    dx=0.1
-    xs, ts=[infimum(d.domain):dx:supremum(d.domain) for d in domains]
+    dx = 0.1
+    xs, ts = [infimum(d.domain):dx:supremum(d.domain) for d in domains]
     function analytic_sol_func(x, t)
-        sum([(8/(k^3*pi^3))*sin(k*pi*x)*cos(C*k*pi*t) for k in 1:2:50000])
+        sum([(8 / (k^3 * pi^3)) * sin(k * pi * x) * cos(C * k * pi * t) for k in 1:2:50000])
     end
 
-    u_predict=reshape([first(phi([x, t], res.u)) for x in xs for t in ts],
-        (length(xs), length(ts)))
-    u_real=reshape([analytic_sol_func(x, t) for x in xs for t in ts],
-        (length(xs), length(ts)))
-    @test u_predict≈u_real atol=0.1
+    u_predict = reshape(
+        [first(phi([x, t], res.u)) for x in xs for t in ts],
+        (length(xs), length(ts))
+    )
+    u_real = reshape(
+        [analytic_sol_func(x, t) for x in xs for t in ts],
+        (length(xs), length(ts))
+    )
+    @test u_predict ≈ u_real atol = 0.1
 end
 
-@testitem "PDE VI: PDE with mixed derivative" tags=[:nnpde1] setup=[NNPDE1TestSetup] begin
+@testitem "PDE VI: PDE with mixed derivative" tags = [:nnpde1] setup = [NNPDE1TestSetup] begin
     using Lux, Random, Optimisers, DomainSets, Cubature, QuasiMonteCarlo, Integrals
     import DomainSets: Interval, infimum, supremum
     using OptimizationOptimJL: BFGS
@@ -399,43 +430,43 @@ end
 
     @parameters x y
     @variables u(..)
-    Dxx=Differential(x)^2
-    Dyy=Differential(y)^2
-    Dx=Differential(x)
-    Dy=Differential(y)
+    Dxx = Differential(x)^2
+    Dyy = Differential(y)^2
+    Dx = Differential(x)
+    Dy = Differential(y)
 
-    eq=Dxx(u(x, y))+Dx(Dy(u(x, y)))-2*Dyy(u(x, y))~-1.0
+    eq = Dxx(u(x, y)) + Dx(Dy(u(x, y))) - 2 * Dyy(u(x, y)) ~ -1.0
 
     # Initial and boundary conditions
-    bcs=[
-        u(x, 0)~x,
-        Dy(u(x, 0))~x,
-        u(x, 0)~Dy(u(x, 0))
+    bcs = [
+        u(x, 0) ~ x,
+        Dy(u(x, 0)) ~ x,
+        u(x, 0) ~ Dy(u(x, 0)),
     ]
 
     # Space and time domains
-    domains=[x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
+    domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
 
-    strategy=StochasticTraining(2048)
-    inner=32
-    chain=Chain(Dense(2, inner, sigmoid), Dense(inner, inner, sigmoid), Dense(inner, 1))
+    strategy = StochasticTraining(2048)
+    inner = 32
+    chain = Chain(Dense(2, inner, sigmoid), Dense(inner, inner, sigmoid), Dense(inner, 1))
 
-    discretization=PhysicsInformedNN(chain, strategy)
+    discretization = PhysicsInformedNN(chain, strategy)
     @named pde_system = PDESystem(eq, bcs, domains, [x, y], [u(x, y)])
 
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, BFGS(); maxiters = 500, callback)
-    phi=discretization.phi
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, BFGS(); maxiters = 500, callback)
+    phi = discretization.phi
 
-    analytic_sol_func(x, y)=x+x*y+y^2/2
-    xs, ys=[infimum(d.domain):0.01:supremum(d.domain) for d in domains]
+    analytic_sol_func(x, y) = x + x * y + y^2 / 2
+    xs, ys = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
 
-    u_predict=[first(phi([x, y], res.u)) for x in xs for y in ys]
-    u_real=[analytic_sol_func(x, y) for x in xs for y in ys]
-    @test u_predict≈u_real rtol=0.1
+    u_predict = [first(phi([x, y], res.u)) for x in xs for y in ys]
+    u_real = [analytic_sol_func(x, y) for x in xs for y in ys]
+    @test u_predict ≈ u_real rtol = 0.1
 end
 
-@testitem "NNPDE: Translating from Flux" tags=[:nnpde1] setup=[NNPDE1TestSetup] begin
+@testitem "NNPDE: Translating from Flux" tags = [:nnpde1] setup = [NNPDE1TestSetup] begin
     using Lux, Random, Optimisers, DomainSets, Cubature, QuasiMonteCarlo, Integrals
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -443,27 +474,27 @@ end
 
     @parameters θ
     @variables u(..)
-    Dθ=Differential(θ)
-    eq=Dθ(u(θ))~θ^3+2*θ+(θ^2)*((1+3*(θ^2))/(1+θ+(θ^3)))-
-    u(θ)*(θ+((1+3*(θ^2))/(1+θ+θ^3)))
-    bcs=[u(0.0)~1.0]
-    domains=[θ ∈ Interval(0.0, 1.0)]
+    Dθ = Differential(θ)
+    eq = Dθ(u(θ)) ~ θ^3 + 2 * θ + (θ^2) * ((1 + 3 * (θ^2)) / (1 + θ + (θ^3))) -
+        u(θ) * (θ + ((1 + 3 * (θ^2)) / (1 + θ + θ^3)))
+    bcs = [u(0.0) ~ 1.0]
+    domains = [θ ∈ Interval(0.0, 1.0)]
 
-    chain=Flux.Chain(Flux.Dense(1, 12, Flux.σ), Flux.Dense(12, 1))
-    discretization=PhysicsInformedNN(chain, QuadratureTraining())
+    chain = Flux.Chain(Flux.Dense(1, 12, Flux.σ), Flux.Dense(12, 1))
+    discretization = PhysicsInformedNN(chain, QuadratureTraining())
     @test discretization.chain isa Lux.AbstractLuxLayer
 
     @named pde_system = PDESystem(eq, bcs, domains, [θ], [u])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, Adam(0.1); maxiters = 1000)
-    prob=remake(prob, u0 = res.u)
-    res=solve(prob, Adam(0.01); maxiters = 500)
-    prob=remake(prob, u0 = res.u)
-    res=solve(prob, Adam(0.001); maxiters = 500)
-    phi=discretization.phi
-    analytic_sol_func(t)=exp(-(t^2)/2)/(1+t+t^3)+t^2
-    ts=[infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
-    u_real=[analytic_sol_func(t) for t in ts]
-    u_predict=[first(phi(t, res.u)) for t in ts]
-    @test u_predict≈u_real atol=0.1
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, Adam(0.1); maxiters = 1000)
+    prob = remake(prob, u0 = res.u)
+    res = solve(prob, Adam(0.01); maxiters = 500)
+    prob = remake(prob, u0 = res.u)
+    res = solve(prob, Adam(0.001); maxiters = 500)
+    phi = discretization.phi
+    analytic_sol_func(t) = exp(-(t^2) / 2) / (1 + t + t^3) + t^2
+    ts = [infimum(d.domain):0.01:supremum(d.domain) for d in domains][1]
+    u_real = [analytic_sol_func(t) for t in ts]
+    u_predict = [first(phi(t, res.u)) for t in ts]
+    @test u_predict ≈ u_real atol = 0.1
 end

--- a/test/NN_SDE_tests.jl
+++ b/test/NN_SDE_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Test-1 solve & autodiff" tags=[:nnsde] begin
+@testitem "Test-1 solve & autodiff" tags = [:nnsde] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers
     using OptimizationOptimJL: BFGS
     Random.seed!(100)
@@ -15,22 +15,23 @@
     luxchain = Chain(Dense(dim, 16, σ), Dense(16, 16, σ), Dense(16, 1)) |> f64
 
     @testset "$(nameof(typeof(opt))) -- $(autodiff)" for opt in [BFGS(), Adam(0.1)],
-        autodiff in [false, true]
+            autodiff in [false, true]
 
         if autodiff
             @test_throws ArgumentError solve(
-                prob, NNSDE(luxchain, opt; autodiff); maxiters = 200, dt = 1 / 20.0f0)
+                prob, NNSDE(luxchain, opt; autodiff); maxiters = 200, dt = 1 / 20.0f0
+            )
             continue
         end
 
-        @testset for (dt, abstol) in [(1 / 20.0f0, 1e-10), (nothing, 1e-6)]
+        @testset for (dt, abstol) in [(1 / 20.0f0, 1.0e-10), (nothing, 1.0e-6)]
             kwargs = (; verbose = false, dt, abstol, maxiters = 200)
             sol = solve(prob, NNSDE(luxchain, opt; autodiff); kwargs...)
         end
     end
 end
 
-@testitem "Test-2 GBM SDE" tags=[:nnsde] begin
+@testitem "Test-2 GBM SDE" tags = [:nnsde] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers, DiffEqNoiseProcess, Distributions
     using OptimizationOptimJL: BFGS
     using MonteCarloMeasurements: Particles, pmean
@@ -48,7 +49,7 @@ end
     luxchain = Chain(Dense(dim, 16, σ), Dense(16, 16, σ), Dense(16, 1)) |> f64
 
     dt = 1 / 50.0f0
-    abstol = 1e-12
+    abstol = 1.0e-12
     autodiff = false
     kwargs = (; verbose = true, dt = dt, abstol, maxiters = 400)
     opt = BFGS()
@@ -56,13 +57,17 @@ end
 
     sol_2 = solve(
         prob, NNSDE(
-            luxchain, opt; autodiff, numensemble = numensemble, sub_batch = 10, batch = true);
-        kwargs...)
+            luxchain, opt; autodiff, numensemble = numensemble, sub_batch = 10, batch = true
+        );
+        kwargs...
+    )
 
     sol_1 = solve(
         prob, NNSDE(
-            luxchain, opt; autodiff, numensemble = numensemble, sub_batch = 1, batch = true);
-        kwargs...)
+            luxchain, opt; autodiff, numensemble = numensemble, sub_batch = 1, batch = true
+        );
+        kwargs...
+    )
 
     # sol_1 and sol_2 have same timespan
     ts = sol_1.timepoints
@@ -71,13 +76,16 @@ end
 
     analytic_sol(u0, p, t, W) = u0 * exp((α - β^2 / 2) * t + β * W)
     function W_kkl(t, z1, z2, z3)
-        √2 * (z1 * sin((1 - 1 / 2) * π * t) / ((1 - 1 / 2) * π) +
-         z2 * sin((2 - 1 / 2) * π * t) / ((2 - 1 / 2) * π) +
-         z3 * sin((3 - 1 / 2) * π * t) / ((3 - 1 / 2) * π))
+        √2 * (
+            z1 * sin((1 - 1 / 2) * π * t) / ((1 - 1 / 2) * π) +
+                z2 * sin((2 - 1 / 2) * π * t) / ((2 - 1 / 2) * π) +
+                z3 * sin((3 - 1 / 2) * π * t) / ((3 - 1 / 2) * π)
+        )
     end
     truncated_sol(
-        u0, t, z1, z2, z3) = u0 *
-                             exp((α - β^2 / 2) * t + β * W_kkl(t, z1, z2, z3))
+        u0, t, z1, z2, z3
+    ) = u0 *
+        exp((α - β^2 / 2) * t + β * W_kkl(t, z1, z2, z3))
 
     num_samples = 2000
     num_time_steps = dt
@@ -95,8 +103,10 @@ end
     end
 
     temp_rands = hcat(z1_samples, z2_samples, z3_samples)'
-    phi_inputs = [hcat([vcat(ts[j], temp_rands[:, i]) for j in eachindex(ts)]...)
-                  for i in 1:num_samples]
+    phi_inputs = [
+        hcat([vcat(ts[j], temp_rands[:, i]) for j in eachindex(ts)]...)
+            for i in 1:num_samples
+    ]
 
     analytic_solution_samples = Array{Float64}(undef, num_time_steps, num_samples)
     truncated_solution_samples = Array{Float64}(undef, num_time_steps, num_samples)
@@ -109,31 +119,42 @@ end
             analytic_solution_samples[i, j] = analytic_sol(u₀, 0, ts[i], W_samples[i, j])
 
             predicted_solution_samples_1[i, j] = sol_1.rode_solution.interp.phi(
-                phi_inputs[j][:, i], sol_1.rode_solution.interp.θ)
+                phi_inputs[j][:, i], sol_1.rode_solution.interp.θ
+            )
             predicted_solution_samples_2[i, j] = sol_2.rode_solution.interp.phi(
-                phi_inputs[j][:, i], sol_2.rode_solution.interp.θ)
+                phi_inputs[j][:, i], sol_2.rode_solution.interp.θ
+            )
 
             truncated_solution_samples[i, j] = truncated_sol(
-                u₀, ts[i], z1_samples[j], z2_samples[j], z3_samples[j])
+                u₀, ts[i], z1_samples[j], z2_samples[j], z3_samples[j]
+            )
         end
     end
 
     # strong ensemble solution tests
-    strong_analytic_solution = [Particles(analytic_solution_samples[i, :])
-                                for i in eachindex(ts)]
-    strong_truncated_solution = [Particles(truncated_solution_samples[i, :])
-                                 for i in eachindex(ts)]
-    strong_predicted_solution_1 = [Particles(predicted_solution_samples_1[i, :])
-                                   for i in eachindex(ts)]
-    strong_predicted_solution_2 = [Particles(predicted_solution_samples_2[i, :])
-                                   for i in eachindex(ts)]
+    strong_analytic_solution = [
+        Particles(analytic_solution_samples[i, :])
+            for i in eachindex(ts)
+    ]
+    strong_truncated_solution = [
+        Particles(truncated_solution_samples[i, :])
+            for i in eachindex(ts)
+    ]
+    strong_predicted_solution_1 = [
+        Particles(predicted_solution_samples_1[i, :])
+            for i in eachindex(ts)
+    ]
+    strong_predicted_solution_2 = [
+        Particles(predicted_solution_samples_2[i, :])
+            for i in eachindex(ts)
+    ]
 
     error_1 = sum(abs2, strong_analytic_solution .- strong_predicted_solution_1)
     error_2 = sum(abs2, strong_analytic_solution .- strong_predicted_solution_2)
     @test pmean(error_1) > pmean(error_2)
 
     @test pmean(sum(abs2.(strong_predicted_solution_1 .- strong_truncated_solution))) >
-          pmean(sum(abs2.(strong_predicted_solution_2 .- strong_truncated_solution)))
+        pmean(sum(abs2.(strong_predicted_solution_2 .- strong_truncated_solution)))
 
     # weak ensemble solution tests
     mean_analytic_solution = mean(analytic_solution_samples, dims = 2)
@@ -149,7 +170,7 @@ end
     MSE_1 = mean(abs2.(mean_analytic_solution .- pmean(u1)))
     MSE_2 = mean(abs2.(mean_analytic_solution .- pmean(u2)))
     @test MSE_2 < MSE_1
-    @test MSE_2 < 5e-2
+    @test MSE_2 < 5.0e-2
 
     error_1 = sum(abs2, mean_analytic_solution .- mean_predicted_solution_1)
     error_2 = sum(abs2, mean_analytic_solution .- mean_predicted_solution_2)
@@ -158,16 +179,16 @@ end
     MSE_1 = mean(abs2.(mean_analytic_solution .- mean_predicted_solution_1))
     MSE_2 = mean(abs2.(mean_analytic_solution .- mean_predicted_solution_2))
     @test MSE_2 < MSE_1
-    @test MSE_2 < 5e-2
+    @test MSE_2 < 5.0e-2
 
     @test mean(abs2.(mean_predicted_solution_1 .- mean_truncated_solution)) >
-          mean(abs2.(mean_predicted_solution_2 .- mean_truncated_solution))
-    @test mean(abs2.(mean_predicted_solution_1 .- mean_truncated_solution)) < 6e-1
-    @test mean(abs2.(mean_predicted_solution_2 .- mean_truncated_solution)) < 4e-2
+        mean(abs2.(mean_predicted_solution_2 .- mean_truncated_solution))
+    @test mean(abs2.(mean_predicted_solution_1 .- mean_truncated_solution)) < 6.0e-1
+    @test mean(abs2.(mean_predicted_solution_2 .- mean_truncated_solution)) < 4.0e-2
 end
 
 # Equation 65 from https://arxiv.org/abs/1804.04344
-@testitem "Test-3 Additive Noise Test Equation" tags=[:nnsde] begin
+@testitem "Test-3 Additive Noise Test Equation" tags = [:nnsde] begin
     using OrdinaryDiffEq, Random, Lux, Optimisers, DiffEqNoiseProcess, Distributions
     using OptimizationOptimJL: BFGS
     using MonteCarloMeasurements: Particles, pmean
@@ -183,10 +204,11 @@ end
     n_z = 6
     dim = 1 + n_z
     luxchain = Chain(
-        Dense(dim, 16, σ), Dense(16, 16, tanh), Dense(16, 16, σ), Dense(16, 1)) |> f64
+        Dense(dim, 16, σ), Dense(16, 16, tanh), Dense(16, 16, σ), Dense(16, 1)
+    ) |> f64
 
     dt = 1 / 50.0f0
-    abstol = 1e-7
+    abstol = 1.0e-7
     autodiff = false
     kwargs = (; verbose = true, dt = dt, abstol, maxiters = 300)
     opt = BFGS()
@@ -194,13 +216,17 @@ end
 
     sol_1 = solve(
         prob, NNSDE(
-            luxchain, opt; autodiff, numensemble = numensemble, sub_batch = 1, batch = true);
-        kwargs...)
+            luxchain, opt; autodiff, numensemble = numensemble, sub_batch = 1, batch = true
+        );
+        kwargs...
+    )
 
     sol_2 = solve(
         prob, NNSDE(
-            luxchain, opt; autodiff, numensemble = numensemble, sub_batch = 10, batch = true);
-        kwargs...)
+            luxchain, opt; autodiff, numensemble = numensemble, sub_batch = 10, batch = true
+        );
+        kwargs...
+    )
 
     # sol_1, sol_2 have the same timespan and are single output.
     ts = sol_1.timepoints
@@ -209,12 +235,14 @@ end
 
     analytic_sol(u0, p, t, W) = (u0 / sqrt(1 + t)) + (β * (t + α * W) / sqrt(1 + t))
     function W_kkl(t, z1, z2, z3, z4, z5, z6)
-        √2 * ((z1 * sin((1 - 1 / 2) * π * t) / ((1 - 1 / 2) * π)) +
-         (z2 * sin((2 - 1 / 2) * π * t) / ((2 - 1 / 2) * π)) +
-         (z3 * sin((3 - 1 / 2) * π * t) / ((3 - 1 / 2) * π)) +
-         (z4 * sin((4 - 1 / 2) * π * t) / ((4 - 1 / 2) * π)) +
-         (z5 * sin((5 - 1 / 2) * π * t) / ((5 - 1 / 2) * π)) +
-         (z6 * sin((6 - 1 / 2) * π * t) / ((6 - 1 / 2) * π)))
+        √2 * (
+            (z1 * sin((1 - 1 / 2) * π * t) / ((1 - 1 / 2) * π)) +
+                (z2 * sin((2 - 1 / 2) * π * t) / ((2 - 1 / 2) * π)) +
+                (z3 * sin((3 - 1 / 2) * π * t) / ((3 - 1 / 2) * π)) +
+                (z4 * sin((4 - 1 / 2) * π * t) / ((4 - 1 / 2) * π)) +
+                (z5 * sin((5 - 1 / 2) * π * t) / ((5 - 1 / 2) * π)) +
+                (z6 * sin((6 - 1 / 2) * π * t) / ((6 - 1 / 2) * π))
+        )
     end
     function truncated_sol(u0, t, z1, z2, z3, z4, z5, z6)
         (u0 / sqrt(1 + t)) + (β * (t + α * W_kkl(t, z1, z2, z3, z4, z5, z6)) / sqrt(1 + t))
@@ -239,9 +267,12 @@ end
     end
 
     temp_rands = hcat(
-        z1_samples, z2_samples, z3_samples, z4_samples, z5_samples, z6_samples)'
-    phi_inputs = [hcat([vcat(ts[j], temp_rands[:, i]) for j in eachindex(ts)]...)
-                  for i in 1:num_samples]
+        z1_samples, z2_samples, z3_samples, z4_samples, z5_samples, z6_samples
+    )'
+    phi_inputs = [
+        hcat([vcat(ts[j], temp_rands[:, i]) for j in eachindex(ts)]...)
+            for i in 1:num_samples
+    ]
 
     analytic_solution_samples = Array{Float64}(undef, num_time_steps, num_samples)
     truncated_solution_samples = Array{Float64}(undef, num_time_steps, num_samples)
@@ -254,25 +285,36 @@ end
             analytic_solution_samples[i, j] = analytic_sol(u₀, 0, ts[i], W_samples[i, j])
 
             predicted_solution_samples_1[i, j] = sol_1.rode_solution.interp.phi(
-                phi_inputs[j][:, i], sol_1.rode_solution.interp.θ)
+                phi_inputs[j][:, i], sol_1.rode_solution.interp.θ
+            )
             predicted_solution_samples_2[i, j] = sol_2.rode_solution.interp.phi(
-                phi_inputs[j][:, i], sol_2.rode_solution.interp.θ)
+                phi_inputs[j][:, i], sol_2.rode_solution.interp.θ
+            )
 
             truncated_solution_samples[i, j] = truncated_sol(
                 u₀, ts[i], z1_samples[j], z2_samples[j], z3_samples[j],
-                z4_samples[j], z5_samples[j], z6_samples[j])
+                z4_samples[j], z5_samples[j], z6_samples[j]
+            )
         end
     end
 
     # strong solution tests
-    strong_analytic_solution = [Particles(analytic_solution_samples[i, :])
-                                for i in eachindex(ts)]
-    strong_truncated_solution = [Particles(truncated_solution_samples[i, :])
-                                 for i in eachindex(ts)]
-    strong_predicted_solution_1 = [Particles(predicted_solution_samples_1[i, :])
-                                   for i in eachindex(ts)]
-    strong_predicted_solution_2 = [Particles(predicted_solution_samples_2[i, :])
-                                   for i in eachindex(ts)]
+    strong_analytic_solution = [
+        Particles(analytic_solution_samples[i, :])
+            for i in eachindex(ts)
+    ]
+    strong_truncated_solution = [
+        Particles(truncated_solution_samples[i, :])
+            for i in eachindex(ts)
+    ]
+    strong_predicted_solution_1 = [
+        Particles(predicted_solution_samples_1[i, :])
+            for i in eachindex(ts)
+    ]
+    strong_predicted_solution_2 = [
+        Particles(predicted_solution_samples_2[i, :])
+            for i in eachindex(ts)
+    ]
 
     error_1 = sum(abs2, strong_analytic_solution .- strong_predicted_solution_1)
     error_2 = sum(abs2, strong_analytic_solution .- strong_predicted_solution_2)
@@ -291,21 +333,21 @@ end
     # testing over different Z_i sample sizes
     MSE_1 = mean(abs2.(mean_analytic_solution .- pmean(u1)))
     MSE_2 = mean(abs2.(mean_analytic_solution .- pmean(u2)))
-    @test MSE_1 < 1e-4
-    @test MSE_2 < 8e-5
+    @test MSE_1 < 1.0e-4
+    @test MSE_2 < 8.0e-5
 
     error_1 = sum(abs2, mean_truncated_solution .- mean_predicted_solution_1)
     error_2 = sum(abs2, mean_truncated_solution .- mean_predicted_solution_2)
     @test error_1 > error_2
-    @test error_2 < 5e-3
+    @test error_2 < 5.0e-3
 
     MSE_1 = mean(abs2.(mean_truncated_solution .- mean_predicted_solution_1))
     MSE_2 = mean(abs2.(mean_truncated_solution .- mean_predicted_solution_2))
     @test MSE_2 < MSE_1
-    @test MSE_2 < 8e-5
+    @test MSE_2 < 8.0e-5
 end
 
-@testitem "Test-4 GBM SDE Inverse, weak & strong solving" tags=[:nnsde] begin
+@testitem "Test-4 GBM SDE Inverse, weak & strong solving" tags = [:nnsde] begin
     # Also works for brownian motion with constant drift.
     using OrdinaryDiffEq, Random, Lux, Optimisers, DiffEqNoiseProcess, Distributions
     using MonteCarloMeasurements: pmean, Particles
@@ -347,7 +389,8 @@ end
         for j in 1:num_samples
             # for each timepoint, pass each strong path's W value.
             analytic_solution_samples[i, j] = analytic_sol(
-                u₀, ideal_p, ts[i], W_samples[i, j])
+                u₀, ideal_p, ts[i], W_samples[i, j]
+            )
         end
     end
 
@@ -356,17 +399,21 @@ end
     dataset = [observed_process, ts]
 
     # solver configuration
-    abstol = 1e-12
+    abstol = 1.0e-12
     autodiff = false
     kwargs = (; verbose = true, dt = 1 / 50.0f0, abstol, maxiters = 700)
     opt = BFGS()
     numensemble = 100
 
     # for inverse problems more sub_batch leads to learning mainly the drift parameter
-    alg_1 = NNSDE(luxchain, opt; autodiff, numensemble = numensemble,
-        sub_batch = 1, batch = true, param_estim = true, strong_loss = true, dataset = dataset)
-    alg_2 = NNSDE(luxchain, opt; autodiff, numensemble = numensemble,
-        sub_batch = 1, batch = true, param_estim = true, strong_loss = false, dataset = dataset)
+    alg_1 = NNSDE(
+        luxchain, opt; autodiff, numensemble = numensemble,
+        sub_batch = 1, batch = true, param_estim = true, strong_loss = true, dataset = dataset
+    )
+    alg_2 = NNSDE(
+        luxchain, opt; autodiff, numensemble = numensemble,
+        sub_batch = 1, batch = true, param_estim = true, strong_loss = false, dataset = dataset
+    )
     sol_1 = solve(prob, alg_1; kwargs...)
     sol_2 = solve(prob, alg_2; kwargs...)
 
@@ -375,13 +422,15 @@ end
     u2 = sol_2.estimated_sol[1]
 
     function W_kkl(t, z1, z2, z3)
-        √2 * (z1 * sin((1 - 1 / 2) * π * t) / ((1 - 1 / 2) * π) +
-         z2 * sin((2 - 1 / 2) * π * t) / ((2 - 1 / 2) * π) +
-         z3 * sin((3 - 1 / 2) * π * t) / ((3 - 1 / 2) * π))
+        √2 * (
+            z1 * sin((1 - 1 / 2) * π * t) / ((1 - 1 / 2) * π) +
+                z2 * sin((2 - 1 / 2) * π * t) / ((2 - 1 / 2) * π) +
+                z3 * sin((3 - 1 / 2) * π * t) / ((3 - 1 / 2) * π)
+        )
     end
     function truncated_sol(u0, p, t, z1, z2, z3)
         u0 *
-        exp((p[1] - p[2]^2 / 2) * t + p[2] * W_kkl(t, z1, z2, z3))
+            exp((p[1] - p[2]^2 / 2) * t + p[2] * W_kkl(t, z1, z2, z3))
     end
 
     # testing dataset must be for the same timepoints as solution
@@ -396,8 +445,10 @@ end
     end
 
     temp_rands = hcat([randn(num_samples) for _ in 1:n_z]...)'
-    phi_inputs = [reduce(hcat, [vcat(ts[j], temp_rands[:, i]) for j in eachindex(ts)])
-                  for i in 1:num_samples]
+    phi_inputs = [
+        reduce(hcat, [vcat(ts[j], temp_rands[:, i]) for j in eachindex(ts)])
+            for i in 1:num_samples
+    ]
 
     analytic_solution_samples = Array{Float64}(undef, num_time_steps, num_samples)
     truncated_solution_samples = Array{Float64}(undef, num_time_steps, num_samples)
@@ -407,13 +458,16 @@ end
         for i in 1:num_time_steps
             # for each sample, pass each timepoints and get output
             analytic_solution_samples[i, j] = analytic_sol(
-                u₀, ideal_p, ts[i], W_samples[i, j])
+                u₀, ideal_p, ts[i], W_samples[i, j]
+            )
 
             predicted_solution_samples_2[i, j] = sol_2.rode_solution.interp.phi(
-                phi_inputs[j][:, i], sol_2.rode_solution.interp.θ)
+                phi_inputs[j][:, i], sol_2.rode_solution.interp.θ
+            )
 
             truncated_solution_samples[i, j] = truncated_sol(
-                u₀, ideal_p, ts[i], temp_rands[:, j]...)
+                u₀, ideal_p, ts[i], temp_rands[:, j]...
+            )
         end
     end
 
@@ -423,7 +477,7 @@ end
     mean_predicted_solution_2 = mean(predicted_solution_samples_2, dims = 2)
 
     # testing over different, same Z_i sample sizes
-    # relaxed tolerances for Julia pre and v1 in the below tests. 
+    # relaxed tolerances for Julia pre and v1 in the below tests.
     # All the below Tests pass for lts-Julia v1.10.10 with tolerances as < 5e-2.
     @test mean(abs2.(mean_analytic_solution .- pmean(u2))) < 0.16
     @test mean(abs2.(mean_analytic_solution .- mean_predicted_solution_2)) < 0.22
@@ -431,23 +485,31 @@ end
 
     # strong solution tests (sol_1)
     # get SDEPINN output at fixed path we solved over.
-    solution_1_strong_solve = reduce(vcat,
-        Base.Fix2(sol_1.rode_solution.interp.phi,
-            sol_1.rode_solution.interp.θ).(
-            collect.(sol_1.training_sets)))
+    solution_1_strong_solve = reduce(
+        vcat,
+        Base.Fix2(
+            sol_1.rode_solution.interp.phi,
+            sol_1.rode_solution.interp.θ
+        ).(
+            collect.(sol_1.training_sets)
+        )
+    )
 
     # get truncated solution on strong path over which training was done.
     truncatedsol_data_inputs = reduce(hcat, sol_1.training_sets)
-    truncated_solution_strong_paths = [truncated_sol(
-                                           u₀, ideal_p, truncatedsol_data_inputs[:, i]...)
-                                       for i in eachindex(ts)]
+    truncated_solution_strong_paths = [
+        truncated_sol(
+                u₀, ideal_p, truncatedsol_data_inputs[:, i]...
+            )
+            for i in eachindex(ts)
+    ]
 
-    @test mean(abs2, solution_1_strong_solve .- truncated_solution_strong_paths) < 5e-2
+    @test mean(abs2, solution_1_strong_solve .- truncated_solution_strong_paths) < 5.0e-2
 
     # estimated sde parameter tests (we trained with 15 observed solution paths).
     # absolute value taken for 2nd estimated parameter as loss for variance is independent of this parameter's direction.
-    @test sol_1.estimated_params[1] .≈ ideal_p[1] rtol=2e-1
-    @test abs(sol_1.estimated_params[2]) .≈ ideal_p[2] rtol=8e-2
-    @test sol_2.estimated_params[1] .≈ ideal_p[1] rtol=2e-1
-    @test abs(sol_2.estimated_params[2]) .≈ ideal_p[2] rtol=8e-2
+    @test sol_1.estimated_params[1] .≈ ideal_p[1] rtol = 2.0e-1
+    @test abs(sol_1.estimated_params[2]) .≈ ideal_p[2] rtol = 8.0e-2
+    @test sol_2.estimated_params[1] .≈ ideal_p[1] rtol = 2.0e-1
+    @test abs(sol_2.estimated_params[2]) .≈ ideal_p[2] rtol = 8.0e-2
 end

--- a/test/adaptive_loss_tests.jl
+++ b/test/adaptive_loss_tests.jl
@@ -1,10 +1,11 @@
 @testsetup module AdaptiveLossTestSetup
 using Optimization, OptimizationOptimisers, Random, DomainSets, Lux, NeuralPDE, Test,
-      TensorBoardLogger
+    TensorBoardLogger
 import DomainSets: Interval, infimum, supremum
 
 function solve_with_adaptive_loss(
-        adaptive_loss; haslogger = false, outdir = mktempdir(), run = 1)
+        adaptive_loss; haslogger = false, outdir = mktempdir(), run = 1
+    )
     logdir = joinpath(outdir, string(run))
     logger = haslogger ? TBLogger(logdir) : nothing
 
@@ -26,7 +27,7 @@ function solve_with_adaptive_loss(
         u(0, y) ~ 0.0,
         u(1, y) ~ -sinpi(1) * sinpi(y),
         u(x, 0) ~ 0.0,
-        u(x, 1) ~ -sinpi(x) * sinpi(1)
+        u(x, 1) ~ -sinpi(x) * sinpi(1),
     ]
 
     # Space and time domains
@@ -52,10 +53,14 @@ function solve_with_adaptive_loss(
                 u_predict = [first(phi([x, y], p.u)) for x in xs for y in ys]
                 total_diff = sum(abs, u_predict .- u_real)
                 log_value(logger, "outer_error/total_diff", total_diff, step = p.iter)
-                log_value(logger, "outer_error/total_diff_rel",
-                    total_diff / sum(abs2, u_real), step = p.iter)
-                log_value(logger, "outer_error/total_diff_sq",
-                    sum(abs2, u_predict .- u_real), step = p.iter)
+                log_value(
+                    logger, "outer_error/total_diff_rel",
+                    total_diff / sum(abs2, u_real), step = p.iter
+                )
+                log_value(
+                    logger, "outer_error/total_diff_sq",
+                    sum(abs2, u_predict .- u_real), step = p.iter
+                )
             end
         end
         return false
@@ -75,50 +80,56 @@ export solve_with_adaptive_loss
 
 end
 
-@testitem "2D Poisson: NonAdaptiveLoss" tags=[:adaptiveloss] setup=[AdaptiveLossTestSetup] begin
-    loss=NonAdaptiveLoss(pde_loss_weights = 1, bc_loss_weights = 1)
+@testitem "2D Poisson: NonAdaptiveLoss" tags = [:adaptiveloss] setup = [AdaptiveLossTestSetup] begin
+    loss = NonAdaptiveLoss(pde_loss_weights = 1, bc_loss_weights = 1)
 
-    tmpdir=mktempdir()
+    tmpdir = mktempdir()
 
-    total_diff_rel=solve_with_adaptive_loss(
-        loss; haslogger = false, outdir = tmpdir, run = 1)
+    total_diff_rel = solve_with_adaptive_loss(
+        loss; haslogger = false, outdir = tmpdir, run = 1
+    )
     @test total_diff_rel < 0.4
     @test length(readdir(tmpdir)) == 0
 
-    total_diff_rel=solve_with_adaptive_loss(
-        loss; haslogger = true, outdir = tmpdir, run = 2)
+    total_diff_rel = solve_with_adaptive_loss(
+        loss; haslogger = true, outdir = tmpdir, run = 2
+    )
     @test total_diff_rel < 0.4
     @test length(readdir(tmpdir)) == 1
 end
 
-@testitem "2D Poisson: GradientScaleAdaptiveLoss" tags=[:adaptiveloss] setup=[AdaptiveLossTestSetup] begin
-    loss=GradientScaleAdaptiveLoss(100, pde_loss_weights = 1e3, bc_loss_weights = 1)
+@testitem "2D Poisson: GradientScaleAdaptiveLoss" tags = [:adaptiveloss] setup = [AdaptiveLossTestSetup] begin
+    loss = GradientScaleAdaptiveLoss(100, pde_loss_weights = 1.0e3, bc_loss_weights = 1)
 
-    tmpdir=mktempdir()
+    tmpdir = mktempdir()
 
-    total_diff_rel=solve_with_adaptive_loss(
-        loss; haslogger = false, outdir = tmpdir, run = 1)
+    total_diff_rel = solve_with_adaptive_loss(
+        loss; haslogger = false, outdir = tmpdir, run = 1
+    )
     @test total_diff_rel < 0.4
     @test length(readdir(tmpdir)) == 0
 
-    total_diff_rel=solve_with_adaptive_loss(
-        loss; haslogger = true, outdir = tmpdir, run = 2)
+    total_diff_rel = solve_with_adaptive_loss(
+        loss; haslogger = true, outdir = tmpdir, run = 2
+    )
     @test total_diff_rel < 0.4
     @test length(readdir(tmpdir)) == 1
 end
 
-@testitem "2D Poisson: MiniMaxAdaptiveLoss" tags=[:adaptiveloss] setup=[AdaptiveLossTestSetup] begin
-    loss=MiniMaxAdaptiveLoss(100; pde_loss_weights = 1, bc_loss_weights = 1)
+@testitem "2D Poisson: MiniMaxAdaptiveLoss" tags = [:adaptiveloss] setup = [AdaptiveLossTestSetup] begin
+    loss = MiniMaxAdaptiveLoss(100; pde_loss_weights = 1, bc_loss_weights = 1)
 
-    tmpdir=mktempdir()
+    tmpdir = mktempdir()
 
-    total_diff_rel=solve_with_adaptive_loss(
-        loss; haslogger = false, outdir = tmpdir, run = 1)
+    total_diff_rel = solve_with_adaptive_loss(
+        loss; haslogger = false, outdir = tmpdir, run = 1
+    )
     @test total_diff_rel < 0.4
     @test length(readdir(tmpdir)) == 0
 
-    total_diff_rel=solve_with_adaptive_loss(
-        loss; haslogger = true, outdir = tmpdir, run = 2)
+    total_diff_rel = solve_with_adaptive_loss(
+        loss; haslogger = true, outdir = tmpdir, run = 2
+    )
     @test total_diff_rel < 0.4
     @test length(readdir(tmpdir)) == 1
 end

--- a/test/dgm_tests.jl
+++ b/test/dgm_tests.jl
@@ -1,6 +1,6 @@
-@testitem "Poisson's equation" tags=[:dgm] begin
+@testitem "Poisson's equation" tags = [:dgm] begin
     using ModelingToolkit, Optimization, OptimizationOptimisers, Distributions,
-          MethodOfLines, OrdinaryDiffEq, LinearAlgebra
+        MethodOfLines, OrdinaryDiffEq, LinearAlgebra
     import DomainSets: Interval, infimum, supremum
 
     @parameters x y
@@ -12,8 +12,10 @@
     eq = Dxx(u(x, y)) + Dyy(u(x, y)) ~ -sin(pi * x) * sin(pi * y)
 
     # Initial and boundary conditions
-    bcs = [u(0, y) ~ 0.0, u(1, y) ~ -sin(pi * 1) * sin(pi * y),
-        u(x, 0) ~ 0.0, u(x, 1) ~ -sin(pi * x) * sin(pi * 1)]
+    bcs = [
+        u(0, y) ~ 0.0, u(1, y) ~ -sin(pi * 1) * sin(pi * y),
+        u(x, 0) ~ 0.0, u(x, 1) ~ -sin(pi * x) * sin(pi * 1),
+    ]
     # Space and time domains
     domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
 
@@ -39,12 +41,12 @@
     u_predict = [first(phi([x, y], res.u)) for x in xs for y in ys]
     u_real = [analytic_sol_func(x, y) for x in xs for y in ys]
 
-    @test u_real≈u_predict atol=0.4
+    @test u_real ≈ u_predict atol = 0.4
 end
 
-@testitem "Black-Scholes PDE: European Call Option" tags=[:dgm] begin
+@testitem "Black-Scholes PDE: European Call Option" tags = [:dgm] begin
     using ModelingToolkit, Optimization, OptimizationOptimisers, Distributions,
-          MethodOfLines, OrdinaryDiffEq, LinearAlgebra
+        MethodOfLines, OrdinaryDiffEq, LinearAlgebra
     import DomainSets: Interval, infimum, supremum
 
     K, T, r, σ, S, S_multiplier = 50.0, 1.0, 0.05, 0.25, 130.0, 1.3
@@ -92,12 +94,12 @@ end
 
     u_real = [analytic_sol_func(t, x) for t in ts, x in xs]
     u_predict = [first(phi([t, x], res.u)) for t in ts, x in xs]
-    @test u_predict≈u_real rtol=0.05
+    @test u_predict ≈ u_real rtol = 0.05
 end
 
-@testitem "Burger's equation" tags=[:dgm] begin
+@testitem "Burger's equation" tags = [:dgm] begin
     using ModelingToolkit, Optimization, OptimizationOptimisers, Distributions,
-          MethodOfLines, OrdinaryDiffEq, LinearAlgebra
+        MethodOfLines, OrdinaryDiffEq, LinearAlgebra
     import DomainSets: Interval, infimum, supremum
 
     @parameters x t
@@ -112,7 +114,7 @@ end
     bcs = [
         u(0.0, x) ~ -sin(π * x),
         u(t, -1.0) ~ 0.0,
-        u(t, 1.0) ~ 0.0
+        u(t, 1.0) ~ 0.0,
     ]
 
     domains = [t ∈ Interval(0.0, 1.0), x ∈ Interval(-1.0, 1.0)]
@@ -147,5 +149,5 @@ end
 
     u_predict = [first(phi([t, x], res.u)) for t in ts, x in xs]
 
-    @test u_predict≈u_MOL rtol=0.1
+    @test u_predict ≈ u_MOL rtol = 0.1
 end

--- a/test/direct_function_tests.jl
+++ b/test/direct_function_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Approximation of function 1D" tags=[:nnpde2] begin
+@testitem "Approximation of function 1D" tags = [:nnpde2] begin
     using Optimization, OptimizationOptimisers, Random, DomainSets, Lux, Optimisers
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -32,10 +32,10 @@
     prob = remake(prob, u0 = res.u)
     res = solve(prob, BFGS(initial_stepnorm = 0.01), maxiters = 500)
 
-    @test discretization.phi(xs', res.u)≈func(xs') rtol=0.02
+    @test discretization.phi(xs', res.u) ≈ func(xs') rtol = 0.02
 end
 
-@testitem "Approximation of function 1D - 2" tags=[:nnpde2] begin
+@testitem "Approximation of function 1D - 2" tags = [:nnpde2] begin
     using Optimization, OptimizationOptimisers, Random, DomainSets, Lux, Optimisers
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -54,8 +54,10 @@ end
     domain = [x ∈ Interval(x0, x_end)]
 
     hidden = 20
-    chain = Chain(Dense(1, hidden, sin), Dense(hidden, hidden, sin),
-        Dense(hidden, hidden, sin), Dense(hidden, 1))
+    chain = Chain(
+        Dense(1, hidden, sin), Dense(hidden, hidden, sin),
+        Dense(hidden, hidden, sin), Dense(hidden, 1)
+    )
 
     strategy = GridTraining(0.01)
     discretization = PhysicsInformedNN(chain, strategy)
@@ -67,10 +69,10 @@ end
     dx = 0.01
     xs = collect(x0:dx:x_end)
     func_s = func(xs)
-    @test discretization.phi(xs', res.u)≈func(xs') rtol=0.02
+    @test discretization.phi(xs', res.u) ≈ func(xs') rtol = 0.02
 end
 
-@testitem "Approximation of function 2D" tags=[:nnpde2] begin
+@testitem "Approximation of function 2D" tags = [:nnpde2] begin
     using Optimization, OptimizationOptimisers, Random, DomainSets, Lux, Optimisers
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
@@ -91,8 +93,10 @@ end
     d = 0.4
     domain = [x ∈ Interval(x0, x_end), y ∈ Interval(y0, y_end)]
     hidden = 25
-    chain = Chain(Dense(2, hidden, tanh), Dense(hidden, hidden, tanh),
-        Dense(hidden, hidden, tanh), Dense(hidden, 1))
+    chain = Chain(
+        Dense(2, hidden, tanh), Dense(hidden, hidden, tanh),
+        Dense(hidden, hidden, tanh), Dense(hidden, 1)
+    )
     strategy = GridTraining(d)
     discretization = PhysicsInformedNN(chain, strategy)
     @named pde_system = PDESystem(eq, bc, domain, [x, y], [u(x, y)])
@@ -107,11 +111,13 @@ end
     phi = discretization.phi
     xs = collect(x0:0.1:x_end)
     ys = collect(y0:0.1:y_end)
-    u_predict = reshape([first(phi([x, y], res.u)) for x in xs for y in ys],
-        (length(xs), length(ys)))
+    u_predict = reshape(
+        [first(phi([x, y], res.u)) for x in xs for y in ys],
+        (length(xs), length(ys))
+    )
     u_real = reshape([func(x, y) for x in xs for y in ys], (length(xs), length(ys)))
     diff_u = abs.(u_predict .- u_real)
-    @test u_predict≈u_real rtol=0.05
+    @test u_predict ≈ u_real rtol = 0.05
 end
 
 @testitem "Trivial BC [0 ~ 0] fails for some training strategies" begin
@@ -142,11 +148,11 @@ end
     chain = Chain(Dense(1, 10, tanh), Dense(10, 10, tanh), Dense(10, 1))
 
     for strategy in (
-        GridTraining(0.01),
-        StochasticTraining(1000),
-        QuasiRandomTraining(1000),
-        QuadratureTraining()
-    )
+            GridTraining(0.01),
+            StochasticTraining(1000),
+            QuasiRandomTraining(1000),
+            QuadratureTraining(),
+        )
         discretization = PhysicsInformedNN(chain, strategy)
         @named pde_system = PDESystem(eq, bc, domain, [x], [u(x)])
         prob = discretize(pde_system, discretization)

--- a/test/forward_tests.jl
+++ b/test/forward_tests.jl
@@ -1,4 +1,4 @@
-@testitem "ODE" tags=[:forward] begin
+@testitem "ODE" tags = [:forward] begin
     using DomainSets, Lux, Random, Zygote, ComponentArrays, Adapt
 
     @parameters x
@@ -25,11 +25,14 @@
     dx = strategy_.dx
     eltypeθ = eltype(sym_prob.flat_init_params)
     depvars, indvars, dict_indvars,
-    dict_depvars, dict_depvar_input = NeuralPDE.get_vars(
-        pde_system.ivs, pde_system.dvs)
+        dict_depvars, dict_depvar_input = NeuralPDE.get_vars(
+        pde_system.ivs, pde_system.dvs
+    )
 
-    train_sets = generate_training_sets(domains, dx, eqs, bcs, eltypeθ,
-        dict_indvars, dict_depvars)
+    train_sets = generate_training_sets(
+        domains, dx, eqs, bcs, eltypeθ,
+        dict_indvars, dict_depvars
+    )
 
     pde_train_sets, bcs_train_sets = train_sets |> NeuralPDE.EltypeAdaptor{eltypeθ}()
     pde_train_sets = first(pde_train_sets)
@@ -38,15 +41,15 @@
     pde_loss_function = sym_prob.loss_functions.datafree_pde_loss_functions[1]
 
     dudx(x) = @. 2 * x
-    @test pde_loss_function(train_data, init_params)≈dudx(train_data) rtol=1e-8
+    @test pde_loss_function(train_data, init_params) ≈ dudx(train_data) rtol = 1.0e-8
 end
 
-@testitem "derivatives" tags=[:forward] begin
+@testitem "derivatives" tags = [:forward] begin
     using DomainSets, Lux, Random, Zygote, ComponentArrays
 
     chain = Chain(Dense(2, 16, σ), Dense(16, 16, σ), Dense(16, 1))
     init_params = Lux.initialparameters(Random.default_rng(), chain) |>
-                  ComponentArray{Float64}
+        ComponentArray{Float64}
 
     eltypeθ = eltype(init_params)
     phi = NeuralPDE.Phi(chain)
@@ -66,8 +69,8 @@ end
     dphi_y = derivative(phi, u_, [1.0, 2.0], [eps_y], 1, init_params)
 
     #first order derivatives
-    @test isapprox(dphi[1][1], dphi_x, atol = 1e-8)
-    @test isapprox(dphi[1][2], dphi_y, atol = 1e-8)
+    @test isapprox(dphi[1][1], dphi_x, atol = 1.0e-8)
+    @test isapprox(dphi[1][2], dphi_y, atol = 1.0e-8)
 
     eps_x = NeuralPDE.get_ε(2, 1, Float64, 2)
     eps_y = NeuralPDE.get_ε(2, 2, Float64, 2)
@@ -79,12 +82,12 @@ end
     dphi_yy = derivative(phi, u_, [1.0, 2.0], [eps_y, eps_y], 2, init_params)
 
     #second order derivatives
-    @test isapprox(hess_phi[1], dphi_xx, atol = 4e-5)
-    @test isapprox(hess_phi[2], dphi_xy, atol = 4e-5)
-    @test isapprox(hess_phi[4], dphi_yy, atol = 4e-5)
+    @test isapprox(hess_phi[1], dphi_xx, atol = 4.0e-5)
+    @test isapprox(hess_phi[2], dphi_xy, atol = 4.0e-5)
+    @test isapprox(hess_phi[4], dphi_yy, atol = 4.0e-5)
 end
 
-@testitem "Integral" tags=[:forward] begin
+@testitem "Integral" tags = [:forward] begin
     using DomainSets, Lux, Random, Zygote, ComponentArrays
 
     @parameters x
@@ -97,14 +100,16 @@ end
     init_params, st = Lux.setup(Random.default_rng(), chain)
     chain([1], init_params, st)
     strategy_ = GridTraining(0.1)
-    discretization = PhysicsInformedNN(chain, strategy_;
-        init_params = init_params)
+    discretization = PhysicsInformedNN(
+        chain, strategy_;
+        init_params = init_params
+    )
     @named pde_system = PDESystem(eq, bcs, domains, [x], [u(x)])
     sym_prob = symbolic_discretize(pde_system, discretization)
     prob = discretize(pde_system, discretization)
     inner_loss = sym_prob.loss_functions.datafree_pde_loss_functions[1]
     exact_u = π / (3 * sqrt(3))
-    @test inner_loss(ones(1, 1), init_params)[1]≈exact_u rtol=1e-5
+    @test inner_loss(ones(1, 1), init_params)[1] ≈ exact_u rtol = 1.0e-5
 
     #infinite intervals
     @parameters x
@@ -122,5 +127,5 @@ end
     prob = discretize(pde_system, discretization)
     inner_loss = sym_prob.loss_functions.datafree_pde_loss_functions[1]
     exact_u = 0
-    @test inner_loss(ones(1, 1), init_params)[1]≈exact_u atol=1e-13
+    @test inner_loss(ones(1, 1), init_params)[1] ≈ exact_u atol = 1.0e-13
 end

--- a/test/neural_adapter_tests.jl
+++ b/test/neural_adapter_tests.jl
@@ -10,205 +10,219 @@ export callback
 
 end
 
-@testitem "Neural Adapter: 2D Poisson" tags=[:neuraladapter] setup=[NeuralAdapterTestSetup] begin
+@testitem "Neural Adapter: 2D Poisson" tags = [:neuraladapter] setup = [NeuralAdapterTestSetup] begin
     using Optimization, Lux, OptimizationOptimisers, Statistics, ComponentArrays, Random,
-          LinearAlgebra
+        LinearAlgebra
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
 
     @parameters x y
     @variables u(..)
-    Dxx=Differential(x)^2
-    Dyy=Differential(y)^2
+    Dxx = Differential(x)^2
+    Dyy = Differential(y)^2
 
     # 2D PDE
-    eq=Dxx(u(x, y))+Dyy(u(x, y))~-sinpi(x)*sinpi(y)
+    eq = Dxx(u(x, y)) + Dyy(u(x, y)) ~ -sinpi(x) * sinpi(y)
 
     # Initial and boundary conditions
-    bcs=[
-        u(0, y)~0.0,
-        u(1, y)~-sinpi(1)*sinpi(y),
-        u(x, 0)~0.0,
-        u(x, 1)~-sinpi(x)*sinpi(1)
+    bcs = [
+        u(0, y) ~ 0.0,
+        u(1, y) ~ -sinpi(1) * sinpi(y),
+        u(x, 0) ~ 0.0,
+        u(x, 1) ~ -sinpi(x) * sinpi(1),
     ]
     # Space and time domains
-    domains=[x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
-    quadrature_strategy=QuadratureTraining(
-        reltol = 1e-3, abstol = 1e-6, maxiters = 50, batch = 100)
-    chain1=Chain(Dense(2, 8, tanh), Dense(8, 8, tanh), Dense(8, 1))
-    discretization=PhysicsInformedNN(chain1, quadrature_strategy)
+    domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
+    quadrature_strategy = QuadratureTraining(
+        reltol = 1.0e-3, abstol = 1.0e-6, maxiters = 50, batch = 100
+    )
+    chain1 = Chain(Dense(2, 8, tanh), Dense(8, 8, tanh), Dense(8, 1))
+    discretization = PhysicsInformedNN(chain1, quadrature_strategy)
 
     @named pde_system = PDESystem(eq, bcs, domains, [x, y], [u(x, y)])
-    prob=discretize(pde_system, discretization)
-    res=solve(prob, Adam(5e-3); callback, maxiters = 2000)
-    phi=discretization.phi
+    prob = discretize(pde_system, discretization)
+    res = solve(prob, Adam(5.0e-3); callback, maxiters = 2000)
+    phi = discretization.phi
 
-    xs, ys=[infimum(d.domain):0.01:supremum(d.domain) for d in domains]
-    analytic_sol_func(x, y)=(sinpi(x)*sinpi(y))/(2pi^2)
+    xs, ys = [infimum(d.domain):0.01:supremum(d.domain) for d in domains]
+    analytic_sol_func(x, y) = (sinpi(x) * sinpi(y)) / (2pi^2)
 
-    u_predict=[first(phi([x, y], res.u)) for x in xs for y in ys]
-    u_real=[analytic_sol_func(x, y) for x in xs for y in ys]
+    u_predict = [first(phi([x, y], res.u)) for x in xs for y in ys]
+    u_real = [analytic_sol_func(x, y) for x in xs for y in ys]
 
-    @test u_predict≈u_real atol=5e-2 norm=Base.Fix2(norm, Inf)
+    @test u_predict ≈ u_real atol = 5.0e-2 norm = Base.Fix2(norm, Inf)
 
-    chain2=Chain(Dense(2, 8, tanh), Dense(8, 8, tanh), Dense(8, 1))
-    initp, st=Lux.setup(Random.default_rng(), chain2)
-    init_params2=ComponentArray{Float64}(initp)
+    chain2 = Chain(Dense(2, 8, tanh), Dense(8, 8, tanh), Dense(8, 1))
+    initp, st = Lux.setup(Random.default_rng(), chain2)
+    init_params2 = ComponentArray{Float64}(initp)
 
-    loss(cord, θ)=first(chain2(cord, θ, st)) .- phi(cord, res.u)
+    loss(cord, θ) = first(chain2(cord, θ, st)) .- phi(cord, res.u)
 
-    grid_strategy=GridTraining(0.05)
-    quadrature_strategy=QuadratureTraining(
-        reltol = 1e-3, abstol = 1e-6, maxiters = 50, batch = 100)
-    stochastic_strategy=StochasticTraining(1000)
-    quasirandom_strategy=QuasiRandomTraining(1000, minibatch = 200, resampling = true)
+    grid_strategy = GridTraining(0.05)
+    quadrature_strategy = QuadratureTraining(
+        reltol = 1.0e-3, abstol = 1.0e-6, maxiters = 50, batch = 100
+    )
+    stochastic_strategy = StochasticTraining(1000)
+    quasirandom_strategy = QuasiRandomTraining(1000, minibatch = 200, resampling = true)
 
     @testset "$(nameof(typeof(strategy_)))" for strategy_ in [
-        grid_strategy, quadrature_strategy, stochastic_strategy, quasirandom_strategy]
+            grid_strategy, quadrature_strategy, stochastic_strategy, quasirandom_strategy,
+        ]
         prob_ = neural_adapter(loss, init_params2, pde_system, strategy_)
-        res_ = solve(prob_, Optimisers.Adam(5e-3); callback, maxiters = 2000)
+        res_ = solve(prob_, Optimisers.Adam(5.0e-3); callback, maxiters = 2000)
         discretization = PhysicsInformedNN(chain2, strategy_; init_params = res_.u)
         phi_ = discretization.phi
 
         u_predict_ = [first(phi_([x, y], res_.u)) for x in xs for y in ys]
-        @test u_predict_≈u_real atol=5e-2 norm=Base.Fix2(norm, Inf)
+        @test u_predict_ ≈ u_real atol = 5.0e-2 norm = Base.Fix2(norm, Inf)
     end
 end
 
-@testitem "Neural Adapter: 2D Poisson, domain decomposition" tags=[:neuraladapter] setup=[NeuralAdapterTestSetup] begin
+@testitem "Neural Adapter: 2D Poisson, domain decomposition" tags = [:neuraladapter] setup = [NeuralAdapterTestSetup] begin
     using Optimization, Lux, OptimizationOptimisers, Statistics, ComponentArrays, Random,
-          LinearAlgebra
+        LinearAlgebra
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
 
     @parameters x y
     @variables u(..)
-    Dxx=Differential(x)^2
-    Dyy=Differential(y)^2
+    Dxx = Differential(x)^2
+    Dyy = Differential(y)^2
 
-    eq=Dxx(u(x, y))+Dyy(u(x, y))~-sinpi(x)*sinpi(y)
+    eq = Dxx(u(x, y)) + Dyy(u(x, y)) ~ -sinpi(x) * sinpi(y)
 
-    bcs=[
-        u(0, y)~0.0,
-        u(1, y)~-sinpi(1)*sinpi(y),
-        u(x, 0)~0.0,
-        u(x, 1)~-sinpi(x)*sinpi(1)
+    bcs = [
+        u(0, y) ~ 0.0,
+        u(1, y) ~ -sinpi(1) * sinpi(y),
+        u(x, 0) ~ 0.0,
+        u(x, 1) ~ -sinpi(x) * sinpi(1),
     ]
 
     # Space
-    x_0, x_end=0.0, 1.0
-    x_domain=Interval(x_0, x_end)
-    y_domain=Interval(0.0, 1.0)
-    domains=[x ∈ x_domain, y ∈ y_domain]
-    count_decomp=10
+    x_0, x_end = 0.0, 1.0
+    x_domain = Interval(x_0, x_end)
+    y_domain = Interval(0.0, 1.0)
+    domains = [x ∈ x_domain, y ∈ y_domain]
+    count_decomp = 10
 
     # Neural network
-    chains=[Chain(Dense(2, 8, tanh), Dense(8, 8, tanh), Dense(8, 1))
-            for _ in 1:count_decomp]
+    chains = [
+        Chain(Dense(2, 8, tanh), Dense(8, 8, tanh), Dense(8, 1))
+            for _ in 1:count_decomp
+    ]
 
-    xs_=infimum(x_domain):(1 / count_decomp):supremum(x_domain)
-    xs_domain=[(xs_[i], xs_[i + 1]) for i in 1:(length(xs_) - 1)]
-    domains_map=map(xs_domain) do (xs_dom)
-        x_domain_=Interval(xs_dom...)
-        domains_=[x ∈ x_domain_, y ∈ y_domain]
+    xs_ = infimum(x_domain):(1 / count_decomp):supremum(x_domain)
+    xs_domain = [(xs_[i], xs_[i + 1]) for i in 1:(length(xs_) - 1)]
+    domains_map = map(xs_domain) do (xs_dom)
+        x_domain_ = Interval(xs_dom...)
+        domains_ = [x ∈ x_domain_, y ∈ y_domain]
     end
 
-    analytic_sol_func(x, y)=(sinpi(x)*sinpi(y))/(2pi^2)
+    analytic_sol_func(x, y) = (sinpi(x) * sinpi(y)) / (2pi^2)
     function create_bcs(x_domain_, phi_bound)
-        x_0, x_e=x_domain_.left, x_domain_.right
-        if x_0==0.0
-            bcs=[u(0, y)~0.0, u(x_e, y)~analytic_sol_func(x_e, y),
-                u(x, 0)~0.0, u(x, 1)~-sinpi(x)*sinpi(1)]
+        x_0, x_e = x_domain_.left, x_domain_.right
+        if x_0 == 0.0
+            bcs = [
+                u(0, y) ~ 0.0, u(x_e, y) ~ analytic_sol_func(x_e, y),
+                u(x, 0) ~ 0.0, u(x, 1) ~ -sinpi(x) * sinpi(1),
+            ]
             return bcs
         end
-        bcs=[u(x_0, y)~phi_bound(x_0, y), u(x_e, y)~analytic_sol_func(x_e, y),
-            u(x, 0)~0.0, u(x, 1)~-sinpi(x)*sinpi(1)]
+        bcs = [
+            u(x_0, y) ~ phi_bound(x_0, y), u(x_e, y) ~ analytic_sol_func(x_e, y),
+            u(x, 0) ~ 0.0, u(x, 1) ~ -sinpi(x) * sinpi(1),
+        ]
         bcs
     end
 
-    reses=[]
-    phis=[]
-    pde_system_map=[]
+    reses = []
+    phis = []
+    pde_system_map = []
 
     for i in 1:count_decomp
-        domains_=domains_map[i]
-        phi_in(cord)=phis[i - 1](cord, reses[i - 1].u)
-        phi_bound(x, y)=phi_in(vcat(x, y))
+        domains_ = domains_map[i]
+        phi_in(cord) = phis[i - 1](cord, reses[i - 1].u)
+        phi_bound(x, y) = phi_in(vcat(x, y))
         @register_symbolic phi_bound(x, y)
-        Base.Broadcast.broadcasted(::typeof(phi_bound), x, y)=phi_bound(x, y)
-        bcs_=create_bcs(domains_[1].domain, phi_bound)
+        Base.Broadcast.broadcasted(::typeof(phi_bound), x, y) = phi_bound(x, y)
+        bcs_ = create_bcs(domains_[1].domain, phi_bound)
         @named pde_system_ = PDESystem(eq, bcs_, domains_, [x, y], [u(x, y)])
         push!(pde_system_map, pde_system_)
 
-        strategy=GridTraining([0.1/count_decomp, 0.1])
-        discretization=PhysicsInformedNN(chains[i], strategy)
-        prob=discretize(pde_system_, discretization)
-        res_=solve(prob, Optimisers.Adam(5e-3); callback, maxiters = 2000)
-        phi=discretization.phi
+        strategy = GridTraining([0.1 / count_decomp, 0.1])
+        discretization = PhysicsInformedNN(chains[i], strategy)
+        prob = discretize(pde_system_, discretization)
+        res_ = solve(prob, Optimisers.Adam(5.0e-3); callback, maxiters = 2000)
+        phi = discretization.phi
 
         push!(reses, res_)
         push!(phis, phi)
     end
 
     function compose_result(dx)
-        u_predict_array=Float64[]
-        diff_u_array=Float64[]
-        ys=infimum(domains[2].domain):dx:supremum(domains[2].domain)
-        xs_=infimum(x_domain):dx:supremum(x_domain)
-        xs=collect(xs_)
+        u_predict_array = Float64[]
+        diff_u_array = Float64[]
+        ys = infimum(domains[2].domain):dx:supremum(domains[2].domain)
+        xs_ = infimum(x_domain):dx:supremum(x_domain)
+        xs = collect(xs_)
         function index_of_interval(x_)
             for (i, x_domain) in enumerate(xs_domain)
-                if x_<=x_domain[2]&&x_>=x_domain[1]
+                if x_ <= x_domain[2]&&x_ >= x_domain[1]
                     return i
                 end
             end
         end
         for x_ in xs
-            i=index_of_interval(x_)
-            u_predict_sub=[first(phis[i]([x_, y], reses[i].u)) for y in ys]
-            u_real_sub=[analytic_sol_func(x_, y) for y in ys]
-            diff_u_sub=u_predict_sub .- u_real_sub
+            i = index_of_interval(x_)
+            u_predict_sub = [first(phis[i]([x_, y], reses[i].u)) for y in ys]
+            u_real_sub = [analytic_sol_func(x_, y) for y in ys]
+            diff_u_sub = u_predict_sub .- u_real_sub
             append!(u_predict_array, u_predict_sub)
             append!(diff_u_array, diff_u_sub)
         end
-        xs, ys=[infimum(d.domain):dx:supremum(d.domain) for d in domains]
-        u_predict=reshape(u_predict_array, (length(xs), length(ys)))
-        diff_u=reshape(diff_u_array, (length(xs), length(ys)))
+        xs, ys = [infimum(d.domain):dx:supremum(d.domain) for d in domains]
+        u_predict = reshape(u_predict_array, (length(xs), length(ys)))
+        diff_u = reshape(diff_u_array, (length(xs), length(ys)))
         u_predict, diff_u
     end
 
-    dx=0.01
-    u_predict, diff_u=compose_result(dx)
+    dx = 0.01
+    u_predict, diff_u = compose_result(dx)
 
-    chain2=Chain(Dense(2, 18, tanh), Dense(18, 18, tanh), Dense(18, 18, tanh),
-        Dense(18, 18, tanh), Dense(18, 1))
+    chain2 = Chain(
+        Dense(2, 18, tanh), Dense(18, 18, tanh), Dense(18, 18, tanh),
+        Dense(18, 18, tanh), Dense(18, 1)
+    )
 
-    initp, st=Lux.setup(Random.default_rng(), chain2)
-    init_params2=ComponentArray{Float64}(initp)
+    initp, st = Lux.setup(Random.default_rng(), chain2)
+    init_params2 = ComponentArray{Float64}(initp)
 
     @named pde_system = PDESystem(eq, bcs, domains, [x, y], [u(x, y)])
 
-    losses=map(1:count_decomp) do i
-        loss(cord, θ)=first(chain2(cord, θ, st)) .- phis[i](cord, reses[i].u)
+    losses = map(1:count_decomp) do i
+        loss(cord, θ) = first(chain2(cord, θ, st)) .- phis[i](cord, reses[i].u)
     end
 
-    prob_=neural_adapter(
-        losses, init_params2, pde_system_map, GridTraining([0.1/count_decomp, 0.1]))
-    res_=solve(prob_, Adam(5e-3); callback, maxiters = 2000)
+    prob_ = neural_adapter(
+        losses, init_params2, pde_system_map, GridTraining([0.1 / count_decomp, 0.1])
+    )
+    res_ = solve(prob_, Adam(5.0e-3); callback, maxiters = 2000)
 
-    prob_=neural_adapter(losses, res_.u, pde_system_map, GridTraining(0.01))
-    res_=solve(prob_, Adam(5e-3); callback, maxiters = 2000)
+    prob_ = neural_adapter(losses, res_.u, pde_system_map, GridTraining(0.01))
+    res_ = solve(prob_, Adam(5.0e-3); callback, maxiters = 2000)
 
-    phi_=NeuralPDE.Phi(chain2)
-    xs, ys=[infimum(d.domain):dx:supremum(d.domain) for d in domains]
-    u_predict_=reshape(
-        [first(phi_([x, y], res_.u)) for x in xs for y in ys], (length(xs), length(ys)))
-    u_real=reshape(
-        [analytic_sol_func(x, y) for x in xs for y in ys], (length(xs), length(ys)))
-    diff_u_=u_predict_ .- u_real
+    phi_ = NeuralPDE.Phi(chain2)
+    xs, ys = [infimum(d.domain):dx:supremum(d.domain) for d in domains]
+    u_predict_ = reshape(
+        [first(phi_([x, y], res_.u)) for x in xs for y in ys], (length(xs), length(ys))
+    )
+    u_real = reshape(
+        [analytic_sol_func(x, y) for x in xs for y in ys], (length(xs), length(ys))
+    )
+    diff_u_ = u_predict_ .- u_real
 
-    @test u_predict≈u_real atol=5e-2 norm=Base.Fix2(norm, Inf)
-    @test u_predict_≈u_real atol=5e-2 norm=Base.Fix2(norm, Inf)
+    @test u_predict ≈ u_real atol = 5.0e-2 norm = Base.Fix2(norm, Inf)
+    @test u_predict_ ≈ u_real atol = 5.0e-2 norm = Base.Fix2(norm, Inf)
 end

--- a/test/qa_tests.jl
+++ b/test/qa_tests.jl
@@ -1,11 +1,11 @@
-@testitem "Aqua" tags=[:qa] begin
+@testitem "Aqua" tags = [:qa] begin
     using NeuralPDE, Aqua
 
     Aqua.test_all(NeuralPDE; ambiguities = false)
     Aqua.test_ambiguities(NeuralPDE, recursive = false)
 end
 
-@testitem "ExplicitImports" tags=[:qa] begin
+@testitem "ExplicitImports" tags = [:qa] begin
     using NeuralPDE, ExplicitImports
 
     @test check_no_implicit_imports(NeuralPDE) === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,16 +5,23 @@ using ReTestItems, InteractiveUtils, Hwloc
 const GROUP = lowercase(get(ENV, "GROUP", "all"))
 
 const RETESTITEMS_NWORKERS = parse(
-    Int, get(ENV, "RETESTITEMS_NWORKERS", string(min(Hwloc.num_physical_cores(), 4))))
-const RETESTITEMS_NWORKER_THREADS = parse(Int,
-    get(ENV, "RETESTITEMS_NWORKER_THREADS",
-        string(max(Hwloc.num_virtual_cores() ÷ RETESTITEMS_NWORKERS, 1))))
+    Int, get(ENV, "RETESTITEMS_NWORKERS", string(min(Hwloc.num_physical_cores(), 4)))
+)
+const RETESTITEMS_NWORKER_THREADS = parse(
+    Int,
+    get(
+        ENV, "RETESTITEMS_NWORKER_THREADS",
+        string(max(Hwloc.num_virtual_cores() ÷ RETESTITEMS_NWORKERS, 1))
+    )
+)
 
 using NeuralPDE
 
 @info "Running tests with $(RETESTITEMS_NWORKERS) workers and \
        $(RETESTITEMS_NWORKER_THREADS) threads for group $(GROUP)"
 
-ReTestItems.runtests(NeuralPDE; tags = (GROUP == "all" ? nothing : [Symbol(GROUP)]),
+ReTestItems.runtests(
+    NeuralPDE; tags = (GROUP == "all" ? nothing : [Symbol(GROUP)]),
     nworkers = RETESTITEMS_NWORKERS,
-    nworker_threads = RETESTITEMS_NWORKER_THREADS, testitem_timeout = 3600)
+    nworker_threads = RETESTITEMS_NWORKER_THREADS, testitem_timeout = 3600
+)


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)