### PR TITLE
Add CUDA Enzyme reverse-mode AD regression test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -121,6 +121,8 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Boltz = "4544d5e4-abc5-4dea-817f-29e4c205d9c8"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
@@ -140,4 +142,4 @@ TensorBoardLogger = "899adc3e-224a-11e9-021f-63837185c80f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AdvancedHMC", "Aqua", "Boltz", "CUDA", "DiffEqNoiseProcess", "ExplicitImports", "FastGaussQuadrature", "Flux", "Hwloc", "InteractiveUtils", "LineSearches", "LogDensityProblems", "LuxCUDA", "LuxCore", "LuxLib", "MCMCChains", "OptimizationOptimJL", "OrdinaryDiffEq", "ReTestItems", "StochasticDiffEq", "TensorBoardLogger", "Test"]
+test = ["AdvancedHMC", "Aqua", "Boltz", "CUDA", "DiffEqNoiseProcess", "DifferentiationInterface", "Enzyme", "ExplicitImports", "FastGaussQuadrature", "Flux", "Hwloc", "InteractiveUtils", "LineSearches", "LogDensityProblems", "LuxCUDA", "LuxCore", "LuxLib", "MCMCChains", "OptimizationOptimJL", "OrdinaryDiffEq", "ReTestItems", "StochasticDiffEq", "TensorBoardLogger", "Test"]

--- a/test/NNPDE_cuda_tests.jl
+++ b/test/NNPDE_cuda_tests.jl
@@ -227,3 +227,43 @@ end
 
     @test u_predict ≈ u_real rtol = 0.2
 end
+
+@testitem "Enzyme reverse-mode gradient - CUDA" tags = [:cuda] setup = [CUDATestSetup] begin
+    using Lux, Random, ComponentArrays, SciMLBase
+    import DomainSets: Interval
+    import DifferentiationInterface as DI
+    import Enzyme
+
+    Random.seed!(100)
+
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+    bcs = [u(0, x) ~ cos(x), u(t, 0) ~ exp(-t), u(t, 2π) ~ exp(-t)]
+    domains = [t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 2π)]
+    @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+
+    inner = 16
+    chain = Chain(
+        Dense(2, inner, σ), Dense(inner, inner, σ),
+        Dense(inner, inner, σ), Dense(inner, 1)
+    )
+    strategy = StochasticTraining(64)
+    ps, st = Lux.setup(Random.default_rng(), chain)
+    ps = ps |> ComponentArray |> gpud |> f64
+    st = st |> gpud |> f64
+
+    discretization = PhysicsInformedNN(chain, strategy; init_params = ps, init_states = st)
+    prob = discretize(pdesys, discretization)
+
+    f = Base.Fix2(prob.f.f, SciMLBase.NullParameters())
+    @test f(prob.u0) isa Real
+
+    backend = DI.AutoEnzyme(; function_annotation = Enzyme.Const)
+    g = DI.gradient(f, backend, prob.u0)
+    @test size(g) == size(prob.u0)
+    @test all(isfinite, Array(g))
+end


### PR DESCRIPTION
## Summary

- Adds a CUDA test (`@testitem "Enzyme reverse-mode gradient - CUDA"`) that builds a small PINN OptimizationProblem on GPU, wraps the loss as a `Base.Fix2` closure, and computes its gradient with DifferentiationInterface + Enzyme.
- Uses `AutoEnzyme(; function_annotation = Enzyme.Const)` because NeuralPDE's `full_loss_function` is a closure over non-differentiated machinery (`phi`, `derivative`, `integral`, `pinnrep`); without `Const`, Enzyme's activity analysis aborts with `EnzymeMutabilityException`.
- Adds `Enzyme` and `DifferentiationInterface` to test deps.

## Context

While investigating SciML/NeuralPDE.jl#1052 we found three independent AD failures (Zygote = GPU broadcast of n-arity `Zygote.accum`; Mooncake = missing rule for `CUDA.context`; Enzyme = activity-inference complaint on the loss closure). The Enzyme failure is the most easily worked around — exactly what this test pins.

⚠️ **Please ignore until reviewed by @ChrisRackauckas.** Opened as draft.

## Test plan

- [ ] GPU CI (`self-hosted, gpu-v100`, `GROUP=CUDA`) runs the new `@testitem`.
- [ ] The test should construct the loss, compute a finite gradient on the GPU, and pass on master.
- [ ] If Enzyme + CuArray combo surfaces additional issues, follow-up in this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)