### PR TITLE
Fix flaky Lorenz System test with deterministic seed

### DIFF
--- a/test/NNPDE2/additional_loss__lorenz_system.jl
+++ b/test/NNPDE2/additional_loss__lorenz_system.jl
@@ -7,6 +7,8 @@ using Test
     import DomainSets: Interval, infimum, supremum
     using OptimizationOptimJL: BFGS
 
+    Random.seed!(100)
+
     @parameters t, σ_, β, ρ
     @variables x(..), y(..), z(..)
     Dt = Differential(t)


### PR DESCRIPTION
## Summary
- Add `Random.seed!(100)` to the Lorenz System test to make neural network weight initialization deterministic
- This prevents intermittent BFGS convergence failures due to unlucky random initialization
- Consistent with other test items in the same file (e.g., `direct_function_tests.jl` already uses `Random.seed!`)

## Problem
The `Lorenz System` test in NNPDE2 group was failing intermittently on CI. On the Feb 2 master CI run, all 26 jobs passed except `Tests (1.11, NNPDE2)` which failed with:
```
Test Failed at test/additional_loss_tests.jl:185
  Expression: sum(abs2, p_[1] - 10.0) < 100000.0
   Evaluated: 3.1761180413083304e6 < 100000.0
```
The BFGS optimizer converged to a bad local minimum because the random neural network weight initialization was non-deterministic.

## Test plan
- [x] Verified locally: NNPDE2 test group passes (12/12 tests, 0 failures)
- [ ] CI should pass on all test groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)