### PR TITLE
Fix NNSDE1 noise-grid off-by-one (DiffEqNoiseProcess endpoint change)

### DIFF
--- a/test/NNSDE1/nn_sde__test_2_gbm_sde.jl
+++ b/test/NNSDE1/nn_sde__test_2_gbm_sde.jl
@@ -67,7 +67,11 @@ using Test
     W_samples = Array{Float64}(undef, num_time_steps, num_samples)
     for i in 1:num_samples
         W = WienerProcess(0.0, 0.0)
-        probtemp = NoiseProblem(W, (0.0, 1.0))
+        # Solve the noise over the actual `ts` grid (which a Float32 `dt` ends just
+        # short of `1.0`) so the path is sampled at exactly `ts`. Using `(0.0, 1.0)`
+        # makes the solver land an extra point on `1.0` (DiffEqNoiseProcess#278), which
+        # no longer matches `length(ts)`.
+        probtemp = NoiseProblem(W, (0.0, ts[end]))
         Np_sol = solve(probtemp; dt = dt)
         W_samples[:, i] = Np_sol.u
     end

--- a/test/NNSDE1/nn_sde__test_3_additive_noise_test_equation.jl
+++ b/test/NNSDE1/nn_sde__test_3_additive_noise_test_equation.jl
@@ -74,7 +74,11 @@ using Test
     W_samples = Array{Float64}(undef, num_time_steps, num_samples)
     for i in 1:num_samples
         W = WienerProcess(0.0, 1.0)
-        probtemp = NoiseProblem(W, (0.0, 1.0))
+        # Solve the noise over the actual `ts` grid (which a Float32 `dt` ends just
+        # short of `1.0`) so the path is sampled at exactly `ts`. Using `(0.0, 1.0)`
+        # makes the solver land an extra point on `1.0` (DiffEqNoiseProcess#278), which
+        # no longer matches `length(ts)`.
+        probtemp = NoiseProblem(W, (0.0, ts[end]))
         Np_sol = solve(probtemp; dt = dt)
         W_samples[:, i] = Np_sol.u
     end

--- a/test/NNSDE1/nn_sde__test_4_gbm_sde_inverse_weak_strong_solving.jl
+++ b/test/NNSDE1/nn_sde__test_4_gbm_sde_inverse_weak_strong_solving.jl
@@ -32,7 +32,11 @@ using Test
     W_samples = Array{Float64}(undef, num_time_steps, num_samples)
     for i in 1:num_samples
         W = WienerProcess(0.0, 0.0)
-        probtemp = NoiseProblem(W, (0.0, 1.0))
+        # Solve the noise over the actual `ts` grid (which a Float32 `dt` ends just
+        # short of `1.0`) so the path is sampled at exactly `ts`. Using `(0.0, 1.0)`
+        # makes the solver land an extra point on `1.0` (DiffEqNoiseProcess#278), which
+        # no longer matches `length(ts)`.
+        probtemp = NoiseProblem(W, (0.0, ts[end]))
         Np_sol = solve(probtemp; dt = dt)
         W_samples[:, i] = Np_sol.u
     end
@@ -94,7 +98,8 @@ using Test
     W_samples = Array{Float64}(undef, num_time_steps, num_samples)
     for i in 1:num_samples
         W = WienerProcess(0.0, 0.0)
-        probtemp = NoiseProblem(W, (0.0, 1.0))
+        # Sample the noise on exactly the solution's `ts` grid; see the note above.
+        probtemp = NoiseProblem(W, (0.0, ts[end]))
         Np_sol = solve(probtemp; dt = 1 / N_solve)
         W_samples[:, i] = Np_sol.u
     end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

The `tests / NNSDE1` lane (julia 1.11 + lts) is red on master with:

```
Test-2 GBM SDE: Error During Test at test/NNSDE1/nn_sde__test_2_gbm_sde.jl:4
  DimensionMismatch: tried to assign 52-element array to 51×1 destination
```

at `W_samples[:, i] = Np_sol.u` (line 72).

## Root cause

The NNSDE1 tests size `W_samples` to `length(ts)` (the NNSDE solution's time grid) and fill each column with `Np_sol.u` from a `NoiseProblem` solved over `(0.0, 1.0)` with the same Float32 `dt`.

`DiffEqNoiseProcess#278` ("Fix NoiseProblem solve overshooting tspan[2]", v5.32.0) made the noise solve land *exactly* on `tspan[2]`. With a Float32 `dt` (e.g. `1/50.0f0`), the grid `0.0:dt:1.0` ends just short of `1.0` (at `0.99999998`), so the noise solve now appends one extra corrected point at exactly `1.0`:

* `dt = 1/50.0f0`:  `length(ts) = 51`, `length(Np_sol.u) = 52`
* `dt = 1/100.0f0`: `length(ts) = 101`, `length(Np_sol.u) = 102`

This is a behavior change (not a NeuralPDE regression): the same off-by-one reproduces back to StochasticDiffEq 6.69.1; the NNSDE1 lane was last green (2026-06-03) with DiffEqNoiseProcess **5.31.1**, whose noise solve stopped at `0.99999998` (51 points, matching `ts`). 5.32.x correctly lands on `1.0`, adding the extra point.

## Fix

Sample the noise over the solution's actual grid: solve the `NoiseProblem` on `(0.0, ts[end])` instead of `(0.0, 1.0)`. The noise grid then equals `ts` exactly (verified `Np_sol.t == ts`), which is the test's intent (`W_samples[i, :]` pairs with `ts[i]`). Applied to test_2/test_3/test_4 (all share the pattern).

## Verification

Run locally on Julia 1.10 (lts) with the CI dependency stack (DiffEqNoiseProcess 5.32.2, StochasticDiffEq 7.0.0, Lux 1.31.4):

* baseline (unmodified): `DimensionMismatch` error reproduced
* `test_2 GBM SDE`: **11/11 Pass**
* `test_3 Additive Noise`: **8/8 Pass**
* `test_4 Inverse weak & strong`: **8/8 Pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)