### PR TITLE
Allow CUDA.jl v6, bump to v6.1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralPDE"
 uuid = "315f7962-48a3-4962-8226-d0f33b1235f0"
-version = "6.1.1"
+version = "6.1.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -59,7 +59,7 @@ Adapt = "4.6.0"
 AdvancedHMC = "0.8"
 ArrayInterface = "7.25.0"
 Boltz = "1"
-CUDA = "5.5.2"
+CUDA = "6"
 ChainRulesCore = "1.26.1"
 ComponentArrays = "0.15.39"
 ConcreteStructs = "0.2.3"


### PR DESCRIPTION
## Summary

Widen the `CUDA` compat from `"5.5.2"` to `"6"` so the package works with CUDA.jl v6.x. The V100 GPU CI runners run nvidia driver 580, which requires CUDA.jl **v6.2+** for correct CUDA runtime selection — versions below 6.2 select the runtime based on the driver version and pick an incompatible runtime ([JuliaGPU/CUDA.jl#3134](https://github.com/JuliaGPU/CUDA.jl/pull/3134), [issue #3079](https://github.com/JuliaGPU/CUDA.jl/issues/3079)). Compat `"6"` lets the resolver pick the latest 6.x with the fix.

## Changes

- Bump `CUDA` compat from `"5.5.2"` to `"6"`.
- Bump the package version from `6.1.1` to `6.1.2` for the widened compat.

Note: `Downgrade.yml` will now test against the CUDA 6.0 floor.
