### PR TITLE
Train NNDAE DAE Case I long enough to meet the accuracy tolerance

### DIFF
--- a/test/NNODE/nndae__dae_case_i.jl
+++ b/test/NNODE/nndae__dae_case_i.jl
@@ -29,8 +29,12 @@ using Test
     chain = Chain(Dense(1, 15, cos), Dense(15, 15, sin), Dense(15, 2))
     alg = NNDAE(chain, Adam(0.01); autodiff = false)
 
+    # Adam(0.01) on this problem is under-trained at 3000 iters: the algebraic variable
+    # u[2] = -cos(2pi t) is still ~0.13 off, leaving the full-grid norm error at ~0.55
+    # (above the 0.4 tolerance). The fit converges deterministically with more steps
+    # (norm ~0.26 at 10000), so train long enough to land comfortably under tolerance.
     sol = solve(
-        prob, alg; verbose = false, dt = 1 / 100.0f0, maxiters = 3000, abstol = 1.0f-10
+        prob, alg; verbose = false, dt = 1 / 100.0f0, maxiters = 10000, abstol = 1.0f-10
     )
 
     @test ground_sol(0:(1 / 100):1) ≈ sol atol = 0.4


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

The `tests / NNODE` lane (julia 1.11 + lts) is red on master with:

```
DAE Case I: Test Failed at test/NNODE/nndae__dae_case_i.jl:36
  Expression: ≈(ground_sol(0:1 / 100:1), sol, atol = 0.4)
```

## Root cause

`DAE Case I` solves a mass-matrix DAE whose algebraic variable is `u[2] = -cos(2pi t)`. With `Adam(0.01)` and `maxiters = 3000` the network is **under-trained**: the differential variable `u[1]` is fit almost perfectly (row norm 0.008), but the algebraic variable `u[2]` is still ~0.13 off (it ends at -0.962 instead of -1.0), leaving the full-grid difference norm at **~0.55**, above the `atol = 0.4` tolerance.

The result is **deterministic** — identical across Julia 1.11 and lts and unchanged across dependency versions back to early June (the CI evaluated values match exactly), so this is a long-standing under-training, not RNG or floating-point noise, and not a too-tight tolerance (0.4 *is* achievable).

## Fix

The fit converges deterministically with more `Adam(0.01)` steps:

| maxiters | norm  | result |
|---------:|------:|:-------|
| 3000     | 0.552 | fail   |
| 5000     | 0.446 | fail   |
| 6000     | 0.387 | pass (thin) |
| 8000     | 0.301 | pass   |
| 10000    | 0.258 | pass (comfortable) |

Raise `maxiters` to **10000** so the test lands comfortably under tolerance via genuine convergence. The tolerance (`atol = 0.4`) and seed are unchanged; this is more training to real convergence, not a loosened assertion. `DAE Case II` (`Adam(0.1)`) already converges to norm ~0.064 at 3000 iters and is untouched.

## Verification

Run locally on Julia 1.10 (lts), NeuralPDE test stack:

* `DAE Case I`: **1/1 Pass** (norm 0.258; was 0.552 -> Test Failed)
* `DAE Case II`: **1/1 Pass** (norm 0.064, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)