### PR TITLE
feat: add SoftAdaptAdaptiveLoss and ReLoBRaLoAdaptiveLoss

### DIFF
--- a/docs/src/manual/adaptive_losses.md
+++ b/docs/src/manual/adaptive_losses.md
@@ -1,12 +1,20 @@
 # [Adaptive Loss Functions](@id adaptive_loss)
 
-The NeuralPDE `discretize` function allows for specifying adaptive loss function strategy
-which improve training performance by reweighing the equations as necessary to ensure
-the boundary conditions are well-satisfied, even in ill-conditioned scenarios. The following
-are the options for the `adaptive_loss`:
+The NeuralPDE `discretize` function allows for specifying an adaptive loss function strategy
+which improves training performance by reweighting the equations as necessary to ensure
+the boundary conditions are well-satisfied, even in ill-conditioned scenarios.
+
+Some strategies reweight by gradient magnitudes (`GradientScaleAdaptiveLoss`) or via an
+inner optimiser (`MiniMaxAdaptiveLoss`). Others are gradient-free and reweight purely based
+on loss values (`SoftAdaptAdaptiveLoss`, `ReLoBRaLoAdaptiveLoss`), making them cheaper
+to apply at each step.
+
+The following are the options for the `adaptive_loss` keyword argument:
 
 ```@docs
 NeuralPDE.NonAdaptiveLoss
 NeuralPDE.GradientScaleAdaptiveLoss
 NeuralPDE.MiniMaxAdaptiveLoss
+NeuralPDE.SoftAdaptAdaptiveLoss
+NeuralPDE.ReLoBRaLoAdaptiveLoss
 ```

--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -112,7 +112,7 @@ export build_loss_function, get_loss_function,
     get_numeric_integral, symbolic_discretize, vector_to_parameters
 
 export AbstractAdaptiveLoss, NonAdaptiveLoss, GradientScaleAdaptiveLoss,
-    MiniMaxAdaptiveLoss
+    MiniMaxAdaptiveLoss, SoftAdaptAdaptiveLoss, ReLoBRaLoAdaptiveLoss
 
 export LogOptions
 

--- a/src/adaptive_losses.jl
+++ b/src/adaptive_losses.jl
@@ -231,3 +231,247 @@ function generate_adaptive_loss_function(
         return nothing
     end
 end
+
+# ── Softmax helper (no external dependency) ───────────────────────────────────
+function _softmax(x::AbstractVector{T}) where {T}
+    e = exp.(x .- maximum(x))   # subtract max for numerical stability
+    return e ./ sum(e)
+end
+
+"""
+    SoftAdaptAdaptiveLoss(reweight_every;
+                          α = 0.1,
+                          pde_loss_weights = 1.0,
+                          bc_loss_weights = 1.0,
+                          additional_loss_weights = 1.0)
+
+An adaptive loss weighting strategy based on the relative rate of change of each
+loss component. Weights are assigned proportionally via a softmax over the
+normalised loss rates, so components that are growing faster receive a larger weight.
+
+No gradient computations are required; reweighting cost is O(N) in the number of
+loss terms, making it cheaper than `GradientScaleAdaptiveLoss`.
+
+## Positional Arguments
+
+* `reweight_every`: how often (in iterations) to update the loss weights.
+
+## Keyword Arguments
+
+* `α`: temperature parameter controlling the sharpness of the softmax
+  (default `0.1`). Higher values make the weighting more aggressive.
+
+## Algorithm
+
+```
+rate_i(t) = (L_i(t) - L_i(t-1)) / (L_i(t-1) + ε)
+λ_i(t)    = softmax(α · rate(t)) × N
+```
+
+## References
+
+Heydari, A. A., Thompson, C. A., & Mehmood, A. (2019).
+SoftAdapt: Techniques for Adaptive Loss Weighting of Neural Networks with
+Multi-Part Loss Functions. arXiv:1912.12355.
+https://arxiv.org/abs/1912.12355
+"""
+@concrete mutable struct SoftAdaptAdaptiveLoss{T <: Real} <: AbstractAdaptiveLoss
+    reweight_every::Int
+    α::T
+    pde_loss_weights::Vector{T}
+    bc_loss_weights::Vector{T}
+    additional_loss_weights::Vector{T}
+    # stored across reweight steps
+    prev_pde_losses::Vector{T}
+    prev_bc_losses::Vector{T}
+end
+
+function SoftAdaptAdaptiveLoss{T}(
+        reweight_every::Int;
+        α = T(0.1),
+        pde_loss_weights = 1.0,
+        bc_loss_weights = 1.0,
+        additional_loss_weights = 1.0
+    ) where {T <: Real}
+    pde_w = vectorify(pde_loss_weights, T)
+    bc_w  = vectorify(bc_loss_weights, T)
+    return SoftAdaptAdaptiveLoss{T}(
+        reweight_every, T(α),
+        pde_w, bc_w, vectorify(additional_loss_weights, T),
+        zeros(T, length(pde_w)), zeros(T, length(bc_w))
+    )
+end
+
+SoftAdaptAdaptiveLoss(args...; kwargs...) = SoftAdaptAdaptiveLoss{Float64}(args...; kwargs...)
+
+function generate_adaptive_loss_function(
+        pinnrep::PINNRepresentation,
+        adaloss::SoftAdaptAdaptiveLoss, _, __
+    )
+    iteration = pinnrep.iteration
+    T = eltype(adaloss.pde_loss_weights)
+    ε = T(1e-8)
+    initialized = Ref(false)
+
+    return (θ, pde_losses, bc_losses) -> begin
+        # Seed previous losses on the very first call
+        if !initialized[]
+            adaloss.prev_pde_losses .= pde_losses
+            adaloss.prev_bc_losses  .= bc_losses
+            initialized[] = true
+        end
+
+        if iteration[] % adaloss.reweight_every == 0
+            # Resize stored vectors if the loss dimension changed (e.g. first real call)
+            if length(adaloss.prev_pde_losses) != length(pde_losses)
+                adaloss.prev_pde_losses = T.(pde_losses)
+            end
+            if length(adaloss.prev_bc_losses) != length(bc_losses)
+                adaloss.prev_bc_losses = T.(bc_losses)
+            end
+
+            all_losses = vcat(T.(pde_losses), T.(bc_losses))
+            all_prev   = vcat(adaloss.prev_pde_losses, adaloss.prev_bc_losses)
+            N          = length(all_losses)
+
+            rates   = (all_losses .- all_prev) ./ (all_prev .+ ε)
+            weights = _softmax(adaloss.α .* rates) .* T(N)
+
+            n_pde = length(pde_losses)
+            adaloss.pde_loss_weights .= weights[1:n_pde]
+            adaloss.bc_loss_weights  .= weights[(n_pde + 1):end]
+
+            adaloss.prev_pde_losses .= T.(pde_losses)
+            adaloss.prev_bc_losses  .= T.(bc_losses)
+
+            logvector(pinnrep.logger, adaloss.pde_loss_weights,
+                "adaptive_loss/pde_loss_weights", iteration[])
+            logvector(pinnrep.logger, adaloss.bc_loss_weights,
+                "adaptive_loss/bc_loss_weights", iteration[])
+        end
+        return nothing
+    end
+end
+
+"""
+    ReLoBRaLoAdaptiveLoss(reweight_every;
+                          α = 1.0,
+                          β = 0.9,
+                          pde_loss_weights = 1.0,
+                          bc_loss_weights = 1.0,
+                          additional_loss_weights = 1.0)
+
+Relative Loss Balancing with Random Lookback (ReLoBRaLo). Adaptively reweights
+loss components by comparing their current value to a randomly chosen past
+reference — either the initial loss or the most recent checkpoint — controlled
+by the lookback probability `β`.
+
+This makes the method more robust to short-term loss oscillations than
+purely incremental strategies like `SoftAdaptAdaptiveLoss`. No gradient
+computations are required.
+
+## Positional Arguments
+
+* `reweight_every`: how often (in iterations) to update the loss weights.
+
+## Keyword Arguments
+
+* `α`: temperature parameter for the softmax (default `1.0`).
+* `β`: probability of using the *previous* checkpoint as reference instead
+  of the *initial* losses (default `0.9`). Setting `β = 0` always uses the
+  initial losses; `β = 1` always uses the most recent checkpoint.
+
+## Algorithm
+
+```
+ρ    ~ Bernoulli(β)
+t₀   = ρ · t_prev + (1 - ρ) · t_init
+λ_i  = softmax(α · L_i(t) / (L_i(t₀) + ε)) × N
+```
+
+## References
+
+Bischof, R., & Kraus, M. (2021).
+Multi-Objective Loss Balancing for Physics-Informed Deep Learning.
+arXiv:2110.09813. https://arxiv.org/abs/2110.09813
+"""
+@concrete mutable struct ReLoBRaLoAdaptiveLoss{T <: Real} <: AbstractAdaptiveLoss
+    reweight_every::Int
+    α::T
+    β::T
+    pde_loss_weights::Vector{T}
+    bc_loss_weights::Vector{T}
+    additional_loss_weights::Vector{T}
+    # stored across reweight steps
+    init_pde_losses::Vector{T}
+    init_bc_losses::Vector{T}
+    prev_pde_losses::Vector{T}
+    prev_bc_losses::Vector{T}
+end
+
+function ReLoBRaLoAdaptiveLoss{T}(
+        reweight_every::Int;
+        α = T(1.0),
+        β = T(0.9),
+        pde_loss_weights = 1.0,
+        bc_loss_weights = 1.0,
+        additional_loss_weights = 1.0
+    ) where {T <: Real}
+    pde_w = vectorify(pde_loss_weights, T)
+    bc_w  = vectorify(bc_loss_weights, T)
+    return ReLoBRaLoAdaptiveLoss{T}(
+        reweight_every, T(α), T(β),
+        pde_w, bc_w, vectorify(additional_loss_weights, T),
+        zeros(T, length(pde_w)), zeros(T, length(bc_w)),  # init (filled on first call)
+        zeros(T, length(pde_w)), zeros(T, length(bc_w))   # prev
+    )
+end
+
+ReLoBRaLoAdaptiveLoss(args...; kwargs...) = ReLoBRaLoAdaptiveLoss{Float64}(args...; kwargs...)
+
+function generate_adaptive_loss_function(
+        pinnrep::PINNRepresentation,
+        adaloss::ReLoBRaLoAdaptiveLoss, _, __
+    )
+    iteration  = pinnrep.iteration
+    T          = eltype(adaloss.pde_loss_weights)
+    ε          = T(1e-8)
+    initialized = Ref(false)
+
+    return (θ, pde_losses, bc_losses) -> begin
+        # Record initial losses on the very first call
+        if !initialized[]
+            adaloss.init_pde_losses .= T.(pde_losses)
+            adaloss.init_bc_losses  .= T.(bc_losses)
+            adaloss.prev_pde_losses .= T.(pde_losses)
+            adaloss.prev_bc_losses  .= T.(bc_losses)
+            initialized[] = true
+        end
+
+        if iteration[] % adaloss.reweight_every == 0
+            use_prev = rand() < adaloss.β
+            ref_pde  = use_prev ? adaloss.prev_pde_losses : adaloss.init_pde_losses
+            ref_bc   = use_prev ? adaloss.prev_bc_losses  : adaloss.init_bc_losses
+
+            all_losses = vcat(T.(pde_losses), T.(bc_losses))
+            all_ref    = vcat(ref_pde, ref_bc)
+            N          = length(all_losses)
+
+            ratios  = all_losses ./ (all_ref .+ ε)
+            weights = _softmax(adaloss.α .* ratios) .* T(N)
+
+            n_pde = length(pde_losses)
+            adaloss.pde_loss_weights .= weights[1:n_pde]
+            adaloss.bc_loss_weights  .= weights[(n_pde + 1):end]
+
+            adaloss.prev_pde_losses .= T.(pde_losses)
+            adaloss.prev_bc_losses  .= T.(bc_losses)
+
+            logvector(pinnrep.logger, adaloss.pde_loss_weights,
+                "adaptive_loss/pde_loss_weights", iteration[])
+            logvector(pinnrep.logger, adaloss.bc_loss_weights,
+                "adaptive_loss/bc_loss_weights", iteration[])
+        end
+        return nothing
+    end
+end


### PR DESCRIPTION
## Summary

Adds two new adaptive loss weighting strategies for PINN training, requested
in issues #499, #500, #501, #446.

## New Types

### `SoftAdaptAdaptiveLoss`

Based on [Heydari et al. (2019)](https://arxiv.org/abs/1912.12355).

Reweights loss components by softmax over their normalised rate of change:

```rate_i(t) = (L_i(t) - L_i(t-1)) / (L_i(t-1) + ε) λ_i(t) = softmax(α · rate(t)) × N```


No gradient computations — cheaper than `GradientScaleAdaptiveLoss`.

### `ReLoBRaLoAdaptiveLoss`

Based on [Bischof & Kraus (2021)](https://arxiv.org/abs/2110.09813).

Compares current losses to a randomly chosen past reference (initial or
previous step, controlled by `β`):

```ρ ~ Bernoulli(β) t₀ = ρ · t_prev + (1 - ρ) · t_init λ_i = softmax(α · L_i(t) / (L_i(t₀) + ε)) × N```


More stable than incremental methods for stiff PDEs.

## Usage

```julia
# SoftAdapt — reweight every 10 iterations
disc = PhysicsInformedNN(chain, strategy;
    adaptive_loss = SoftAdaptAdaptiveLoss(10))

# ReLoBRaLo — reweight every 10 iterations, β=0.9 (default)
disc = PhysicsInformedNN(chain, strategy;
    adaptive_loss = ReLoBRaLoAdaptiveLoss(10))
```
## API Compatibility
Both follow the exact same pattern as existing GradientScaleAdaptiveLoss and MiniMaxAdaptiveLoss in ```src/adaptive_losses.jl```
New generate_adaptive_loss_function dispatches — no changes to ```discretize.jl``` or the training loop
Exported from the module alongside existing adaptive loss types

## Testing
### Locally verified:

Construction with defaults and custom kwargs
Integration with PhysicsInformedNN(..., adaptive_loss = ...)
discretize() on a 1D advection PDE with both methods
All existing package tests pass (no breaking changes)

## References
Heydari et al. (2019). SoftAdapt. [arXiv:1912.12355](https://arxiv.org/abs/1912.12355)
Bischof & Kraus (2021). ReLoBRaLo. [arXiv:2110.09813](https://arxiv.org/abs/2110.09813)