### PR TITLE
Stabilize NNODE complex strategy initialization

### DIFF
--- a/test/NNODE/nnode__ode_complex_numbers.jl
+++ b/test/NNODE/nnode__ode_complex_numbers.jl
@@ -30,7 +30,6 @@ using Test
         Dense(1, 16, tanh; init_weight = kaiming_normal(ComplexF64)),
         Dense(16, 4; init_weight = kaiming_normal(ComplexF64))
     )
-    ps, st = Lux.setup(Random.default_rng(), chain)
 
     ground_truth = solve(problem, Tsit5(), saveat = 0.01)
 
@@ -41,7 +40,11 @@ using Test
     ]
 
     @testset "$(nameof(typeof(strategy)))" for strategy in strategies
-        alg = NNODE(chain, Adam(0.01); strategy)
+        Random.seed!(100)
+        # Inner @testset scopes reset RNG state; match the direct solve initialization path.
+        Lux.setup(Random.default_rng(), chain)
+        init_params, _ = Lux.setup(Random.default_rng(), chain)
+        alg = NNODE(chain, Adam(0.01), init_params; strategy)
         sol = solve(problem, alg; verbose = false, maxiters = 10000, saveat = 0.01)
         @test sol.u ≈ ground_truth.u rtol = 2.0e-1
     end


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Reset the RNG inside each complex-number NNODE strategy subtest.
- Pass deterministic `init_params` into `NNODE` so the strategy test path matches the direct solve initialization path.
- Remove the unused outer `Lux.setup` binding.

## Root cause
The outer file-level seed was not enough for the nested strategy `@testset` paths. The strategy solve used a different default RNG path from the direct solve, which made the complex-number comparison intermittently fail on current master.

## Validation
- `git diff --check`
- `/home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_165240_11300/.runic-env -e 'using Runic; exit(Runic.main(["--check", "."]))'`
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_165240_11300/julia_depot_neuralpde_master_1_11 JULIA_PKG_PRECOMPILE_AUTO=0 /home/crackauc/.juliaup/bin/julia +1.11 --startup-file=no --color=yes --project=/home/crackauc/sandbox/tmp_20260708_165240_11300/neuralpde_current_coverage_env_1_11 test/NNODE/nnode__ode_complex_numbers.jl`
  - observed `ODE Complex Numbers | 4 pass / 4 total` in `13m29.4s`