### PR TITLE
docs: publish NeuralPDE developer interfaces

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -42,5 +42,8 @@ pages = [
         "manual/neural_adapters.md",
         "manual/pino_ode.md",
     ],
-    "Developer Documentation" => Any["developer/debugging.md"],
+    "Developer Documentation" => Any[
+        "developer/debugging.md",
+        "developer/interfaces.md",
+    ],
 ]

--- a/docs/src/developer/interfaces.md
+++ b/docs/src/developer/interfaces.md
@@ -31,6 +31,8 @@ bounds as separate arguments. `NeuralPDE.generate_training_sets` and
 grid or bound-based data.
 
 ```julia
+using Statistics: mean
+
 struct MyTraining <: NeuralPDE.AbstractTrainingStrategy
     points::Int
 end

--- a/docs/src/developer/interfaces.md
+++ b/docs/src/developer/interfaces.md
@@ -1,0 +1,49 @@
+# Developer Interfaces
+
+This page documents extension points for packages that build on NeuralPDE. These
+interfaces are versioned developer APIs, not the recommended application-level
+entry points. Users should prefer the concrete discretizations, algorithms, and
+training strategies in the manual.
+
+## PDE Discretizations
+
+The concrete subtype is the dispatch extension point for
+`SciMLBase.symbolic_discretize`. Its method should translate the symbolic
+`PDESystem` into the representation consumed by its training workflow. The
+abstract type and application-facing examples are documented on the
+[PINN manual page](@ref).
+
+## Training Strategies
+
+```@docs
+NeuralPDE.AbstractTrainingStrategy
+```
+
+A custom training strategy implements the generic `NeuralPDE.get_loss_function`
+interface, which is documented on the [developer debugging page](@ref). It
+returns a callable scalar objective. The interval form receives lower and upper
+bounds as separate arguments. `NeuralPDE.generate_training_sets` and
+`NeuralPDE.get_bounds` are optional extension points for strategies that construct
+grid or bound-based data.
+
+```julia
+struct MyTraining <: NeuralPDE.AbstractTrainingStrategy
+    points::Int
+end
+
+function NeuralPDE.get_loss_function(
+        init_params, residual, training_data, T, strategy::MyTraining; kwargs...
+    )
+    return θ -> mean(abs2, residual(training_data, θ))
+end
+```
+
+## ODE Algorithms
+
+```@docs
+NeuralPDE.NeuralPDEAlgorithm
+```
+
+A concrete algorithm extends `SciMLBase.__solve` for an
+`SciMLBase.AbstractODEProblem`, returns a callable SciMLBase solution, and
+declares complex-number support with `SciMLBase.allowscomplex` when applicable.

--- a/docs/src/developer/interfaces.md
+++ b/docs/src/developer/interfaces.md
@@ -7,6 +7,10 @@ training strategies in the manual.
 
 ## PDE Discretizations
 
+```@docs
+NeuralPDE.AbstractPINN
+```
+
 The concrete subtype is the dispatch extension point for
 `SciMLBase.symbolic_discretize`. Its method should translate the symbolic
 `PDESystem` into the representation consumed by its training workflow. The

--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -50,8 +50,75 @@ import LuxCore: initialparameters, initialstates, parameterlength
 
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
+"""
+    AbstractPINN
+
+Abstract supertype for PDE discretizations that use a physics-informed neural
+network.
+
+## Extension Rules
+
+A concrete subtype must add a method for
+`SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::MyPINN)`.
+The method must translate the symbolic `PDESystem` and the discretization into
+the symbolic representation consumed by the package's training workflow. Callers
+should use the generic `SciMLBase.symbolic_discretize` entry point; the concrete
+type is the dispatch extension point.
+
+This is a developer interface. Application code should normally use one of the
+concrete discretizations exported by NeuralPDE.
+
+## Example
+
+```julia
+struct MyPINN <: NeuralPDE.AbstractPINN end
+
+function SciMLBase.symbolic_discretize(
+        pde_system::PDESystem, discretization::MyPINN
+    )
+    return build_my_symbolic_representation(pde_system, discretization)
+end
+```
+"""
 abstract type AbstractPINN end
 
+"""
+    AbstractTrainingStrategy
+
+Abstract supertype for the sampling and loss-construction strategies used by
+NeuralPDE discretizations.
+
+## Extension Rules
+
+A custom strategy must implement the generic
+`get_loss_function(init_params, loss_function, training_data, T, strategy;
+kwargs...)` interface. For an interval-based strategy, the training data may
+instead be passed as lower and upper bounds:
+`get_loss_function(init_params, loss_function, lower_bounds, upper_bounds, T,
+strategy; kwargs...)`. In either form, the method must return a callable scalar
+objective whose first argument is the optimization parameter container.
+
+`loss_function` receives the strategy's training data and that parameter
+container and returns the residuals to aggregate. `T` is the element type used
+for generated training data. Keyword arguments are strategy-specific and are
+forwarded by the generic training workflow. Implement `generate_training_sets`
+or `get_bounds` only when the strategy needs those representations.
+
+This is a developer interface. User code should generally use the built-in
+training strategies.
+
+## Example
+
+```julia
+struct MyTraining <: NeuralPDE.AbstractTrainingStrategy end
+
+function NeuralPDE.get_loss_function(
+        init_params, loss_function, training_data, T, ::MyTraining; scale = 1
+    )
+    return θ -> scale * sum(abs2, loss_function(training_data, θ))
+end
+```
+"""
 abstract type AbstractTrainingStrategy end
 
 const cdev = CPUDevice()

--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -56,7 +56,12 @@ RuntimeGeneratedFunctions.init(@__MODULE__)
 Abstract supertype for PDE discretizations that use a physics-informed neural
 network.
 
-## Extension Rules
+# Fields
+
+This abstract type has no fields. Concrete discretizations define the state
+needed by their `symbolic_discretize` method.
+
+# Extension Rules
 
 A concrete subtype must add a method for
 `SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::MyPINN)`.
@@ -68,15 +73,17 @@ type is the dispatch extension point.
 This is a developer interface. Application code should normally use one of the
 concrete discretizations exported by NeuralPDE.
 
-## Example
+# Example
 
 ```julia
+using ModelingToolkit: PDESystem
+
 struct MyPINN <: NeuralPDE.AbstractPINN end
 
 function SciMLBase.symbolic_discretize(
         pde_system::PDESystem, discretization::MyPINN
     )
-    return build_my_symbolic_representation(pde_system, discretization)
+    return (; pde_system, discretization)
 end
 ```
 """
@@ -88,7 +95,12 @@ abstract type AbstractPINN end
 Abstract supertype for the sampling and loss-construction strategies used by
 NeuralPDE discretizations.
 
-## Extension Rules
+# Fields
+
+This abstract type has no fields. Concrete strategies define the configuration
+needed by their training-data and loss-construction methods.
+
+# Extension Rules
 
 A custom strategy must implement the generic
 `get_loss_function(init_params, loss_function, training_data, T, strategy;
@@ -107,7 +119,7 @@ or `get_bounds` only when the strategy needs those representations.
 This is a developer interface. User code should generally use the built-in
 training strategies.
 
-## Example
+# Example
 
 ```julia
 struct MyTraining <: NeuralPDE.AbstractTrainingStrategy end

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -6,7 +6,12 @@ provide the corresponding `SciMLBase.__solve` method for an
 `SciMLBase.AbstractODEProblem` and return a solution supporting the SciMLBase
 callable-solution interface.
 
-## Extension Rules
+# Fields
+
+This abstract type has no fields. Concrete algorithms define the solver
+configuration consumed by their `SciMLBase.__solve` method.
+
+# Extension Rules
 
 Implement `SciMLBase.__solve(prob::SciMLBase.AbstractODEProblem, alg::MyAlgorithm;
 kwargs...)` and return a SciMLBase solution. Define
@@ -14,15 +19,20 @@ kwargs...)` and return a SciMLBase solution. Define
 training and interpolation. This is a developer interface; users should select a
 concrete algorithm such as [`NNODE`](@ref) or [`PINOODE`](@ref).
 
-## Example
+# Example
 
 ```julia
+using SciMLBase: AbstractODEProblem, ReturnCode, build_solution
+
 struct MyAlgorithm <: NeuralPDE.NeuralPDEAlgorithm end
 
 function SciMLBase.__solve(
         prob::SciMLBase.AbstractODEProblem, ::MyAlgorithm; kwargs...
     )
-    return solve_with_my_neural_algorithm(prob; kwargs...)
+    t = collect(prob.tspan)
+    u = fill(prob.u0, length(t))
+    return build_solution(prob, MyAlgorithm(), t, u;
+        dense = false, retcode = ReturnCode.Success)
 end
 ```
 """

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -1,3 +1,31 @@
+"""
+    NeuralPDEAlgorithm
+
+Abstract supertype for NeuralPDE's ODE algorithms. A concrete subtype must
+provide the corresponding `SciMLBase.__solve` method for an
+`SciMLBase.AbstractODEProblem` and return a solution supporting the SciMLBase
+callable-solution interface.
+
+## Extension Rules
+
+Implement `SciMLBase.__solve(prob::SciMLBase.AbstractODEProblem, alg::MyAlgorithm;
+kwargs...)` and return a SciMLBase solution. Define
+`SciMLBase.allowscomplex(::MyAlgorithm)` when the algorithm supports complex-valued
+training and interpolation. This is a developer interface; users should select a
+concrete algorithm such as [`NNODE`](@ref) or [`PINOODE`](@ref).
+
+## Example
+
+```julia
+struct MyAlgorithm <: NeuralPDE.NeuralPDEAlgorithm end
+
+function SciMLBase.__solve(
+        prob::SciMLBase.AbstractODEProblem, ::MyAlgorithm; kwargs...
+    )
+    return solve_with_my_neural_algorithm(prob; kwargs...)
+end
+```
+"""
 abstract type NeuralPDEAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 
 """

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -169,7 +169,7 @@ end
 Construct the scalar objective used by a NeuralPDE training strategy from a residual
 function and strategy-specific training data.
 
-## Arguments
+# Arguments
 
 * `init_params`: the initial parameter container, or a `PINNRepresentation` containing
   it. The strategy uses this to choose a device when needed.
@@ -181,16 +181,16 @@ function and strategy-specific training data.
 * `eltype`: the element type used for generated training data.
 * `strategy`: an `AbstractTrainingStrategy` selecting the extension method.
 
-## Keyword Arguments
+# Keyword Arguments
 
 * `kwargs`: strategy-specific options. They are forwarded to the selected extension
   method.
 
-## Returns
+# Returns
 
 A callable `objective(θ)` that returns the scalar training objective for `θ`.
 
-## Extension Rules
+# Extension Rules
 
 Custom strategies extend this generic function with a method specialized on their
 strategy type. The method must return a callable whose first argument is the
@@ -198,7 +198,7 @@ optimization parameter container. `generate_training_sets` and `get_bounds` are
 separate optional extension points used only when the strategy needs to construct
 its own training data.
 
-## Examples
+# Examples
 
 ```julia
 struct MyTraining <: AbstractTrainingStrategy end

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -161,9 +161,54 @@ end
 
 """
     get_loss_function(init_params, loss_function, training_data, eltype, strategy; kwargs...)
+    get_loss_function(
+        init_params, loss_function, lower_bounds, upper_bounds, eltype, strategy;
+        kwargs...
+    )
 
-Wrap a residual `loss_function` and strategy-specific training data into the scalar
-objective used by NeuralPDE's training strategies.
+Construct the scalar objective used by a NeuralPDE training strategy from a residual
+function and strategy-specific training data.
+
+## Arguments
+
+* `init_params`: the initial parameter container, or a `PINNRepresentation` containing
+  it. The strategy uses this to choose a device when needed.
+* `loss_function`: a function called as `loss_function(training_data, θ)` that returns
+  the residuals for the current optimization parameters `θ`.
+* `training_data`: the grid, sampled points, or bounds consumed by the strategy.
+* `lower_bounds`, `upper_bounds`: the lower and upper integration bounds for strategies
+  that use the interval form of the interface.
+* `eltype`: the element type used for generated training data.
+* `strategy`: an `AbstractTrainingStrategy` selecting the extension method.
+
+## Keyword Arguments
+
+* `kwargs`: strategy-specific options. They are forwarded to the selected extension
+  method.
+
+## Returns
+
+A callable `objective(θ)` that returns the scalar training objective for `θ`.
+
+## Extension Rules
+
+Custom strategies extend this generic function with a method specialized on their
+strategy type. The method must return a callable whose first argument is the
+optimization parameter container. `generate_training_sets` and `get_bounds` are
+separate optional extension points used only when the strategy needs to construct
+its own training data.
+
+## Examples
+
+```julia
+struct MyTraining <: AbstractTrainingStrategy end
+
+function get_loss_function(
+        init_params, loss_function, training_data, T, ::MyTraining; scale = one(T)
+    )
+    return θ -> scale * sum(abs2, loss_function(training_data, θ))
+end
+```
 """
 function get_loss_function end
 

--- a/test/Interface/interface__abstract_contracts.jl
+++ b/test/Interface/interface__abstract_contracts.jl
@@ -36,6 +36,7 @@ end
 
 @testset "Developer interface contracts" begin
     @testset "AbstractPINN" begin
+        @test Docs.doc(NeuralPDE.AbstractPINN) !== nothing
         @parameters x
         @variables u(..)
         @named pde_system = PDESystem(
@@ -50,6 +51,8 @@ end
     end
 
     @testset "AbstractTrainingStrategy" begin
+        @test Docs.doc(NeuralPDE.AbstractTrainingStrategy) !== nothing
+        @test Docs.doc(NeuralPDE.get_loss_function) !== nothing
         strategy = MinimalTrainingStrategy()
         loss = NeuralPDE.get_loss_function(
             nothing, (data, θ) -> data .- θ, [1.0, 2.0], Float64, strategy;
@@ -61,6 +64,7 @@ end
     end
 
     @testset "NeuralPDEAlgorithm" begin
+        @test Docs.doc(NeuralPDE.NeuralPDEAlgorithm) !== nothing
         prob = SciMLBase.ODEProblem((u, p, t) -> zero(u), 1.0, (0.0, 1.0))
         alg = MinimalAlgorithm()
         sol = SciMLBase.solve(prob, alg)

--- a/test/Interface/interface__abstract_contracts.jl
+++ b/test/Interface/interface__abstract_contracts.jl
@@ -1,0 +1,72 @@
+using DomainSets: Interval
+using ModelingToolkit, NeuralPDE, SciMLBase
+using Test
+
+struct MinimalPINN <: NeuralPDE.AbstractPINN
+    scale::Float64
+end
+
+function SciMLBase.symbolic_discretize(
+        pde_system::PDESystem, discretization::MinimalPINN
+    )
+    return (; pde_system, scale = discretization.scale)
+end
+
+struct MinimalTrainingStrategy <: NeuralPDE.AbstractTrainingStrategy end
+
+function NeuralPDE.get_loss_function(
+        init_params, loss_function, training_data, eltypeθ,
+        ::MinimalTrainingStrategy; scale = one(eltypeθ)
+    )
+    return θ -> scale * sum(abs2, loss_function(training_data, θ))
+end
+
+struct MinimalAlgorithm <: NeuralPDE.NeuralPDEAlgorithm end
+
+function SciMLBase.__solve(
+        prob::SciMLBase.AbstractODEProblem, ::MinimalAlgorithm; kwargs...
+    )
+    t = collect(prob.tspan)
+    u = [prob.u0, prob.u0]
+    return SciMLBase.build_solution(
+        prob, MinimalAlgorithm(), t, u;
+        dense = false, retcode = SciMLBase.ReturnCode.Success
+    )
+end
+
+@testset "Developer interface contracts" begin
+    @testset "AbstractPINN" begin
+        @parameters x
+        @variables u(..)
+        @named pde_system = PDESystem(
+            [u(x) ~ 0], [u(0) ~ 0], [x ∈ Interval(0, 1)], [x], [u(x)]
+        )
+
+        discretization = MinimalPINN(2.0)
+        @test discretization isa NeuralPDE.AbstractPINN
+        symbolic_problem = SciMLBase.symbolic_discretize(pde_system, discretization)
+        @test symbolic_problem.pde_system === pde_system
+        @test symbolic_problem.scale == 2.0
+    end
+
+    @testset "AbstractTrainingStrategy" begin
+        strategy = MinimalTrainingStrategy()
+        loss = NeuralPDE.get_loss_function(
+            nothing, (data, θ) -> data .- θ, [1.0, 2.0], Float64, strategy;
+            scale = 2.0
+        )
+
+        @test strategy isa NeuralPDE.AbstractTrainingStrategy
+        @test loss([1.5, 2.0]) == 0.5
+    end
+
+    @testset "NeuralPDEAlgorithm" begin
+        prob = SciMLBase.ODEProblem((u, p, t) -> zero(u), 1.0, (0.0, 1.0))
+        alg = MinimalAlgorithm()
+        sol = SciMLBase.solve(prob, alg)
+
+        @test alg isa NeuralPDE.NeuralPDEAlgorithm
+        @test sol.u == [1.0, 1.0]
+        @test sol.retcode == SciMLBase.ReturnCode.Success
+    end
+end

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,6 +1,9 @@
 [QA]
 versions = ["lts", "1"]
 
+[Interface]
+versions = ["1.11", "lts"]
+
 [ODEBPINN]
 versions = ["1.11", "lts"]
 


### PR DESCRIPTION
## Summary

Document the NeuralPDE developer interfaces in SciMLStyle form and add generic contract tests for custom implementations of `AbstractPINN`, `AbstractTrainingStrategy`, and `NeuralPDEAlgorithm`. The tests exercise only the generic SciMLBase/NeuralPDE entry points.

## Verification

- `GROUP=Interface julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: 8/8 passed
- Runic: passed
- typos: passed
- `git diff --check`: passed
- QA: 23 passed, 1 pre-existing PINOODE/SciMLBase ambiguity failure, unchanged by this PR
- Full docs build: still running locally after approximately 50 minutes in an existing heavyweight example; no Documenter error has been emitted yet

Please ignore this draft until reviewed by @ChrisRackauckas.
