### PR TITLE
Fix direct-function interval tests

### DIFF
--- a/test/direct_function__empty_boundary_condition_fails_in_solve_phase.jl
+++ b/test/direct_function__empty_boundary_condition_fails_in_solve_phase.jl
@@ -3,12 +3,13 @@ using Test
 
 @testset "Empty boundary condition [] fails in solve phase" begin
     using NeuralPDE, Optimization, OptimizationOptimisers, Lux
+    import DomainSets: Interval
     @parameters x
     @variables u(..)
 
     eq = [u(x) ~ 2 + abs(x - 0.5)]
     bc = []
-    domain = [x ∈ IntervalDomain(0.0, 2.0)]
+    domain = [x ∈ Interval(0.0, 2.0)]
     chain = Chain(Dense(1, 10, tanh), Dense(10, 10, tanh), Dense(10, 1))
 
     for strategy in (

--- a/test/direct_function__trivial_bc_0_0_fails_for_some_training_strategies.jl
+++ b/test/direct_function__trivial_bc_0_0_fails_for_some_training_strategies.jl
@@ -3,12 +3,13 @@ using Test
 
 @testset "Trivial BC [0 ~ 0] fails for some training strategies" begin
     using NeuralPDE, Optimization, OptimizationOptimisers, Lux
+    import DomainSets: Interval
     @parameters x
     @variables u(..)
 
     eq = [u(x) ~ 2 + abs(x - 0.5)]
     bc = [0 ~ 0]
-    domain = [x ∈ IntervalDomain(0.0, 2.0)]
+    domain = [x ∈ Interval(0.0, 2.0)]
     chain = Chain(Dense(1, 10, tanh), Dense(10, 10, tanh), Dense(10, 1))
 
     for strategy in (StochasticTraining(1000), QuasiRandomTraining(1000))


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- import `DomainSets.Interval` in the direct-function tests
- replace removed/undefined `IntervalDomain` usage with `Interval`

## Local verification
```
timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --project=. -e 'import Pkg; Pkg.instantiate(); include("test/direct_function__empty_boundary_condition_fails_in_solve_phase.jl"); include("test/direct_function__trivial_bc_0_0_fails_for_some_training_strategies.jl")'\n\nTest Summary:                                    | Pass  Total     Time\nEmpty boundary condition [] fails in solve phase |    4      4  2m00.8s\nTest Summary:                                         | Pass  Total  Time\nTrivial BC [0 ~ 0] fails for some training strategies |    2      2  1.2s\n```\n\nAlso ran `git diff --check`, with no output.