### PR TITLE
Refactor: PINOODE returns `PDETimeSeriesSolution` tagged with `PINOODEMetadata`

### DIFF
--- a/docs/src/tutorials/pino_ode.md
+++ b/docs/src/tutorials/pino_ode.md
@@ -43,7 +43,10 @@ opt = OptimizationOptimisers.Adam(0.03)
 # Define `PINNODE`
 alg = PINOODE(deeponet, opt, bounds, num_params; strategy = strategy)
 
-# Solve the ODE problem using the PINOODE algorithm
+# Solve the ODE problem using the PINOODE algorithm.
+# `sol` is a `PDETimeSeriesSolution` (the parameters are extra PDE
+# dimensions on top of `t`), not an `ODESolution`. The natural query
+# is `sol(p, t)` with `p` and `t` as arrays — see below.
 sol = solve(prob, alg, verbose = false, maxiters = 4000)
 ```
 

--- a/src/pino_ode_solve.jl
+++ b/src/pino_ode_solve.jl
@@ -358,6 +358,73 @@ end
 SciMLBase.interp_summary(::PINOODEInterpolation) = "Trained neural network interpolation"
 SciMLBase.allowscomplex(::PINOODE) = true
 
+"""
+    PINOODEMetadata(p_train)
+
+Discretization metadata for a `PINOODE` solve. Tags a
+`SciMLBase.PDETimeSeriesSolution` so the metadata-driven call dispatch
+forwards `(sol)(p, t)` and friends to the trained operator.
+
+Conceptually a `PINOODE` solve is a PDE solve whose independent
+variables are `(p_1, …, p_n, t)` — the parameters of the original ODE
+become extra PDE dimensions — so reusing `PDETimeSeriesSolution` with a
+PINO-specific metadata type is the natural fit. `hasTime` is `Val{true}`
+because `t` is one of the iv axes.
+"""
+struct PINOODEMetadata{P} <: SciMLBase.AbstractDiscretizationMetadata{Val{true}}
+    p_train::P
+end
+
+# Metadata-dispatched call: `(sol)(p, t)` is the natural PDE-style query.
+function (sol::SciMLBase.PDETimeSeriesSolution{T, N, S, <:PINOODEMetadata})(
+        p, t
+    ) where {T, N, S}
+    return sol.interp(p, t)
+end
+
+# Convenience: re-use the training-set `p` when only `t` is given.
+function (sol::SciMLBase.PDETimeSeriesSolution{T, N, S, <:PINOODEMetadata})(
+        t::AbstractArray
+    ) where {T, N, S}
+    return sol.interp(getfield(sol, :disc_data).p_train, t)
+end
+
+function (sol::SciMLBase.PDETimeSeriesSolution{T, N, S, <:PINOODEMetadata})(
+        t::Number
+    ) where {T, N, S}
+    return sol.interp(t, nothing, Val{0}, getfield(sol, :disc_data).p_train, nothing)
+end
+
+# `sol.p` -> training-set parameter tensor (was `sol.prob.p` in the old
+# `ODESolution` shim, where a fake `ODEProblem` had its `p` field
+# overridden with the sample tensor). `sol.original` -> the underlying
+# OptimizationSolution from training (PDETimeSeriesSolution stores it as
+# `original_sol`; the alias keeps the legacy `ODESolution`-style name
+# usable so call sites needn't churn).
+function Base.getproperty(
+        sol::SciMLBase.PDETimeSeriesSolution{T, N, S, <:PINOODEMetadata}, name::Symbol
+    ) where {T, N, S}
+    name === :p && return getfield(sol, :disc_data).p_train
+    name === :original && return getfield(sol, :original_sol)
+    return getfield(sol, name)
+end
+
+# Construct a PDETimeSeriesSolution tagged with PINOODEMetadata. Keeps
+# the explicit type-parameter splat out of `__solve`.
+function build_pinoode_solution(
+        u, original_sol, t, ivdomain, metadata::PINOODEMetadata,
+        prob, alg, interp, retcode
+    )
+    return SciMLBase.PDETimeSeriesSolution{
+        eltype(u), ndims(u), typeof(u), typeof(metadata), typeof(original_sol),
+        Nothing, typeof(t), typeof(ivdomain), Nothing, Nothing,
+        typeof(prob), typeof(alg), typeof(interp), Nothing,
+    }(
+        u, original_sol, nothing, t, ivdomain, nothing, nothing, metadata,
+        prob, alg, interp, true, 0, retcode, nothing
+    )
+end
+
 function SciMLBase.__solve(
         prob::SciMLBase.AbstractODEProblem,
         alg::PINOODE,
@@ -449,21 +516,10 @@ function SciMLBase.__solve(
     (p, t) = get_trainset(strategy, phi.smodel.model, bounds, number_of_parameters, tspan)
     interp = PINOODEInterpolation(phi, res.u)
     u = interp(p, t)
-    prob_sol = ODEProblem(f.f, u0, tspan, p)
+    metadata = PINOODEMetadata(p)
+    ivdomain = (bounds..., tspan)
 
-    sol = SciMLBase.build_solution(
-        prob_sol, alg, t, u;
-        k = res, dense = true,
-        interp = interp,
-        calculate_error = false,
-        retcode = ReturnCode.Success,
-        original = res,
-        resid = res.objective
+    return build_pinoode_solution(
+        u, res, t, ivdomain, metadata, prob, alg, interp, ReturnCode.Success
     )
-    SciMLBase.has_analytic(prob.f) &&
-        SciMLBase.calculate_solution_errors!(
-        sol; timeseries_errors = true,
-        dense_errors = false
-    )
-    return sol
 end

--- a/test/PINO_ode_tests.jl
+++ b/test/PINO_ode_tests.jl
@@ -32,6 +32,7 @@ end
 #Test Chain
 @testitem "Example Chain du = cos(p * t)" tags = [:pinoode] setup = [PINOODETestSetup] begin
     using NeuralPDE, Lux, OptimizationOptimisers, NeuralOperators, Random
+    using SciMLBase: SciMLBase, PDETimeSeriesSolution
     equation = (u, p, t) -> cos(p * t)
     tspan = (0.0, 1.0)
     u0 = 1.0
@@ -49,6 +50,19 @@ end
     opt = OptimizationOptimisers.Adam(0.01)
     alg = PINOODE(chain, opt, bounds, number_of_parameters; strategy = strategy)
     sol = solve(prob, alg, verbose = false, maxiters = 3000)
+
+    # Solution type contract: a `PINOODE` solve is a PDE solve where the
+    # ODE parameters are extra PDE dimensions, so the result is a
+    # `PDETimeSeriesSolution` tagged with `PINOODEMetadata` — *not* an
+    # `ODESolution`. `sol.prob` is the user's original ODEProblem, not a
+    # fake one with the parameter sample tensor stuffed in.
+    @test sol isa PDETimeSeriesSolution
+    @test sol isa SciMLBase.AbstractPDETimeSeriesSolution
+    @test !(sol isa SciMLBase.AbstractODESolution)
+    @test sol.prob === prob
+    @test sol.alg === alg
+    @test sol.retcode == SciMLBase.ReturnCode.Success
+
     ground_analytic = (u0, p, t) -> u0 + sin(p * t) / (p)
     p, t = get_trainset(chain, bounds, 50, tspan, 0.025)
     ground_solution = ground_analytic.(u0, p, t)
@@ -59,16 +73,19 @@ end
     predict_sol = sol.interp(p, t)
     @test ground_solution ≈ predict_sol rtol = 0.08
 
-    p = sol.prob.p
+    p = sol.p
     ground_solution = ground_analytic.(u0, p, [1.0])
     predict_sol = sol(1.0)
     @test ground_solution ≈ predict_sol rtol = 0.08
 
-    p = sol.prob.p
+    p = sol.p
     t = rand(size(p)...)
     ground_solution = ground_analytic.(u0, p, t)
     predict_sol = sol(t)
     @test ground_solution ≈ predict_sol rtol = 0.08
+
+    # Explicit PDE-style (p, t) call form.
+    @test sol(p, t) == predict_sol
 end
 
 #Test DeepONet
@@ -104,7 +121,7 @@ end
     @test ground_solution ≈ predict_sol rtol = 0.08
 
     # NeuralOperators 0.6+ requires 2D trunk input
-    p, t = sol.prob.p, rand(1, 20)
+    p, t = sol.p, rand(1, 20)
     ground_solution = ground_analytic.(u0, p, vec(t))
     predict_sol = sol(t)
     @test ground_solution ≈ predict_sol rtol = 0.08


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

Closes the silent breakage seen in SciML/OrdinaryDiffEq.jl#3613 / #1060 by stopping `PINOODE` from pretending to be an `ODESolution`.

## Reframing

A `PINOODE` solve is conceptually a *PDE* solve where the parameters of the original ODE become extra independent variables alongside `t` — the trained operator is a learned mapping `(p_1, …, p_n, t) → u`. There is no tabulated trajectory to interpolate, and the natural query is `(p, t)` with both as arrays, not the standard `(t::Number)` / `(t::Vector)` `ODESolution` interface.

The OrdinaryDiffEq v7 ecosystem bump (NeuralPDE commit 553e7293) removed the per-solver `(sol::ODESolution{…,A<:PINOODE})(t::AbstractArray, …)` overrides under the assumption that SciMLBase's `AbstractODESolution` call methods would cover them. They don't — SciMLBase only defines the inner-stage `(sol)(t, deriv, idxs, continuity)` methods for `t::Number` / `t::AbstractVector{<:Number}`. PINO solutions querying with parameter-and-time arrays (e.g. a 3-D `Array{Float64,3}`) have been hitting `MethodError` ever since.

## What changes

* New `struct PINOODEMetadata{P} <: SciMLBase.AbstractDiscretizationMetadata{Val{true}}` storing the parameter sample tensor used for training. `hasTime` is `Val{true}` because `t` remains one of the iv axes. This is the same discretizer-style metadata pattern MOL uses to tag `PDETimeSeriesSolution`.
* `__solve` returns `PDETimeSeriesSolution{…,<:PINOODEMetadata}` instead of `build_solution(ODESolution, …)`. Built via a small `build_pinoode_solution` helper to keep the explicit type-parameter splat out of `__solve`.
* Metadata-dispatched call interface — natural PDE-style query:
  - `sol(p, t)` — primary
  - `sol(t::AbstractArray)` — convenience, re-uses the training-set `p`
  - `sol(t::Number)` — convenience, scalar time
* `Base.getproperty` on `PDETimeSeriesSolution{…,<:PINOODEMetadata}` exposes two field aliases:
  - `sol.p` → `sol.disc_data.p_train` (was `sol.prob.p` in the old `ODESolution` shim).
  - `sol.original` → `sol.original_sol` (the `OptimizationSolution`; alias keeps the legacy `ODESolution`-style name working).
* `sol.prob` is now the user's *original* `ODEProblem` (no more fake remake with overridden `p`). `sol.alg` is the `PINOODE` algorithm.
* `PINOODESolution` is **not** exported as a new name — the concrete type is just `PDETimeSeriesSolution{…,<:PINOODEMetadata}`. Users dispatch on the metadata.

## Why not `AbstractOperatorSolution` in SciMLBase

I initially proposed adding a fresh non-array supertype upstream (SciMLBase #1352). After your reframing — \"a PINOODE is just a PDE solve, where parameters are other PDE dimensions\" — it became clear no SciMLBase change is needed: the existing `PDETimeSeriesSolution` + `AbstractDiscretizationMetadata{Val{true}}` machinery is exactly the right shape, with the metadata dispatching the call. SciMLBase #1351 (the `AbstractArray` band-aid) and #1352 (the new abstract type) have both been closed in favor of this PR.

## Test migration

* `sol.prob.p` → `sol.p` (3 sites in `test/PINO_ode_tests.jl`).
* Added a new typecheck block in the first test item asserting `sol isa PDETimeSeriesSolution`, `sol isa AbstractPDETimeSeriesSolution`, `!(sol isa AbstractODESolution)`, `sol.prob === prob`, `sol.alg === alg`, retcode, and an explicit `sol(p, t)` form check.
* Other call sites (`sol.interp(p, t)`, `sol(t)`, `sol(1.0)`, `sol.original.objective`) work unchanged via dispatch + getproperty aliases.

## Local validation

Trained a 50-iter Chain PINOODE in a fresh env on top of this branch and verified:
- Type contract: `isa PDETimeSeriesSolution`, `isa AbstractPDETimeSeriesSolution`, `!isa AbstractODESolution`.
- Field aliases (`sol.p`, `sol.original`) hit the right targets.
- Native fields (`sol.disc_data isa PINOODEMetadata`, `sol.ivdomain == (bounds..., tspan)`, `sol.t`, `sol.u`, `sol.interp`).
- Call interface: `sol(p, t)`, `sol(t::Matrix)`, `sol(1.0)`, `sol.interp(p, t)` all dispatch correctly and agree where they should.

Full PINOODE training tests (`GROUP=pinoode`) take a while in CI — running them locally is not practical. CI on this PR will exercise them.

## Test plan

- [x] Smoke training run + type/field/call assertions pass locally on a small Chain PINOODE.
- [ ] CI: `Tests (1.11, PINOODE)` and `Tests (lts, PINOODE)` go from red to green (these are the jobs that have been failing on master with `MethodError: no method matching (::SciMLBase.ODESolution{…,PINOODE,…})(::Type{Val{0}}, ::Array{Float64,3}, ::Nothing, ::Symbol)`).
- [ ] Tutorial doc note updated; no other docs touched.