### PR TITLE
fix: update broken GitHub Actions CI badge (CI → Tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/NeuralPDE/stable/)
 
 [![codecov](https://codecov.io/gh/SciML/NeuralPDE.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/SciML/NeuralPDE.jl)
-[![Build Status](https://github.com/SciML/NeuralPDE.jl/workflows/CI/badge.svg)](https://github.com/SciML/NeuralPDE.jl/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/SciML/NeuralPDE.jl/workflows/Tests/badge.svg)](https://github.com/SciML/NeuralPDE.jl/actions?query=workflow%3ATests)
 [![Build status](https://badge.buildkite.com/fa31256f4b8a4f95fe5ab90c3bf4ef56055a2afe675435c182.svg?branch=master)](https://buildkite.com/julialang/neuralpde-dot-jl)
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)


### PR DESCRIPTION
The GitHub Actions CI badge was broken and showing no icon because the workflow 
was renamed from `CI` to `Tests.yml`. 

<img width="565" height="213" alt="Screenshot 2026-05-05 at 3 31 22 AM" src="https://github.com/user-attachments/assets/7f6a56d4-8669-41f9-a89f-495509ae1f42" />

Now Fixed.

<img width="373" height="193" alt="Screenshot 2026-05-05 at 4 16 05 AM" src="https://github.com/user-attachments/assets/0215e853-a199-42d0-891a-845ce4d51f16" />
