### PR TITLE
Make the QA group actually scan the package extensions

### DIFF
--- a/ext/NeuralPDEBPINNExt.jl
+++ b/ext/NeuralPDEBPINNExt.jl
@@ -10,12 +10,10 @@ using NeuralPDE: NeuralPDE, AbstractTrainingStrategy, GridTraining, StochasticTr
 using AdvancedHMC: AdvancedHMC, DiagEuclideanMetric, HMC, HMCDA, Hamiltonian,
     JitteredLeapfrog, Leapfrog, MassMatrixAdaptor, NUTS, StanHMCAdaptor,
     StepSizeAdaptor, TemperedLeapfrog, find_good_stepsize
-using ChainRulesCore: @ignore_derivatives
-using ComponentArrays: ComponentArrays, ComponentArray, getdata, getaxes
+using ComponentArrays: ComponentArrays, ComponentArray, getdata
 using ConcreteStructs: @concrete
-using Distributions: Distributions, Distribution, MvNormal, Normal, dim, logpdf
+using Distributions: Distributions, Distribution, MvNormal, logpdf
 using ForwardDiff: ForwardDiff
-using Functors: fmap
 using IntervalSets: infimum, supremum
 using LinearAlgebra: Diagonal
 using LogDensityProblems: LogDensityProblems
@@ -27,7 +25,7 @@ using MonteCarloMeasurements: Particles
 using Printf: @printf
 using Random: Random
 using Integrals: IntegralProblem, QuadGKJL
-using SciMLBase: SciMLBase, isinplace, solve, symbolic_discretize
+using SciMLBase: SciMLBase, isinplace, solve
 using SymbolicUtils: SymbolicUtils
 using Symbolics: Symbolics
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,11 +1,19 @@
 [deps]
+AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 NeuralPDE = "315f7962-48a3-4962-8226-d0f33b1235f0"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+TensorBoardLogger = "899adc3e-224a-11e9-021f-63837185c80f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+AdvancedHMC = "0.8"
 Aqua = "0.8.9"
+LogDensityProblems = "2"
+MCMCChains = "7"
 SciMLTesting = "2.1"
+TensorBoardLogger = "0.1.24"
 Test = "1.10"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,10 @@
 using SciMLTesting, NeuralPDE, Test
 
+# ExplicitImports only sees an extension once its trigger packages are loaded, so
+# load every weakdep here to bring NeuralPDEBPINNExt and
+# NeuralPDETensorBoardLoggerExt into the set of modules run_qa scans.
+using AdvancedHMC, LogDensityProblems, MCMCChains, TensorBoardLogger
+
 function _is_reexported_api(pkg::Module, name::Symbol)
     isdefined(pkg, name) || return false
     value = getfield(pkg, name)
@@ -54,12 +59,30 @@ run_qa(
         #   ForwardDiff: derivative, jacobian
         #   QuasiMonteCarlo: generate_design_matrices, sample
         #   Base: mapany; Base.Broadcast: dottable
+        #   NeuralPDE: logvector, the vector counterpart of the public `logscalar`
+        #     logging hook that NeuralPDETensorBoardLoggerExt implements. Promoting it
+        #     to public API needs a docstring, a docs entry and a version bump, so it
+        #     is a separate change.
+        #   AdvancedHMC: make_kernel, the sampler-to-kernel constructor
+        #     NeuralPDEBPINNExt needs to turn an HMC/NUTS/HMCDA spec into a kernel.
+        #     AdvancedHMC exports no equivalent.
         all_qualified_accesses_are_public = (;
             ignore = (
                 :AbstractDiscretizationMetadata, :__solve, :has_analytic,
                 :interp_summary, :calculate_solution_errors!,
                 :_iszero, :variables, :derivative, :jacobian,
                 :generate_design_matrices, :sample, :mapany, :dottable,
+                :logvector, :make_kernel,
+            ),
+        ),
+        # NeuralPDEBPINNExt is part of NeuralPDE, but ExplicitImports sees it as a
+        # separate module, so NeuralPDE's own non-public helpers look like external
+        # internals. There is no public spelling for any of these.
+        all_explicit_imports_are_public = (;
+            ignore = (
+                :AbstractTrainingStrategy, :BPINNstats, :get_dataset_train_points,
+                :merge_strategy_with_loglikelihood_function, :safe_expand,
+                :safe_get_device,
             ),
         ),
     ),


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Why

`SciMLTesting.run_qa` runs ExplicitImports' checks over the package *and its
extensions* — but ExplicitImports finds extensions via `Base.get_extension`,
which returns `nothing` until the extension's trigger packages are loaded. The
QA environment loaded no weakdeps, so neither NeuralPDE extension was being
scanned at all.

Verified directly rather than inferred. On the base branch:

```
EXT NeuralPDEBPINNExt => nothing
EXT NeuralPDETensorBoardLoggerExt => nothing
SCANNED: NeuralPDE
```

With the four weakdeps added to `test/qa/Project.toml` and `using`-ed in `qa.jl`:

```
EXT NeuralPDEBPINNExt => NeuralPDEBPINNExt
EXT NeuralPDETensorBoardLoggerExt => NeuralPDETensorBoardLoggerExt
SCANNED: NeuralPDETensorBoardLoggerExt
SCANNED: NeuralPDE
SCANNED: NeuralPDEBPINNExt
```

This is a real gap being closed, not incidental coverage that already happened
to work: neither extension was loaded on the base branch.

## Coverage

Both extensions are now scanned:

| Extension | Triggers | Status |
|---|---|---|
| `NeuralPDEBPINNExt` | AdvancedHMC, LogDensityProblems, MCMCChains | scanned |
| `NeuralPDETensorBoardLoggerExt` | TensorBoardLogger | scanned |

Nothing is left out — NeuralPDE has exactly these four weakdeps, none of them
need GPU hardware or external system libraries, and all four co-resolve in the
QA environment. `[compat]` entries mirror the root `Project.toml` bounds.

## What the new coverage found, and how each was handled

**Fixed in the extension source** (`no_stale_explicit_imports` — six unused
explicit imports in `NeuralPDEBPINNExt`):

- `ChainRulesCore: @ignore_derivatives` — unused; the whole `using` line is gone.
- `Functors: fmap` — unused; the whole `using` line is gone.
- `ComponentArrays: getaxes` — unused.
- `Distributions: Normal` — only appears in docstrings/comments; `MvNormal` is
  what the code actually uses.
- `Distributions: dim` — the code only does field access `ltd.dim`, never
  `Distributions.dim`.
- `SciMLBase: symbolic_discretize` — the code calls it qualified as
  `SciMLBase.symbolic_discretize`.

**Ignored, with justification** (no public spelling exists at the owner):

- `all_explicit_imports_are_public`: `AbstractTrainingStrategy`, `BPINNstats`,
  `get_dataset_train_points`, `merge_strategy_with_loglikelihood_function`,
  `safe_expand`, `safe_get_device`. These are **NeuralPDE's own** non-public
  helpers. `NeuralPDEBPINNExt` is part of NeuralPDE, but ExplicitImports treats
  an extension as a separate module, so the package's own internals look
  external. Qualifying them instead would just move the finding to
  `all_qualified_accesses_are_public`.
- `all_qualified_accesses_are_public: :make_kernel` — `AdvancedHMC.make_kernel`
  turns an `HMC`/`NUTS`/`HMCDA` spec into a kernel. It is not exported and not
  declared `public` in AdvancedHMC, and AdvancedHMC ships no exported
  equivalent.
- `all_qualified_accesses_are_public: :logvector` — `NeuralPDE.logvector` is the
  vector counterpart of `NeuralPDE.logscalar`, which is already `@public` and
  documented precisely because logger backends implement it.
  `NeuralPDETensorBoardLoggerExt` implements both. Promoting `logvector` to
  public API needs a docstring, a docs entry and a version bump, so it belongs
  in its own PR rather than here.

No check was disabled, and no `@test_broken`/`@test_skip` was added.

## Local `GROUP=QA` result

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch,
Julia 1.12, SciMLTesting v2.6.1:

```
Test Summary:                                  | Pass  Fail  Broken  Total     Time
QA/qa.jl                                       |   16     1       1     18  2m10.7s
  Quality Assurance                            |   16     1       1     18  1m22.2s
    Unbound type parameters                    |    1                    1     0.1s
    Compare Project.toml and test/Project.toml |    1                    1     0.0s
    Stale dependencies                         |    1                    1    17.9s
    Compat bounds                              |    4                    4     0.3s
    Piracy                                     |    1                    1     0.2s
    aqua: ambiguities (broken)                 |                  1      1     0.0s
    ExplicitImports                            |    6                    6    36.0s
    Public API documentation                   |    2                    2     5.9s
    No unapproved public reexports             |          1              1     3.2s
```

All six ExplicitImports checks pass with both extensions in scope.

### The one remaining failure is pre-existing on master

`No unapproved public reexports` is **not** caused by this PR. I reproduced it
on unmodified `origin/master` (`da44ff18`) in a clean `git worktree` with a
fresh QA environment: 480 unapproved public reexports, same assertion. It comes
from `src/NeuralPDE.jl:52` `@reexport using SciMLBase, ModelingToolkit`, which
exposes ~480–516 externally-owned public names (mostly Symbolics/SymbolicUtils
internals leaking through ModelingToolkit's own reexport chain), while
`check_reexports` defaults to `true` and `qa.jl` passes no `reexports_allow`.

It started with **SciMLTesting v2.4.0** (2026-07-21), which enabled the new
`public_reexports` check by default (SciML/SciMLTesting.jl#28) — no NeuralPDE
change is involved, and `SciMLTesting = "2.1"` compat picked it up
automatically. SciML CI has been red for QA on master since then: green at
v2.2.0 on 2026-07-13, first red on 2026-07-21, still red on the current HEAD.

Deliberately **not** fixed here to keep this PR to one thing. The likely fix is
`check_reexports = false` with a comment noting NeuralPDE is an intentional
`@reexport` facade over SciMLBase/ModelingToolkit; `reexports_allow =
REEXPORTED_API` also passes (I checked — the sets are identical) but is
self-approving and only looks curated.

## Other notes

- Runic reports no changes needed on the touched files.
- `test/qa/Manifest.toml` is gitignored and is not committed.

### Links

- Failing QA job on current master: https://github.com/SciML/NeuralPDE.jl/actions/runs/30597418135/job/91052776083
- First failing master run (2026-07-21): https://github.com/SciML/NeuralPDE.jl/actions/runs/29845514101/job/88700352470
- Last green master QA job (2026-07-13): https://github.com/SciML/NeuralPDE.jl/actions/runs/29218384865/job/86721308644
- SciMLTesting PR that enabled the reexport check: https://github.com/SciML/SciMLTesting.jl/pull/28
