### PR TITLE
Make the NNPDE1 3rd-order ODE test independent of the RNG and FP noise

### DIFF
--- a/test/NNPDE1/nnpde__pde_iii_3rd_order_ode.jl
+++ b/test/NNPDE1/nnpde__pde_iii_3rd_order_ode.jl
@@ -50,7 +50,8 @@ using NeuralPDE
 using Test
 
 @testset "PDE III: 3rd-order ODE" begin
-    using Lux, Random, Optimisers, DomainSets, Cubature, QuasiMonteCarlo, Integrals
+    using Lux, Random, Optimisers, DomainSets, Cubature, QuasiMonteCarlo, Integrals,
+        ComponentArrays
     import DomainSets: Interval, infimum, supremum
     import OptimizationOptimJL: BFGS
 
@@ -85,9 +86,17 @@ using Test
         [Chain(Dense(1, 12, tanh), Dense(12, 12, tanh), Dense(12, 1)) for _ in 1:3]
         [Chain(Dense(1, 4, tanh), Dense(4, 1)) for _ in 1:2]
     ]
-    quasirandom_strategy = QuasiRandomTraining(100; sampling_alg = LatinHypercubeSample())
+    # BFGS requires the objective to stay fixed between evaluations, and Sobol sampling
+    # keeps the collocation set independent of the global RNG.
+    quasirandom_strategy = QuasiRandomTraining(
+        100; sampling_alg = SobolSample(), resampling = false, minibatch = 1
+    )
 
-    discretization = PhysicsInformedNN(chain, quasirandom_strategy)
+    init_params = let rng = Xoshiro(100)
+        [ComponentArray{Float64}(Lux.initialparameters(rng, c)) for c in chain]
+    end
+
+    discretization = PhysicsInformedNN(chain, quasirandom_strategy; init_params)
 
     @named pde_system = PDESystem(
         eq, bcs, domains, [x],
@@ -100,17 +109,24 @@ using Test
     pde_inner_loss_functions = sym_prob.loss_functions.pde_loss_functions
     bcs_inner_loss_functions = sym_prob.loss_functions.bc_loss_functions
 
+    # Stop on the loss level the accuracy assertion needs instead of on a fixed iteration
+    # count. BFGS is still descending at 1000 iterations here, so a truncated run lands
+    # wherever floating-point differences (code coverage, BLAS, hardware) put it.
+    training_tol = 1.0e-9
+
     callback = function (p, l)
         if p.iter % 100 == 0||p.iter == 1
             println("loss: ", l)
             println("pde_losses: ", map(l_ -> l_(p.u), pde_inner_loss_functions))
             println("bcs_losses: ", map(l_ -> l_(p.u), bcs_inner_loss_functions))
         end
-        return false
+        return l < training_tol
     end
 
-    res = solve(prob, BFGS(); maxiters = 1000, callback)
+    res = solve(prob, BFGS(); maxiters = 5000, callback)
     phi = discretization.phi[1]
+
+    @test res.objective < training_tol
 
     analytic_sol_func(x) = (π * x * (-x + (π^2) * (2 * x - 3) + 1) - sin(π * x)) / (π^3)
 


### PR DESCRIPTION
Fixes https://github.com/SciML/NeuralPDE.jl/issues/1095.

**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Problem

`test/NNPDE1/nnpde__pde_iii_3rd_order_ode.jl` was unreliable for three
independent reasons, all of which fed the same failure:

1. **Unseeded initialization.** `PhysicsInformedNN(chain, quasirandom_strategy)`
   fell back to `Random.default_rng()`, so the starting point depended on
   whatever the ambient RNG state was.
2. **A non-stationary objective.** `QuasiRandomTraining(100; sampling_alg =
   LatinHypercubeSample())` defaults to `resampling = true`, which draws a fresh
   Latin hypercube sample on *every* loss evaluation. BFGS assumes the objective
   is fixed between evaluations; `nnpde__pde_vi_pde_with_mixed_derivative.jl`
   already carries a comment saying exactly this.
3. **Truncated optimization.** BFGS was cut off at `maxiters = 1000` while the
   loss was still descending roughly an order of magnitude per 250 iterations.
   The endpoint was therefore wherever the trajectory happened to be at
   iteration 1000, not a converged minimum.

`--code-coverage=user` changes floating-point results (inlining/SIMD), which is
enough to move a still-descending trajectory to a different loss. In the
reported case that was `4.50e-8` (fails) versus `1.85e-8` (passes) against an
`atol = 1e-4` assertion.

## Fix

- Seed the initialization explicitly with `Xoshiro(100)`, forcing `Float64`
  params the same way NeuralPDE's own default path does.
- Hold the collocation set fixed: `SobolSample()` with `resampling = false,
  minibatch = 1`. Sobol is deterministic, so the training set no longer depends
  on the global RNG at all.
- Terminate on the loss level the accuracy assertion needs (`1e-9`) rather than
  on an iteration count, with `maxiters = 5000` as a cap, and assert
  `res.objective < training_tol` so an under-trained run fails loudly instead of
  silently producing a marginal prediction.

The `@test u_predict ≈ u_real atol = 10^-4` assertion is **unchanged** — no
tolerance was weakened.

## Verification (Julia 1.12.6, local)

Reproduced the original failure first, using the exact RNG recorded in the issue
under `--threads=1,1 --code-coverage=user --check-bounds=yes --warn-overwrite=yes
--depwarn=yes --inline=yes --startup-file=no`:

```
loss after 1000 iterations: 4.502195204451791e-8
PDE III: 3rd-order ODE: Test Failed ... atol=0.0001
coverage reproduction | Fail 1 Total 1  5m36.0s   (exit 1)
```

byte-identical to the numbers in the issue.

With this branch, the same wrapper and the same recorded RNG:

| run | result |
|---|---|
| coverage, `--threads=1,1`, full CI flag set | **2/2 pass**, 4m36.2s |
| no coverage, `--threads=1,1` | **2/2 pass**, 3m09.1s |
| coverage, `--threads=4,1` | **2/2 pass**, 3m52.6s |

Robustness sweep over five initialization seeds (100–104), with and without
coverage — nine runs, all passing, showing the margin under the unchanged
`atol = 1e-4`:

| | L2 error range | max component error | BFGS iterations |
|---|---|---|---|
| no coverage (seeds 100–104) | 3.78e-6 – 1.14e-5 | ≤ 2.58e-6 | 1117 – 2396 |
| coverage (seeds 100–103) | 5.95e-6 – 1.09e-5 | ≤ 2.33e-6 | 1551 – 2121 |

Worst observed L2 error is 1.14e-5 against a 1e-4 assertion — an 8.8x margin,
versus the 1.22e-4 that failed before. Worst iteration count is 2396 against the
5000 cap.

Global-RNG independence was checked directly: running with `Random.seed!(1)`
versus `Random.seed!(987654)` produced bit-identical results
(`l2 = 2.3733811692614514e-5`, 758 iterations in both).

Full group under coverage, `GROUP=NNPDE1 julia --project -e 'using Pkg;
Pkg.test(; coverage=true)'` — **23/23 pass**:

```
NNPDE1/nnpde__nnpde_translating_from_flux.jl      | 2  2   6m08.0s
NNPDE1/nnpde__pde_i_heterogeneous_system.jl       | 4  4   1m54.3s
NNPDE1/nnpde__pde_ii_2d_poisson.jl                | 6  6  12m36.8s
NNPDE1/nnpde__pde_iii_3rd_order_ode.jl            | 2  2   1m15.2s
NNPDE1/nnpde__pde_iv_system_of_pdes.jl            | 2  2  12m19.4s
NNPDE1/nnpde__pde_v_2d_wave_equation.jl           | 1  1  10m40.6s
NNPDE1/nnpde__pde_vi_pde_with_mixed_derivative.jl | 1  1   2m33.4s
NNPDE1/nnpde__test_heterogeneous_ode.jl           | 5  5   3m00.6s
     Testing NeuralPDE tests passed
```

Runic.jl reports no formatting changes for the modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSNGVAqeupxtHtFdaYH3y6
