### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,32 +19,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1.11"
-          - "lts"
-        group:
-          - "QA"
-          - "ODEBPINN"
-          - "PDEBPINN"
-          - "NNSDE1"
-          - "NNSDE2"
-          - "NNPDE1"
-          - "NNPDE2"
-          - "AdaptiveLoss"
-          - "Forward"
-          - "DGM"
-          - "NNODE"
-          - "PINOODE"
-          - "NeuralAdapter"
-          - "IntegroDiff"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
-      coverage-directories: "src,ext"
-      julia-runtest-depwarn: "yes"  # TensorBoardLogger has a global depwarn
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,41 @@
+[QA]
+versions = ["1.11", "lts"]
+
+[ODEBPINN]
+versions = ["1.11", "lts"]
+
+[PDEBPINN]
+versions = ["1.11", "lts"]
+
+[NNSDE1]
+versions = ["1.11", "lts"]
+
+[NNSDE2]
+versions = ["1.11", "lts"]
+
+[NNPDE1]
+versions = ["1.11", "lts"]
+
+[NNPDE2]
+versions = ["1.11", "lts"]
+
+[AdaptiveLoss]
+versions = ["1.11", "lts"]
+
+[Forward]
+versions = ["1.11", "lts"]
+
+[DGM]
+versions = ["1.11", "lts"]
+
+[NNODE]
+versions = ["1.11", "lts"]
+
+[PINOODE]
+versions = ["1.11", "lts"]
+
+[NeuralAdapter]
+versions = ["1.11", "lts"]
+
+[IntegroDiff]
+versions = ["1.11", "lts"]


### PR DESCRIPTION
## Summary

Converts the root `Tests.yml` workflow to the canonical **thin caller** of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, moving the hand-maintained `group × version` matrix into a new **root `test/test_groups.toml`**.

The test job becomes:

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    secrets: "inherit"
```

`on:` triggers, `concurrency:`, the filename (`Tests.yml`) and the `name: "Tests"` are all preserved verbatim so branch-protection status checks keep matching. All other workflow files (Downgrade, Downstream, GPU, FormatCheck, SpellCheck, TagBot, etc.) are left untouched.

## Matrix match

The previous in-YAML matrix was 14 groups × `{1.11, lts}` = **28 cells** (all `ubuntu-latest`, no `continue-on-error`). The new `test/test_groups.toml` lists each group on `["1.11", "lts"]`, and `compute_affected_sublibraries.jl --root-matrix` reproduces the old set exactly:

**28/28 exact** (same groups, same versions, all `ubuntu-latest`, `continue_on_error=false`).

Groups: QA, ODEBPINN, PDEBPINN, NNSDE1, NNSDE2, NNPDE1, NNPDE2, AdaptiveLoss, Forward, DGM, NNODE, PINOODE, NeuralAdapter, IntegroDiff.

## No `with:` overrides needed

The old caller's explicit settings all match `grouped-tests.yml` defaults, so the caller carries no `with:` block:

- `runtests.jl` reads the standard `GROUP` env var → default `group-env-name: GROUP`.
- `coverage-directories: "src,ext"` → default.
- coverage enabled → default.
- `check-bounds` was unset (old `tests.yml` default `yes`) → new default `yes`.
- No `apt-packages`, no `check-bounds: auto`, coverage not disabled.

(The old caller set `julia-runtest-depwarn: "yes"`, which equals the default the underlying `tests.yml` uses regardless, so depwarn=yes behavior is preserved.)

Linux-only: no `os` field added (default `ubuntu-latest`).

## Category A notes

`runtests.jl` already had `Core`/group dispatch via `GROUP`, and the `QA` group (Aqua + ExplicitImports in `test/qa_tests.jl`) already exists upstream, so **no `runtests.jl` change** and **no local Aqua run** were required — static matrix verification only. The pre-existing Aqua/ExplicitImports exclusions in `qa_tests.jl` are upstream's and were not modified.

## QA

n/a — QA group already present and unchanged; no QA exclusions added or removed.

---

Ignore until reviewed by @ChrisRackauckas.