### PR TITLE
Restore PINOODE ODESolution call dispatches for AbstractArray t

### DIFF
--- a/src/pino_ode_solve.jl
+++ b/src/pino_ode_solve.jl
@@ -358,6 +358,24 @@ end
 SciMLBase.interp_summary(::PINOODEInterpolation) = "Trained neural network interpolation"
 SciMLBase.allowscomplex(::PINOODE) = true
 
+# SciMLBase only defines `(sol::AbstractODESolution)(t, ...)` for `t::Number` and
+# `t::AbstractVector{<:Number}`. PINO solutions are queried with parameter-and-time
+# arrays (e.g. `Matrix`), so add dispatches that forward to `sol.interp` for any
+# `AbstractArray` input when the solution was produced by `PINOODE`.
+function (sol::ODESolution{T, N, U, U2, D, T2, R, D2, P, A})(
+        t::AbstractArray, ::Type{deriv}, idxs::Nothing,
+        continuity
+    ) where {T, N, U, U2, D, T2, R, D2, P, A <: PINOODE, deriv}
+    return sol.interp(t, idxs, deriv, sol.prob.p, continuity)
+end
+
+function (sol::ODESolution{T, N, U, U2, D, T2, R, D2, P, A})(
+        t::AbstractVector{<:Number}, ::Type{deriv}, idxs::Nothing,
+        continuity
+    ) where {T, N, U, U2, D, T2, R, D2, P, A <: PINOODE, deriv}
+    return sol.interp(t, idxs, deriv, sol.prob.p, continuity)
+end
+
 function SciMLBase.__solve(
         prob::SciMLBase.AbstractODEProblem,
         alg::PINOODE,


### PR DESCRIPTION
> Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Master CI run [#25571392087](https://github.com/SciML/NeuralPDE.jl/actions/runs/25571392087) fails on the `Tests (1.11, PINOODE)` and `Tests (lts, PINOODE)` jobs with `MethodError: no method matching (::SciMLBase.ODESolution{...})(::Type{Val{0}}, ...)` from `test/PINO_ode_tests.jl:33` and `:75`.
- Root cause: commit 553e7293 (`Bump compat for OrdinaryDiffEq v7 / StochasticDiffEq v7 ecosystem`) deleted the `(sol::ODESolution{...,A<:PINOODE})(t, deriv, idxs::Nothing, continuity)` call overrides on the assumption that SciMLBase's `AbstractODESolution` call methods covered them. They don't: SciMLBase only defines the inner-stage `(sol)(t, deriv, idxs, continuity)` methods for `t::Number` and `t::AbstractVector{<:Number}`. PINO ODE solutions are queried with parameter-and-time **arrays** (e.g. `Matrix`), so `sol(t)` with `t::Matrix` hits a `MethodError` in both SciMLBase v2 and v3.
- Re-add the two narrow dispatches on `ODESolution{...,A<:PINOODE}` (one for `AbstractArray`, one for `AbstractVector{<:Number}` to disambiguate against SciMLBase's vector method) that forward to `sol.interp(t, idxs, deriv, sol.prob.p, continuity)`. The 10-leading-typevar parametric form still aligns with both v2 and v3 layouts (16 type parameters; `A` at position 10 = `alg`).

The GPU `Tests` job failure (resolver "empty intersection between NeuralPDE@6.0.0 and project compatibility 5") is a separate GPU-env-only compat issue and is **not** addressed here.

## Reproduction

```julia
using NeuralPDE, Lux, OptimizationOptimisers, NeuralOperators, Random
prob = ODEProblem((u, p, t) -> cos(p * t), 1.0, (0.0, 1.0))
chain = Chain(Dense(2 => 10, Lux.tanh_fast), Dense(10 => 10, Lux.tanh_fast), Dense(10 => 1))
alg = PINOODE(chain, OptimizationOptimisers.Adam(0.01), [(pi, 2pi)], 30;
              strategy = StochasticTraining(30))
sol = solve(prob, alg; verbose = false, maxiters = 50)
sol(rand(size(sol.prob.p)...))   # before: MethodError; after: ok
```

## Test plan

- [x] Reproduce the failure on master locally.
- [x] Apply fix; the standalone reproduction above now returns a `Matrix` instead of erroring.
- [x] Run `Pkg.test("NeuralPDE")` with `GROUP=PINOODE` locally; the previously failing test items "Example Chain du = cos(p * t)" and "Example DeepONet du = cos(p * t)" now pass.
- [ ] Wait for CI to confirm full PINOODE suite is green on Julia 1.11 and lts.