### PR TITLE
Alias legacy NNPDE test group

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,11 @@
 using SciMLTesting
-run_tests()
+
+if current_group() == "NNPDE"
+    for group in ("NNPDE1", "NNPDE2")
+        withenv("GROUP" => group) do
+            run_tests(; test_dir = @__DIR__)
+        end
+    end
+else
+    run_tests()
+end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Treat the legacy aggregate `GROUP=NNPDE` as an alias for the existing `NNPDE1` and `NNPDE2` folder-mode groups.
- Keep `test/test_groups.toml` unchanged so NeuralPDE's own generated CI matrix does not add a duplicate aggregate group.

## Why
Optimization.jl's downstream workflow still requests `GROUP=NNPDE`, while NeuralPDE now declares the split groups `NNPDE1` and `NNPDE2`. SciMLTesting folder mode rejects unknown groups before running tests, so the downstream job fails before exercising NeuralPDE.

## Verification
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_165240_11300/.runic-env -m Runic --check test/runtests.jl`
- `timeout 7200 env GROUP=NNPDE /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'`
  - observed `NNPDE1` files pass, including `nnpde__pde_iv_system_of_pdes.jl | 2 pass / 2 total` and `nnpde__pde_v_2d_wave_equation.jl | 1 pass / 1 total`
  - observed `NNPDE2` files pass, including `additional_loss__lorenz_system.jl | 6 pass / 6 total` and `direct_function__approximation_of_function_2d.jl | 1 pass / 1 total`
  - final output: `Testing NeuralPDE tests passed`
- `git diff --check`