### PR TITLE
Avoid eval in PDEBPINN differential masking

### DIFF
--- a/test/PDEBPINN/bpinn_pde__bpinn_pde_inv_iii_improved_parametric_kuromo_sivashinsky_equation_solve.jl
+++ b/test/PDEBPINN/bpinn_pde__bpinn_pde_inv_iii_improved_parametric_kuromo_sivashinsky_equation_solve.jl
@@ -4,28 +4,25 @@ using Test
 @testset "BPINN PDE Inv III: Improved Parametric Kuromo-Sivashinsky Equation solve" begin
     using MCMCChains, Lux, ModelingToolkit, Distributions, OrdinaryDiffEq,
         AdvancedHMC, LogDensityProblems, Statistics, Random, Functors, NeuralPDE, MonteCarloMeasurements,
-        ComponentArrays
+        ComponentArrays, SymbolicUtils
     import DomainSets: Interval, infimum, supremum
 
     Random.seed!(100)
 
-    function recur_expression(exp, Dict_differentials)
-        for in_exp in exp.args
-            if !(in_exp isa Expr)
-                # skip +,== symbols, characters etc
-                continue
+    function recur_expression(term, Dict_differentials)
+        term = SymbolicUtils.unwrap(term)
+        SymbolicUtils.iscall(term) || return nothing
 
-            elseif in_exp.args[1] isa ModelingToolkit.Differential
-                # first symbol of differential term
-                # Dict_differentials for masking differential terms
-                # and resubstituting differentials in equations after putting in interpolations
-                # temp = in_exp.args[end]
-                Dict_differentials[eval(in_exp)] = Symbolics.variable("diff_$(length(Dict_differentials) + 1)")
-                return
-            else
-                recur_expression(in_exp, Dict_differentials)
-            end
+        op = SymbolicUtils.operation(term)
+        if op isa ModelingToolkit.Differential
+            Dict_differentials[term] = Symbolics.variable("diff_$(length(Dict_differentials) + 1)")
+            return nothing
         end
+
+        for arg in SymbolicUtils.arguments(term)
+            recur_expression(arg, Dict_differentials)
+        end
+        return nothing
     end
 
     @parameters α
@@ -122,8 +119,10 @@ using Test
     # neccesarry for loss function construction (involves Operator masking)
     eqs = pde_system.eqs
     Dict_differentials = Dict()
-    exps = toexpr.(eqs)
-    nullobj = [recur_expression(exp, Dict_differentials) for exp in exps]
+    for eq in eqs
+        recur_expression(eq.lhs, Dict_differentials)
+        recur_expression(eq.rhs, Dict_differentials)
+    end
 
     # Dict_differentials is now ;
     # Dict{Any, Any} with 5 entries:


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Traverse Symbolics/SymbolicUtils terms directly when collecting PDE differential masks.
- Avoid converting equations to Julia expressions and calling module-global `eval` on terms containing local symbolic variables.
- Keep the masking behavior unchanged: the target Kuramoto-Sivashinsky PDE test still finds the same five differential terms.

## Root cause
The existing helper converted symbolic equations with `toexpr` and then evaluated expression nodes. Under the current SafeTestsets/test-module scoping, local symbolic variables such as `u` are not available to that `eval`, producing `UndefVarError: u not defined` before the PDEBPINN solve can run.

## Validation
- `git diff --check`
- `/home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_165240_11300/.runic-env -e 'using Runic; exit(Runic.main(["--check", "."]))'`
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_165240_11300/julia_depot_pdebpinn_main_verify JULIA_PKG_PRECOMPILE_AUTO=0 /home/crackauc/.juliaup/bin/julia +1.11 --startup-file=no --color=yes --project=. -e 'using Pkg; Pkg.test(coverage=false, test_fn=()->include(joinpath("test", "PDEBPINN", "bpinn_pde__bpinn_pde_inv_iii_improved_parametric_kuromo_sivashinsky_equation_solve.jl")))'`
  - observed `BPINN PDE Inv III: Improved Parametric Kuromo-Sivashinsky Equation solve | 2 pass / 2 total` in `37m24.1s`
  - after the focused file passed, the `Pkg.test(test_fn=...)` wrapper unexpectedly continued into the default package test harness and was interrupted during that unrelated full-suite phase.