### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,27 +11,16 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false  # Disabled: see https://github.com/SciML/NeuralPDE.jl/issues/1023
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         group:
           - NNPDE1
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,49 +7,17 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: PDESystemLibrary.jl, group: NeuralPDE}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      julia-version: "1"
+      julia-arch: "x64"
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.35.1 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/src/adaptive_losses.jl
+++ b/src/adaptive_losses.jl
@@ -294,7 +294,7 @@ function SoftAdaptAdaptiveLoss{T}(
         additional_loss_weights = 1.0
     ) where {T <: Real}
     pde_w = vectorify(pde_loss_weights, T)
-    bc_w  = vectorify(bc_loss_weights, T)
+    bc_w = vectorify(bc_loss_weights, T)
     return SoftAdaptAdaptiveLoss{T}(
         reweight_every, T(α),
         pde_w, bc_w, vectorify(additional_loss_weights, T),
@@ -310,14 +310,14 @@ function generate_adaptive_loss_function(
     )
     iteration = pinnrep.iteration
     T = eltype(adaloss.pde_loss_weights)
-    ε = T(1e-8)
+    ε = T(1.0e-8)
     initialized = Ref(false)
 
     return (θ, pde_losses, bc_losses) -> begin
         # Seed previous losses on the very first call
         if !initialized[]
             adaloss.prev_pde_losses .= pde_losses
-            adaloss.prev_bc_losses  .= bc_losses
+            adaloss.prev_bc_losses .= bc_losses
             initialized[] = true
         end
 
@@ -331,23 +331,27 @@ function generate_adaptive_loss_function(
             end
 
             all_losses = vcat(T.(pde_losses), T.(bc_losses))
-            all_prev   = vcat(adaloss.prev_pde_losses, adaloss.prev_bc_losses)
-            N          = length(all_losses)
+            all_prev = vcat(adaloss.prev_pde_losses, adaloss.prev_bc_losses)
+            N = length(all_losses)
 
-            rates   = (all_losses .- all_prev) ./ (all_prev .+ ε)
+            rates = (all_losses .- all_prev) ./ (all_prev .+ ε)
             weights = _softmax(adaloss.α .* rates) .* T(N)
 
             n_pde = length(pde_losses)
             adaloss.pde_loss_weights .= weights[1:n_pde]
-            adaloss.bc_loss_weights  .= weights[(n_pde + 1):end]
+            adaloss.bc_loss_weights .= weights[(n_pde + 1):end]
 
             adaloss.prev_pde_losses .= T.(pde_losses)
-            adaloss.prev_bc_losses  .= T.(bc_losses)
+            adaloss.prev_bc_losses .= T.(bc_losses)
 
-            logvector(pinnrep.logger, adaloss.pde_loss_weights,
-                "adaptive_loss/pde_loss_weights", iteration[])
-            logvector(pinnrep.logger, adaloss.bc_loss_weights,
-                "adaptive_loss/bc_loss_weights", iteration[])
+            logvector(
+                pinnrep.logger, adaloss.pde_loss_weights,
+                "adaptive_loss/pde_loss_weights", iteration[]
+            )
+            logvector(
+                pinnrep.logger, adaloss.bc_loss_weights,
+                "adaptive_loss/bc_loss_weights", iteration[]
+            )
         end
         return nothing
     end
@@ -418,7 +422,7 @@ function ReLoBRaLoAdaptiveLoss{T}(
         additional_loss_weights = 1.0
     ) where {T <: Real}
     pde_w = vectorify(pde_loss_weights, T)
-    bc_w  = vectorify(bc_loss_weights, T)
+    bc_w = vectorify(bc_loss_weights, T)
     return ReLoBRaLoAdaptiveLoss{T}(
         reweight_every, T(α), T(β),
         pde_w, bc_w, vectorify(additional_loss_weights, T),
@@ -433,44 +437,48 @@ function generate_adaptive_loss_function(
         pinnrep::PINNRepresentation,
         adaloss::ReLoBRaLoAdaptiveLoss, _, __
     )
-    iteration  = pinnrep.iteration
-    T          = eltype(adaloss.pde_loss_weights)
-    ε          = T(1e-8)
+    iteration = pinnrep.iteration
+    T = eltype(adaloss.pde_loss_weights)
+    ε = T(1.0e-8)
     initialized = Ref(false)
 
     return (θ, pde_losses, bc_losses) -> begin
         # Record initial losses on the very first call
         if !initialized[]
             adaloss.init_pde_losses .= T.(pde_losses)
-            adaloss.init_bc_losses  .= T.(bc_losses)
+            adaloss.init_bc_losses .= T.(bc_losses)
             adaloss.prev_pde_losses .= T.(pde_losses)
-            adaloss.prev_bc_losses  .= T.(bc_losses)
+            adaloss.prev_bc_losses .= T.(bc_losses)
             initialized[] = true
         end
 
         if iteration[] % adaloss.reweight_every == 0
             use_prev = rand() < adaloss.β
-            ref_pde  = use_prev ? adaloss.prev_pde_losses : adaloss.init_pde_losses
-            ref_bc   = use_prev ? adaloss.prev_bc_losses  : adaloss.init_bc_losses
+            ref_pde = use_prev ? adaloss.prev_pde_losses : adaloss.init_pde_losses
+            ref_bc = use_prev ? adaloss.prev_bc_losses : adaloss.init_bc_losses
 
             all_losses = vcat(T.(pde_losses), T.(bc_losses))
-            all_ref    = vcat(ref_pde, ref_bc)
-            N          = length(all_losses)
+            all_ref = vcat(ref_pde, ref_bc)
+            N = length(all_losses)
 
-            ratios  = all_losses ./ (all_ref .+ ε)
+            ratios = all_losses ./ (all_ref .+ ε)
             weights = _softmax(adaloss.α .* ratios) .* T(N)
 
             n_pde = length(pde_losses)
             adaloss.pde_loss_weights .= weights[1:n_pde]
-            adaloss.bc_loss_weights  .= weights[(n_pde + 1):end]
+            adaloss.bc_loss_weights .= weights[(n_pde + 1):end]
 
             adaloss.prev_pde_losses .= T.(pde_losses)
-            adaloss.prev_bc_losses  .= T.(bc_losses)
+            adaloss.prev_bc_losses .= T.(bc_losses)
 
-            logvector(pinnrep.logger, adaloss.pde_loss_weights,
-                "adaptive_loss/pde_loss_weights", iteration[])
-            logvector(pinnrep.logger, adaloss.bc_loss_weights,
-                "adaptive_loss/bc_loss_weights", iteration[])
+            logvector(
+                pinnrep.logger, adaloss.pde_loss_weights,
+                "adaptive_loss/pde_loss_weights", iteration[]
+            )
+            logvector(
+                pinnrep.logger, adaloss.bc_loss_weights,
+                "adaptive_loss/bc_loss_weights", iteration[]
+            )
         end
         return nothing
     end


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

This PR migrates the CI to the centralized SciML reusable workflows (all pinned `@v1`, every caller gets `secrets: "inherit"`), preserving existing matrices and behavior.

## Converted (inline -> central caller)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade -> `downgrade.yml@v1` (kept the `if: false` disable from #1023, preserved `group: NNPDE1`, `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`)
- **Downstream.yml** (`IntegrationTest`): inline -> matrix of `downstream.yml@v1` callers (preserved `SciML/PDESystemLibrary.jl` group `NeuralPDE`)

## Left as-is
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"` — unchanged.
- **GPU.yml**: unchanged. The CUDA-tests and Documentation jobs run on a self-hosted `[self-hosted, gpu-v100]` runner and the docs job sets `DATADEPS_ALWAYS_ACCEPT`. The centralized callers route self-hosted jobs to a single `self-hosted` label and cannot express the `gpu-v100` label nor the extra env, so converting would not faithfully preserve behavior. Because GPU.yml already builds/deploys the docs on GPU, no separate `documentation.yml@v1` caller was added (it would run on ubuntu and fail without a GPU).
- **TagBot.yml**: unchanged.

## Other
- **dependabot.yml**: removed the `crate-ci/typos` version ignore (typos is now centrally pinned); kept `github-actions` weekly and `julia` daily (group `all-julia-packages: ["*"]`, dirs `/`, `/docs`, `/test`).
- No `CompatHelper.yml` present.

## Formatting / spelling
- Runic: applied — reformatted `src/adaptive_losses.jl` (alignment + multiline call wrapping + `1e-8` -> `1.0e-8`).
- Typos: 0 fixed (already clean; repo has `.typos.toml`).

## Heads-up
Job/check names change with the move to reusable workflows (e.g. `Runic Format Check`, `Spell Check with Typos`, `Downstream Tests - NeuralPDE`, `Downgrade Tests - NNPDE1`). **Branch-protection required-status-check names will need updating** to match the new check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)