### PR TITLE
docs: qualify LineSearches.BackTracking in nonlinear_hyperbolic example

### DIFF
--- a/docs/src/examples/nonlinear_hyperbolic.md
+++ b/docs/src/examples/nonlinear_hyperbolic.md
@@ -101,7 +101,8 @@ callback = function (p, l)
     return false
 end
 
-res = Optimization.solve(prob, BFGS(linesearch = BackTracking()); maxiters = 200, callback)
+res = Optimization.solve(
+    prob, BFGS(linesearch = LineSearches.BackTracking()); maxiters = 200, callback)
 
 phi = discretization.phi
 


### PR DESCRIPTION
## Problem

The `Documentation` CI job on `master` fails when building `docs/src/examples/nonlinear_hyperbolic.md`:

```
failed to run `@example` block in docs/src/examples/nonlinear_hyperbolic.md:35-124
  exception = UndefVarError: `BackTracking` not defined in `Main.__atexample__named__nonlinear_hyperbolic`
  Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity.
    - Also exported by NonlinearSolve (loaded but not imported in Main).
  Hint: a global variable of this name also exists in LineSearches.
```

This example is the **only** docs page that imports both `NonlinearSolve` (needed for `IntervalNonlinearProblem`/`ITP` in the analytic-solution root solve) and `LineSearches` (needed for `BackTracking`). Both packages now export `BackTracking`, so the bare `BackTracking()` reference is ambiguous and resolves to nothing → `UndefVarError`, which aborts the build (and cascades `ps not defined` into later blocks). All other docs pages import only `LineSearches`, so they are unaffected.

## Fix

Qualify the reference as `LineSearches.BackTracking()`, matching the intended line search. `BackTracking` is the only name exported by both `NonlinearSolve` and `LineSearches`, so no other references in the example need qualifying.

## Verification

Reproduced and verified the fix locally on Julia 1.10 in a fresh env with `NonlinearSolve` + `LineSearches`:

```
NonlinearSolve exports BackTracking? true
LineSearches exports BackTracking?   true
--- bare BackTracking() ---
WARNING: both LineSearches and NonlinearSolve export "BackTracking"; uses of it in module Main must be qualified
bare FAILED: UndefVarError: `BackTracking` not defined
--- qualified LineSearches.BackTracking() (the fix) ---
LineSearches.BackTracking() OK
```

This is a docs-only change (markdown `@example` block); it does not affect Runic/JuliaFormatter checks.

## Scope

This PR fixes only the `Documentation` job. Other `master` CI failures (QA Aqua method ambiguity from the recent PINOODE→`PDETimeSeriesSolution` refactor, and the NNODE / NNSDE / PDEBPINN test-group failures) are genuine code/test breakages reported separately and are out of scope here.

Please ignore until reviewed by @ChrisRackauckas.
