### PR TITLE
Fix default verbosity in NNODE and NNSDE

### DIFF
--- a/src/NN_SDE_solve.jl
+++ b/src/NN_SDE_solve.jl
@@ -901,7 +901,7 @@ function SciMLBase.__solve(
 
     plen = maxiters === nothing ? 6 : ndigits(maxiters)
     callback = function (p, l)
-        if verbose
+        if verbose === true
             if maxiters === nothing
                 @printf("[NNSDE]\tIter: [%*d]\tLoss: %g\n", plen, p.iter, l)
             else

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -467,7 +467,7 @@ function SciMLBase.__solve(
 
     plen = maxiters === nothing ? 6 : ndigits(maxiters)
     callback = function (p, l)
-        if verbose
+        if verbose === true
             if maxiters === nothing
                 @printf("[NNODE]\tIter: [%*d]\tLoss: %g\n", plen, p.iter, l)
             else

--- a/test/NNODE/nnode__scalar.jl
+++ b/test/NNODE/nnode__scalar.jl
@@ -28,4 +28,7 @@ using Test
             sol = solve(prob, NNODE(luxchain, opt; autodiff); kwargs...)
         end
     end
+
+    sol = solve(prob, NNODE(luxchain, Adam(0.1)); dt = 1 / 20.0f0, maxiters = 1)
+    @test !isempty(sol.u)
 end

--- a/test/NNSDE1/nn_sde__test_1_solve_autodiff.jl
+++ b/test/NNSDE1/nn_sde__test_1_solve_autodiff.jl
@@ -32,4 +32,7 @@ using Test
             sol = solve(prob, NNSDE(luxchain, opt; autodiff); kwargs...)
         end
     end
+
+    sol = solve(prob, NNSDE(luxchain, Adam(0.1)); dt = 1 / 20.0f0, maxiters = 1)
+    @test !isempty(sol.timepoints)
 end


### PR DESCRIPTION
## Summary

- handle DiffEqBase v7's `DEVerbosity` default in the NNODE and NNSDE optimization callbacks
- retain iteration printing when callers explicitly pass `verbose = true`
- exercise omitted `verbose` in the NNODE and NNSDE solver tests

## Root cause

The callbacks assumed that the `verbose` keyword was always a `Bool`. DiffEqBase commit [`6853462`](https://github.com/SciML/OrdinaryDiffEq.jl/commit/68534628d5de82286bab6155feeec0ac5857b116) changed the v7 `solve` default to `DEFAULT_VERBOSE`, a `DEVerbosity`. NeuralPDE opened DiffEqBase/OrdinaryDiffEq v7 compatibility in `5c011a7` without adapting these pre-existing callbacks, so an ordinary `solve(prob, NNODE(...))` or `solve(prob, NNSDE(...))` reached a non-Boolean value in `if verbose`.

The local progress output remains an explicit opt-in: only the literal `verbose = true` enables it. This matches the existing SDEPINN compatibility handling.

Issue #1105 currently records a separate numerical assertion failure in the data-collocation tutorial. This PR fixes the default-verbosity defect found during that investigation and does not close #1105.

## Validation

- reproduced the pre-fix `TypeError: non-boolean (DiffEqBase.DEVerbosity...) used in boolean context` in both NNODE and NNSDE with Julia 1.12.6 and DiffEqBase 7.13.0
- rendered a normal Documenter `@example` containing both omitted-`verbose` solves on Julia 1.12.6 and Julia 1.10.11
- passed `NNSDE1/nn_sde__test_1_solve_autodiff.jl` on Julia 1.12.6, 1.11.9, and 1.10.11
- passed Runic and `git diff --check`
- full NNODE/NNSDE groups and the unmodified clean full-docs build are still running locally; final results will be added in a PR comment

Ignore this PR until it has been reviewed by @ChrisRackauckas.
