### PR TITLE
fix: update broken GitHub Actions CI badge (CI → Tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/NeuralPDE/stable/)
 
 [![codecov](https://codecov.io/gh/SciML/NeuralPDE.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/SciML/NeuralPDE.jl)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/SciML/NeuralPDE.jl/Tests.yml?branch=master&logo=github)](https://github.com/SciML/NeuralPDE.jl/actions/workflows/Tests.yml)
+[![Build Status](https://github.com/SciML/NeuralPDE.jl/workflows/Tests/badge.svg)](https://github.com/SciML/NeuralPDE.jl/actions?query=workflow%3ATests)
 [![Build status](https://badge.buildkite.com/fa31256f4b8a4f95fe5ab90c3bf4ef56055a2afe675435c182.svg?branch=master)](https://buildkite.com/julialang/neuralpde-dot-jl)
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/NeuralPDE/stable/)
 
 [![codecov](https://codecov.io/gh/SciML/NeuralPDE.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/SciML/NeuralPDE.jl)
-[![Build Status](https://github.com/SciML/NeuralPDE.jl/workflows/CI/badge.svg)](https://github.com/SciML/NeuralPDE.jl/actions?query=workflow%3ACI)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/SciML/NeuralPDE.jl/Tests.yml?branch=master&logo=github)](https://github.com/SciML/NeuralPDE.jl/actions/workflows/Tests.yml)
 [![Build status](https://badge.buildkite.com/fa31256f4b8a4f95fe5ab90c3bf4ef56055a2afe675435c182.svg?branch=master)](https://buildkite.com/julialang/neuralpde-dot-jl)
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)


### PR DESCRIPTION
## Description
The GitHub Actions CI badge was broken and showing no icon because the workflow 
was renamed from `CI` to `Tests.yml`. The old badge URL returns a 404.

<img width="368" height="183" alt="Screenshot 2026-05-05 at 4 04 38 AM" src="https://github.com/user-attachments/assets/98555860-b23a-4cd9-8aeb-a271a103cdc4" />


## Changes
- Updated the badge URL from the broken GitHub Actions SVG endpoint to shields.io
- Added `&logo=github` for consistency with the Buildkite badge which also has an icon
- No code, tests, or API changes involved — documentation-only fix

<img width="352" height="189" alt="Screenshot 2026-05-05 at 4 04 24 AM" src="https://github.com/user-attachments/assets/aeabfd65-1da5-4de7-8873-b91fe293b51f" />
