### PR TITLE
Make NNODE tstops comparison reproducible

### DIFF
--- a/test/NNODE/nnode__training_strategy_with_tstops.jl
+++ b/test/NNODE/nnode__training_strategy_with_tstops.jl
@@ -27,6 +27,7 @@ using Test
         Dense(1 => N, σ), Dense(N => N, σ), Dense(N => N, σ), Dense(N => N, σ),
         Dense(N => length(u0))
     )
+    init_params, _ = Lux.setup(Xoshiro(100), chain)
 
     threshold = 0.2
 
@@ -35,19 +36,25 @@ using Test
             WeightedIntervalTraining([0.3, 0.3, 0.4], 3),
             StochasticTraining(3),
         ]
-        alg = NNODE(chain, Adam(0.01); strategy, tstops = addedPoints)
+        Random.seed!(100)
+        alg = NNODE(chain, Adam(0.01), deepcopy(init_params); strategy)
+        sol = solve(prob_oop, alg; verbose = false, maxiters = 1000, saveat)
+        error_without_points = abs(mean(sol) - mean(true_sol))
+
+        Random.seed!(100)
+        alg = NNODE(chain, Adam(0.01), deepcopy(init_params); strategy)
+        sol = solve(
+            prob_oop, alg; verbose = false,
+            maxiters = 10000, saveat, tstops = addedPoints
+        )
+        error_with_points = abs(mean(sol) - mean(true_sol))
 
         @testset "Without added points" begin
-            sol = solve(prob_oop, alg; verbose = false, maxiters = 10000, saveat)
-            @test abs(mean(sol) - mean(true_sol)) ≥ threshold
+            @test error_without_points ≥ threshold
         end
 
         @testset "With added points" begin
-            sol = solve(
-                prob_oop, alg; verbose = false,
-                maxiters = 10000, saveat, tstops = addedPoints
-            )
-            @test abs(mean(sol) - mean(true_sol)) < threshold
+            @test error_with_points < threshold
         end
     end
 end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- restore the original 1,000-iteration no-points control and pass `tstops` only to the solve that exercises it
- initialize both sides of each comparison from the same explicit Lux parameters
- create a fresh `NNODE` algorithm for each solve

## Why

The test migration in #903 changed the no-points control from 1,000 to 10,000 iterations and attached `tstops` to the `NNODE` constructor as well as the intended solve call. Combined with implicit random network initialization, the negative control can now converge past its threshold depending on the process state. Restoring the original control budget and pairing identical initial parameters makes the intended comparison reproducible.

## Local verification

- clean master Julia 1.11 `GROUP=NNODE`: reproduced the target failure (`0.186795218 < 0.2` for the stochastic no-points control)
- Julia 1.11 `GROUP=NNODE`: complete group pass; changed file 6/6
- changed test on Julia 1.10: 6/6 pass
- repository-wide `Runic --check .`: pass
