### PR TITLE
Handle DEVerbosity in weak SDE callbacks

### DIFF
--- a/src/NN_SDE_weaksolve.jl
+++ b/src/NN_SDE_weaksolve.jl
@@ -203,7 +203,8 @@ function SciMLBase.__solve(
     bc_losses = sym.loss_functions.bc_loss_functions
 
     cb = function (p, l)
-        (!verbose) && return false
+        # DiffEqBase now passes DEVerbosity by default; keep these debug prints opt-in.
+        verbose === true || return false
         println("loss = ", l)
         println("pde = ", map(f -> f(p.u), pde_losses))
         println("bc  = ", map(f -> f(p.u), bc_losses))


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- treats weak SDE callback debug printing as explicitly opt-in with `verbose === true`
- avoids applying Boolean `!` to the default `DiffEqBase.DEVerbosity` object passed by current DiffEqBase/SciMLBase

## Root cause
Current `DiffEqBase.solve` passes `verbose::DiffEqBase.DEVerbosity{true,...}` by default into NeuralPDE's weak SDE solve path. The callback in `NN_SDE_weaksolve.jl` assumed `verbose` was Boolean and called `!verbose`, causing `MethodError: no method matching !(::DiffEqBase.DEVerbosity{...})` in the NNSDE2 GBM test.

## Verification
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_165240_11300/julia_depot_nnsde2_main_verify GROUP=NNSDE2 JULIA_PKG_PRECOMPILE_AUTO=0 /home/crackauc/.juliaup/bin/julia +1.11 --startup-file=no --color=yes --project=. -e 'using Pkg; Pkg.test(coverage=false)'`\n  - `NNSDE2/nn_sde_weaksolve__gbm_sde.jl | 1 pass / 1 total`\n  - `NNSDE2/nn_sde_weaksolve__ou_process.jl | 1 pass / 1 total`\n  - `Testing NeuralPDE tests passed`\n- `git diff --check`\n- `julia +1.12 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_165240_11300/.runic-env -e 'using Runic; exit(Runic.main(["--check", "."]))'`