### PR TITLE
Release prep: bump version to 6.1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralPDE"
 uuid = "315f7962-48a3-4962-8226-d0f33b1235f0"
-version = "6.1.2"
+version = "6.1.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

The registered version 6.1.2 (tree-sha `1e819d40d62c6b5b19d299feaad5bb179d651665`) corresponds to commit `bfcbae6` ("Fix direct-function interval tests (#1083)"). Four commits have landed on `master` since then without a version bump:

- `bf12f3a` Stabilize NNODE complex strategy initialization (#1086)
- `f9c1881` Handle DEVerbosity in weak SDE callbacks (#1085) — small forward-compat bug fix (`(!verbose) && return false` → `verbose === true || return false`) so the debug callback doesn't error if `verbose` is passed as a `DEVerbosity` type instead of `Bool`
- `091a3e9` Update SciMLTesting QA docs checks (#1088) — adds `@doc` docstrings for already-exported API (`NNSDE`, `SDEPINN`, `AbstractAdaptiveLoss`, `get_numeric_integral`, `get_loss_function`) and docs pages; bumps the test-only `SciMLTesting` compat from `"1"` to `"2.1"` (needed for `public_api_names`/`api_docs_kwargs` used in the QA test, which only exists from SciMLTesting 2.1.0 onward)
- `7b49315` Avoid eval in PDEBPINN differential masking (#1087) — test-only refactor replacing `eval` with `SymbolicUtils.iscall/operation/arguments` tree traversal

## Bump type: PATCH (6.1.2 → 6.1.3)

No exports changed (`src/NeuralPDE.jl` export list is untouched) and no new public API was introduced — the added docstrings attach to functions/types that were already exported. The only behavioral change is the defensive `verbose` handling fix in `NN_SDE_weaksolve.jl`, which is a bug fix, not new functionality. Everything else is docs, tests, or QA tooling.

## Compat bounds

Left untouched except for the `SciMLTesting = "2.1"` bump that was already made correctly in commit `091a3e9` itself (test-only extra dependency, not part of the runtime dependency graph). No SciML-ecosystem runtime dependency (SciMLBase, ModelingToolkit, OrdinaryDiffEq, StochasticDiffEq, etc.) had its lower bound touched, and the DEVerbosity fix is written to be safe against both old (`Bool`) and new (`DEVerbosity`) `verbose` argument types, so no lower-bound raise is required.