### PR TITLE
Retarget downstream tests to NeuralLyapunov

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: PDESystemLibrary.jl, group: NeuralPDE}
+          - {user: SciML, repo: NeuralLyapunov.jl, group: Core}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       julia-version: "1"


### PR DESCRIPTION
Ignore this draft until it has been reviewed by @ChrisRackauckas.

## Summary

- replace the stale `PDESystemLibrary.jl/NeuralPDE` downstream cell with `NeuralLyapunov.jl/Core`
- retain substantive downstream coverage: NeuralLyapunov's four Core test files import NeuralPDE and construct `PhysicsInformedNN` discretizations

## Root cause

PDESystemLibrary no longer declares a `NeuralPDE` test group. Its SciMLTesting migration in `2d30c12a25e6be822d7e1858508c4c07e91e61cc` intentionally dropped the dead NeuralPDE matrix cells and adopted strict folder-group validation. NeuralPDE's downstream workflow continued requesting that removed group, so every run failed before executing a test:

```text
ArgumentError: run_tests (folder mode): GROUP="NeuralPDE" ... is not a group declared in test_groups.toml (declared: ["Core", "QA"])
```

An automated repository bisect identified `2d30c12a25e6be822d7e1858508c4c07e91e61cc` as the first commit where the old workflow request became invalid.

## Verification

The old target was reproduced locally on Julia 1.12.6:

```sh
GROUP=NeuralPDE julia +1.12 --project=pdesystemlibrary -e 'using Pkg; Pkg.develop(PackageSpec(path="neuralpde")); Pkg.update(); Pkg.test(; coverage=false)'
```

It exited 1 with the missing-group error above.

The replacement downstream target was tested with the feature checkout developed into NeuralLyapunov:

```sh
GROUP=Core julia +1.12 --project=neurallyapunov -e 'using Pkg; Pkg.develop(PackageSpec(path="neuralpde")); Pkg.update(); Pkg.test(; coverage=false)'
```

It exited 0 with substantive summaries:

```text
Damped simple harmonic oscillator                     4 / 4 passed
Damped pendulum                                       9 / 9 passed
Damped pendulum - AdditiveLyapunovNet structure       9 / 9 passed
Damped pendulum - MultiplicativeLyapunovNet structure 9 / 9 passed
Testing NeuralLyapunov tests passed
```

Additional checks:

```text
actionlint .github/workflows/Downstream.yml                 passed
julia +1.12 --project=../runic-env -m Runic --check .       passed
git diff --check                                             passed
```
