### PR TITLE
Replace deprecated system variable accessors

### DIFF
--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -416,7 +416,7 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ab
 
     depvars, indvars, dict_indvars,
         dict_depvars, dict_depvar_input = get_vars(
-        pde_system.indvars, pde_system.depvars
+        get_ivs(pde_system), get_dvs(pde_system)
     )
 
     if init_params === nothing


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This PR addresses the following warnings that I was getting from NeuralPDE by replacing the deprecated accesses:

```
┌ Warning: `sys.indvars` is deprecated, please use `get_ivs(sys)`
│   caller = symbolic_discretize(pde_system::ModelingToolkitBase.PDESystem, discretization::NeuralPDE.PhysicsInformedNN{Vector{Boltz.Layers.MLP{Lux.Chain{@NamedTuple{block1::Lux.Dense{typeof(tanh), Int64, Int64, Nothing, Nothing, Static.True}, block2::Lux.Dense{typeof(tanh), Int64, Int64, Nothing, Nothing, Static.True}, block3::Lux.Dense{typeof(identity), Int64, Int64, Nothing, Nothing, Static.True}}, Nothing}}}, NeuralPDE.QuadratureTraining{Float64, Integrals.CubatureJLh}, Vector{@NamedTuple{block1::@NamedTuple{weight::Matrix{Float64}, bias::Vector{Float64}}, block2::@NamedTuple{weight::Matrix{Float64}, bias::Vector{Float64}}, block3::@NamedTuple{weight::Matrix{Float64}, bias::Vector{Float64}}}}, Vector{@NamedTuple{block1::@NamedTuple{}, block2::@NamedTuple{}, block3::@NamedTuple{}}}, Vector{NeuralPDE.Phi{LuxCore.StatefulLuxLayerImpl.StatefulLuxLayer{Val{true}, Boltz.Layers.MLP{Lux.Chain{@NamedTuple{block1::Lux.Dense{typeof(tanh), Int64, Int64, Nothing, Nothing, Static.True}, block2::Lux.Dense{typeof(tanh), Int64, Int64, Nothing, Nothing, Static.True}, block3::Lux.Dense{typeof(identity), Int64, Int64, Nothing, Nothing, Static.True}}, Nothing}}, Nothing, @NamedTuple{block1::@NamedTuple{}, block2::@NamedTuple{}, block3::@NamedTuple{}}}}}, typeof(NeuralPDE.numeric_derivative), Bool, Nothing, Nothing, Nothing, Base.RefValue{Int64}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}}) at discretize.jl:417
└ @ Core ~/.julia/packages/NeuralPDE/KbHbA/src/discretize.jl:417
┌ Warning: `sys.depvars` is deprecated, please use `get_dvs(sys)`
│   caller = symbolic_discretize(pde_system::ModelingToolkitBase.PDESystem, discretization::NeuralPDE.PhysicsInformedNN{Vector{Boltz.Layers.MLP{Lux.Chain{@NamedTuple{block1::Lux.Dense{typeof(tanh), Int64, Int64, Nothing, Nothing, Static.True}, block2::Lux.Dense{typeof(tanh), Int64, Int64, Nothing, Nothing, Static.True}, block3::Lux.Dense{typeof(identity), Int64, Int64, Nothing, Nothing, Static.True}}, Nothing}}}, NeuralPDE.QuadratureTraining{Float64, Integrals.CubatureJLh}, Vector{@NamedTuple{block1::@NamedTuple{weight::Matrix{Float64}, bias::Vector{Float64}}, block2::@NamedTuple{weight::Matrix{Float64}, bias::Vector{Float64}}, block3::@NamedTuple{weight::Matrix{Float64}, bias::Vector{Float64}}}}, Vector{@NamedTuple{block1::@NamedTuple{}, block2::@NamedTuple{}, block3::@NamedTuple{}}}, Vector{NeuralPDE.Phi{LuxCore.StatefulLuxLayerImpl.StatefulLuxLayer{Val{true}, Boltz.Layers.MLP{Lux.Chain{@NamedTuple{block1::Lux.Dense{typeof(tanh), Int64, Int64, Nothing, Nothing, Static.True}, block2::Lux.Dense{typeof(tanh), Int64, Int64, Nothing, Nothing, Static.True}, block3::Lux.Dense{typeof(identity), Int64, Int64, Nothing, Nothing, Static.True}}, Nothing}}, Nothing, @NamedTuple{block1::@NamedTuple{}, block2::@NamedTuple{}, block3::@NamedTuple{}}}}}, typeof(NeuralPDE.numeric_derivative), Bool, Nothing, Nothing, Nothing, Base.RefValue{Int64}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}}) at discretize.jl:417
└ @ Core ~/.julia/packages/NeuralPDE/KbHbA/src/discretize.jl:417
```