### PR TITLE
Use a fixed objective in the mixed derivative test

### DIFF
--- a/test/NNPDE1/nnpde__pde_vi_pde_with_mixed_derivative.jl
+++ b/test/NNPDE1/nnpde__pde_vi_pde_with_mixed_derivative.jl
@@ -74,11 +74,15 @@ using Test
     # Space and time domains
     domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
 
-    strategy = StochasticTraining(2048)
+    # BFGS requires the objective to stay fixed between evaluations.
+    strategy = QuasiRandomTraining(
+        2048; sampling_alg = SobolSample(), resampling = false, minibatch = 1
+    )
     inner = 32
     chain = Chain(Dense(2, inner, sigmoid), Dense(inner, inner, sigmoid), Dense(inner, 1))
+    init_params, _ = Lux.setup(Xoshiro(100), chain)
 
-    discretization = PhysicsInformedNN(chain, strategy)
+    discretization = PhysicsInformedNN(chain, strategy; init_params)
     @named pde_system = PDESystem(eq, bcs, domains, [x, y], [u(x, y)])
 
     prob = discretize(pde_system, discretization)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- use one fixed Sobol collocation batch for the mixed-derivative BFGS test
- initialize the Lux network from an explicit `Xoshiro(100)` state

## Why

`StochasticTraining` regenerated the collocation points on every objective evaluation. That makes the objective itself change while BFGS is building its local model and made the accuracy assertion process-dependent. A single fixed low-discrepancy batch preserves the intended collocation coverage while giving BFGS a stable objective.

## Local verification

- repository-wide `Runic --check .`: pass
- Julia 1.11 changed test, first run: 1/1 pass
- Julia 1.11 changed test, independent repeat: 1/1 pass with the same initial loss
- Julia 1.10 exact downgrade-stack changed test: 1/1 pass with and without compiled modules
