### PR TITLE
Stabilize gradient scale adaptive loss test

### DIFF
--- a/test/AdaptiveLoss/adaptive_loss__2d_poisson_gradientscaleadaptiveloss.jl
+++ b/test/AdaptiveLoss/adaptive_loss__2d_poisson_gradientscaleadaptiveloss.jl
@@ -10,7 +10,7 @@ module AdaptiveLossTestSetup
         logger = haslogger ? TBLogger(logdir) : nothing
 
         Random.seed!(60)
-        hid = 40
+        hid = 32
         chain = Chain(Dense(2, hid, tanh), Dense(hid, hid, tanh), Dense(hid, 1))
         strategy = StochasticTraining(256)
 
@@ -86,18 +86,20 @@ using NeuralPDE
 using Test
 
 @testset "2D Poisson: GradientScaleAdaptiveLoss" begin
-    loss = GradientScaleAdaptiveLoss(100, pde_loss_weights = 1.0e3, bc_loss_weights = 1)
-
     tmpdir = mktempdir()
 
     total_diff_rel = solve_with_adaptive_loss(
-        loss; haslogger = false, outdir = tmpdir, run = 1
+        GradientScaleAdaptiveLoss(
+            100; pde_loss_weights = 1.0e3, bc_loss_weights = 1
+        ); haslogger = false, outdir = tmpdir, run = 1
     )
     @test total_diff_rel < 0.4
     @test length(readdir(tmpdir)) == 0
 
     total_diff_rel = solve_with_adaptive_loss(
-        loss; haslogger = true, outdir = tmpdir, run = 2
+        GradientScaleAdaptiveLoss(
+            100; pde_loss_weights = 1.0e3, bc_loss_weights = 1
+        ); haslogger = true, outdir = tmpdir, run = 2
     )
     @test total_diff_rel < 0.4
     @test length(readdir(tmpdir)) == 1


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- restore the 32-neuron hidden width that made this stochastic convergence test reliable before #903
- construct a fresh `GradientScaleAdaptiveLoss` for each logger variant so mutable adaptive-loss state cannot leak between solves

## Root cause

The test became unreliable when #903 simultaneously increased the hidden width from 32 to 40 and reduced its optimization budget. On current dependencies, the original seed and 40-neuron network reproducibly finish at relative error 0.643115, above the 0.4 assertion. An A/B run changing only the width back to 32 finishes at 0.207279. The test also reused one mutable adaptive-loss object across two independent solves, which made the logger comparison order-dependent.

## Validation

- clean `master`, Julia 1.11: `GROUP=AdaptiveLoss julia --project -e 'using Pkg; Pkg.test(; coverage = true)'` failed 2 of 4 assertions in this file (relative errors 0.643115 and 0.520205)
- this branch, Julia 1.11, exact native command: `GROUP=AdaptiveLoss julia --project -e 'using Pkg; Pkg.test(; coverage = true)'` passed all 12 tests across the AdaptiveLoss group
- this branch, Julia 1.10, exact native command: `GROUP=AdaptiveLoss julia --project -e 'using Pkg; Pkg.test(; coverage = true)'` passed the complete AdaptiveLoss group
- direct fresh-process run of the changed test passed 4/4 assertions and produced identical adaptive-loss logs for the logger and no-logger variants
- repository-wide `Runic --check .` passed
