### PR TITLE
ci: drop removed allow-reresolve input from central downgrade caller

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -22,5 +22,4 @@ jobs:
       julia-version: "1.10"
       group: "${{ matrix.group }}"
       skip: "Pkg,TOML"
-      allow-reresolve: false
     secrets: "inherit"


### PR DESCRIPTION
## Summary

The reusable workflow `SciML/.github/.github/workflows/downgrade.yml@v1` was retagged and **no longer exposes an `allow-reresolve` input**. The downgrade caller in `.github/workflows/Downgrade.yml` still passes `allow-reresolve: false` in its `with:` block, which now fails the downgrade job with an unexpected-input error.

This PR removes only that one line. The central workflow already hardcodes `allow_reresolve: false` on its `julia-runtest` step, so behavior is unchanged.

## Diff

```diff
       skip: "Pkg,TOML"
-      allow-reresolve: false
     secrets: "inherit"
```

`git show --stat` is a single line removal in `.github/workflows/Downgrade.yml` (1 file changed, 1 deletion).

---

**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)