### PR TITLE
Restore GradientScale AdaptiveLoss test capacity

### DIFF
--- a/test/AdaptiveLoss/adaptive_loss__2d_poisson_gradientscaleadaptiveloss.jl
+++ b/test/AdaptiveLoss/adaptive_loss__2d_poisson_gradientscaleadaptiveloss.jl
@@ -10,7 +10,7 @@ module AdaptiveLossTestSetup
         logger = haslogger ? TBLogger(logdir) : nothing
 
         Random.seed!(60)
-        hid = 32
+        hid = 40
         chain = Chain(Dense(2, hid, tanh), Dense(hid, hid, tanh), Dense(hid, 1))
         strategy = StochasticTraining(256)
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

Fixes #1103.

## Investigation

The clean current `master` AdaptiveLoss group failed both GradientScale solution-error assertions with `total_diff_rel = 0.6782495387996011`.

An adjacent-commit history check established the boundary conclusively:

- `8b2ec976c2bb9d7190cdba6cfa96d72f14e854fe` (parent): AdaptiveLoss passed 12/12.
- `c9a6930c15527f847afb03d01f74266b4bd4a9ce`: both GradientScale assertions failed with the same deterministic value as current master.

That commit reduced the hidden-layer width from 40 to 32 while also separating the adaptive-loss state between the logger variants. The state separation is correct; the width reduction deterministically underfits the existing solution-error requirement.

## Fix

Restore the hidden-layer width to 40 while retaining separate `GradientScaleAdaptiveLoss` instances. The existing logger and no-logger solution-error assertions provide the regression coverage, so no assertion or tolerance was changed.

## Local verification

- `GROUP=AdaptiveLoss julia +release --project=. -e 'using Pkg; Pkg.test()'`: 12/12 passed.
- `GROUP=AdaptiveLoss julia +1.11 --project=. -e 'using Pkg; Pkg.test()'`: 12/12 passed.
- `GROUP=AdaptiveLoss julia +lts --project=. -e 'using Pkg; Pkg.test()'`: 12/12 passed.
- Runic check on the changed test file: passed.