### PR TITLE
Enable NeuralPDE rendered public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -27,20 +27,10 @@ run_qa(
     ),
     api_docs_kwargs = (;
         rendered = true,
-        # NeuralPDE reexports ModelingToolkit and SciMLBase. Their docstrings count
-        # when they exist, but NeuralPDE's manual should only render NeuralPDE-owned API.
+        # NeuralPDE reexports ModelingToolkit and SciMLBase; those names are
+        # documented in their owning packages, not in NeuralPDE's API reference.
+        ignore = REEXPORTED_API,
         rendered_ignore = REEXPORTED_API,
-        # Upstream reexported names which do not currently have source docstrings.
-        ignore = (
-            Symbol("@brownian"), Symbol("@mtkbuild"), Symbol("@symbolic_wrap"),
-            Symbol("@wrapped"), :AbstractCollocation, :DiscreteSystem,
-            :DynamicOptSolution, :ImplicitDiscreteSystem, :ODESystem, :RuleSet,
-            :alias_elimination, :but_ordered_incidence, :get_canonical_expr,
-            :highest_order_variable_mask, :independent_variable, :infimum,
-            :irreducibles, :is_derivative, :istree, :lowest_order_variable_mask,
-            :maybe_zeros, :mtkcompile!, :pantelides_reassemble, :setnominal,
-            :solve_for, :structural_simplify, :supremum, :tearing_substitution,
-        ),
     ),
     # ambiguities: PINOODE's `PDETimeSeriesSolution{...,<:PINOODEMetadata}(p, t)`
     # callable is ambiguous with the RecursiveArrayTools/SciMLBase


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enables rendered public API documentation checking in NeuralPDE QA.
- Uses the existing dynamic `REEXPORTED_API` set for both source-docstring and rendered-docs ignores, so dependency-owned reexports stay owned by their source packages.
- Removes the stale hard-coded upstream ignore list from the QA config.

## Validation
- `git diff --check`
- `julia +1.10 --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/toolenvs/runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check test/qa/qa.jl`\n- `julia +1.10 --project=tmp/neuralpde_qa_env -e 'using Pkg; Pkg.develop(Pkg.PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'` (`Quality Assurance | 14 pass, 1 broken, 15 total`)\n