### PR TITLE
Release 6.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralPDE"
 uuid = "315f7962-48a3-4962-8226-d0f33b1235f0"
-version = "6.1.3"
+version = "6.2.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Publishes the `@public logscalar` declaration added in #1096 so downstream packages can import it without tripping strict SciMLTesting QA.

Minor bump because the change widens the public API surface; no behaviour change.

## Why this needs a release

`logscalar` is the logging extension hook: declared in `src/pinn_types.jl`, dispatched from `src/discretize.jl` and `src/adaptive_losses.jl`, and given its concrete method by `ext/NeuralPDETensorBoardLoggerExt.jl`. A generic function that a package extension implements and that downstream packages add methods to is interface by definition — `SciML/NeuralLyapunov.jl` does exactly that in `src/logger.jl:30`. NeuralPDE already exports the companion `LogOptions`.

Without this release, strict QA in NeuralLyapunov#209 hard-errors with `logscalar is not public in NeuralPDE`.

## Blocked downstream

- SciML/NeuralLyapunov.jl#209, which pins `NeuralPDE = "6.0.0"` and so admits this release with no compat change.