### PR TITLE
fix: make NNODE/PINOODE/NNSDE/SDEPINN subtype the SciMLBase algorithm hierarchy

### DIFF
--- a/src/NN_SDE_solve.jl
+++ b/src/NN_SDE_solve.jl
@@ -128,7 +128,7 @@ Stochastic Physics-Informed Neural Ordinary Differential Equations : https://arx
 Stochastic PDE Functionality #531 : https://github.com/SciML/NeuralPDE.jl/issues/531
 
 """
-@concrete struct NNSDE
+@concrete struct NNSDE <: SciMLBase.AbstractSDEAlgorithm
     chain <: AbstractLuxLayer
     opt
     init_params

--- a/src/NN_SDE_weaksolve.jl
+++ b/src/NN_SDE_weaksolve.jl
@@ -45,7 +45,7 @@ alg = SDEPINN(
 )
 ```
 """
-@concrete struct SDEPINN
+@concrete struct SDEPINN <: SciMLBase.AbstractSDEAlgorithm
     chain <: AbstractLuxLayer
     optimalg
     norm_loss_alg

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -126,7 +126,7 @@ Lagaris, Isaac E., Aristidis Likas, and Dimitrios I. Fotiadis. "Artificial neura
 for solving ordinary and partial differential equations." IEEE Transactions on Neural
 Networks 9, no. 5 (1998): 987-1000.
 """
-@concrete struct NNODE
+@concrete struct NNODE <: NeuralPDEAlgorithm
     chain <: AbstractLuxLayer
     opt
     init_params

--- a/src/pino_ode_solve.jl
+++ b/src/pino_ode_solve.jl
@@ -30,7 +30,7 @@ neural operator, which is used as a solver for a parametrized `ODEProblem`.
 * Sifan Wang "Learning the solution operator of parametric partial differential equations with physics-informed DeepOnets"
 * Zongyi Li "Physics-Informed Neural Operator for Learning Partial Differential Equations"
 """
-@concrete struct PINOODE
+@concrete struct PINOODE <: NeuralPDEAlgorithm
     chain
     opt
     bounds

--- a/test/Interface/interface__abstract_contracts.jl
+++ b/test/Interface/interface__abstract_contracts.jl
@@ -73,4 +73,20 @@ end
         @test sol.u == [1.0, 1.0]
         @test sol.retcode == SciMLBase.ReturnCode.Success
     end
+
+    # `DiffEqBase.extract_alg` only picks up the algorithm passed to `solve` when it
+    # is a `SciMLBase.AbstractSciMLAlgorithm`. Anything else is treated as "no
+    # algorithm given" and is silently replaced by the default solver of the loaded
+    # solver package, so the NeuralPDE solver would never run.
+    @testset "Solver algorithms subtype the SciMLBase algorithm hierarchy" begin
+        for T in (NeuralPDE.NNODE, NeuralPDE.PINOODE, NeuralPDE.BNNODE)
+            @test T <: SciMLBase.AbstractODEAlgorithm
+        end
+
+        @test NeuralPDE.NNDAE <: SciMLBase.AbstractDAEAlgorithm
+
+        for T in (NeuralPDE.NNSDE, NeuralPDE.SDEPINN)
+            @test T <: SciMLBase.AbstractSDEAlgorithm
+        end
+    end
 end

--- a/test/NNODE/nnode__nnode_translating_from_flux.jl
+++ b/test/NNODE/nnode__nnode_translating_from_flux.jl
@@ -22,6 +22,11 @@ using Test
 
     alg = NNODE(fluxchain, opt)
     @test alg.chain isa Lux.AbstractLuxLayer
+    # `NNODE` must be recognized as a SciML algorithm, otherwise `solve` silently
+    # falls back to the default ODE algorithm (see the `DiffEqBase.extract_alg`
+    # path exercised whenever OrdinaryDiffEq is loaded alongside NeuralPDE).
+    @test alg isa SciMLBase.AbstractODEAlgorithm
     sol = solve(prob, alg; verbose = false, abstol = 1.0e-10, maxiters = 200)
+    @test sol.alg isa NNODE
     @test sol.errors[:l2] < 0.5
 end


### PR DESCRIPTION
## Failing lanes

At master `62ff9be8` ("Add PDE precompilation workload (#1119)"):

- `tests / NNODE (julia 1.11, ubuntu-latest)` — [job 96902117865](https://github.com/SciML/NeuralPDE.jl/actions/runs/32519247903/job/96902117865)
- `tests / NNODE (julia lts, ubuntu-latest)` — [job 96902117912](https://github.com/SciML/NeuralPDE.jl/actions/runs/32519247903/job/96902117912)

Both abort on `test/NNODE/nnode__nnode_translating_from_flux.jl`, the first file in
the group that constructs an `NNODE` (the two `nndae__*` files that run before it use
`NNDAE`, which was unaffected).

Note these are the only two lanes the NNODE group runs on — `test/test_groups.toml`
declares `[NNODE] versions = ["1.11", "lts"]`. There is no `julia 1` NNODE lane, so
the failure is **not** Julia-version specific.

## Actual error

```
NNODE: Translating from Flux: Error During Test at test/NNODE/nnode__nnode_translating_from_flux.jl:4
  Got exception outside of a @test
  ArgumentError: Passing a `Bool` for `verbose` is no longer supported in OrdinaryDiffEq v7: `verbose` now takes a verbosity object.

      solve(prob, alg; verbose = DEVerbosity(SciMLLogging.None()))  # was verbose = false
      solve(prob, alg; verbose = DEVerbosity())                     # was verbose = true
  Stacktrace:
    [1] _process_verbose_param
      @ DiffEqBase ~/.julia/packages/DiffEqBase/mLfsc/src/verbosity.jl:356 [inlined]
    [2] #_ode_init#99
      @ OrdinaryDiffEqCore ~/.julia/packages/OrdinaryDiffEqCore/ICc50/src/solve.jl:231 [inlined]
    [3] __init(prob::ODEProblem{...}, alg::OrdinaryDiffEqCore.CompositeAlgorithm{...}, ...)
    [4] __solve(::ODEProblem{...}, ::OrdinaryDiffEqCore.CompositeAlgorithm{...}; ...)
    [5] solve_call(_prob::ODEProblem{...}, args::OrdinaryDiffEqCore.CompositeAlgorithm{...}; ...)
    [6] solve_up(prob::ODEProblem{...}, sensealg::Nothing, u0::Float32, p::NullParameters, args::NeuralPDE.NNODE{...}; ...)
    [7] solve(prob::ODEProblem{...}, args::NeuralPDE.NNODE{...}; ..., verbose::Bool, ...)
    [8] macro expansion
      @ test/NNODE/nnode__nnode_translating_from_flux.jl:25 [inlined]
```

The tell is frames [6] → [5]: `solve_up` receives `args::NNODE`, but `solve_call`
receives an `OrdinaryDiffEqCore.CompositeAlgorithm`. **`NNODE` never ran at all** —
the default ODE solver ran in its place, and the error is just that solver rejecting
`verbose = false`.

## Root cause

`NNODE` is declared with no supertype:

```julia
@concrete struct NNODE
```

It used to be `<: NeuralPDEAlgorithm` (which is `<: SciMLBase.AbstractODEAlgorithm`);
the supertype was dropped in 4506f6aa when the struct was converted to `@concrete`.
`PINOODE`, `NNSDE` and `SDEPINN` have the same defect. `NNDAE`
(`<: SciMLBase.AbstractDAEAlgorithm`) and `BNNODE` (`<: NeuralPDEAlgorithm`) do not,
which is why their tests kept passing.

`DiffEqBase.solve` locates the algorithm through `SciMLBase.extract_alg`
(SciMLBase 3.49.1, `src/solve.jl:46`), which only accepts a positional argument that
is a `SciMLBase.AbstractSciMLAlgorithm`:

```julia
elseif first(solve_args) isa SciMLBase.AbstractSciMLAlgorithm &&
        !(first(solve_args) isa SciMLBase.EnsembleAlgorithm)
    first(solve_args)
else
    nothing
end
```

`NNODE` falls into the `else`, so `alg === nothing` and `solve_up`
(DiffEqBase 7.18.1, `src/solve.jl:637`) does:

```julia
alg = extract_alg(args, kwargs, ...)      # nothing
if isnothing(alg)
    alg = prepare_alg(alg, u0, p, prob)   # OrdinaryDiffEqDefault: DefaultODEAlgorithm()
end
return if isnothing(alg) || !(alg isa AbstractDEAlgorithm)
    ...
else
    ...
    if length(args) > 1
        solve_call(_prob, _alg, Base.tail(args)...; kwargs...)
    else
        solve_call(_prob, _alg; kwargs...)   # <- the NNODE in args is discarded
    end
end
```

`OrdinaryDiffEqDefault` defines `DiffEqBase.prepare_alg(::Nothing, u0, p, ::ODEProblem)`,
so as soon as OrdinaryDiffEq is loaded the "no algorithm" case resolves to
`DefaultODEAlgorithm()` and the user's algorithm is thrown away. Every NNODE test file
does `using OrdinaryDiffEq`; the PINOODE tests do not, which is why PINOODE has been
getting away with the same defect.

### Why it appeared at 62ff9be8 and not at v6.2.2

This is **not** caused by the precompilation workload in #1119, and the workload is
fine (`test/Interface/precompile_workload.jl` passes locally). The trigger is an
upstream release in the three days between the two master pushes:

| | v6.2.2 run (Aug 18, green) | 62ff9be8 run (Aug 21, red) |
|---|---|---|
| DiffEqBase | 7.15.0 | **7.18.1** |
| SciMLBase | 3.49.0 | 3.49.1 |
| OrdinaryDiffEqCore | 4.14.3 | 4.14.3 |

DiffEqBase 7.18 turned `verbose::Bool` into a hard `ArgumentError`. Before that the
substituted default solver happily accepted `verbose = false` and returned a
Tsit5/Vern7 solution — which passed `@test sol.errors[:l2] < 0.5` because a real ODE
solver nails `du = cospi(2t)`. So the latent bug is older and worse than the CI red:
`solve(prob, NNODE(...))` has been silently returning a classical ODE solution instead
of a PINN solution whenever OrdinaryDiffEq was loaded.

## Fix

Restore the supertypes:

| type | supertype |
|---|---|
| `NNODE` | `NeuralPDEAlgorithm` (`<: SciMLBase.AbstractODEAlgorithm`) |
| `PINOODE` | `NeuralPDEAlgorithm` |
| `NNSDE` | `SciMLBase.AbstractSDEAlgorithm` |
| `SDEPINN` | `SciMLBase.AbstractSDEAlgorithm` |

`PINOODE`, `NNSDE` and `SDEPINN` are included because they are the same one-line
defect and are one `using StochasticDiffEq` / `using OrdinaryDiffEq` away from the
same silent fallback.

Regression tests:

- `test/Interface/interface__abstract_contracts.jl` — type-level contract that every
  solver algorithm subtypes the right `SciMLBase.Abstract*Algorithm`. Cheap, runs on
  both lanes, and would have caught this at the time it was introduced.
- `test/NNODE/nnode__nnode_translating_from_flux.jl` — `@test alg isa SciMLBase.AbstractODEAlgorithm`
  and `@test sol.alg isa NNODE`, so a silent substitution fails even if the numbers
  happen to look fine.

## Verification

Run locally on Julia 1.11.8 in a fresh environment that resolved to the **same**
versions as the red CI lane (DiffEqBase v7.18.1, SciMLBase v3.49.1, OrdinaryDiffEq
v7.6.0, OrdinaryDiffEqDefault v2.4.5):

| test | result |
|---|---|
| `test/NNODE/nnode__nnode_translating_from_flux.jl` | **4/4 pass** (was 1 pass / 1 fail / 1 error) |
| `test/Interface/interface__abstract_contracts.jl` | 18/18 pass |
| `test/Interface/precompile_workload.jl` | 2/2 pass |
| `test/NNSDE1/nn_sde__test_1_solve_autodiff.jl` | 2/2 pass |
| `test/PINOODE/pino_ode__example_du_cos_p_t_u.jl` | 1/1 pass |

Reverting only the `src/ode_solve.jl` hunk and re-running reproduces the CI
stacktrace exactly, character for character, including the
`solve_up(args::NNODE) → solve_call(args::CompositeAlgorithm)` frame pair — so the
diagnosis is confirmed, not inferred.

The full NNODE/PINOODE/NNSDE groups were not run end to end locally (heavy deps);
relying on CI for those.

`Runic` reports no changes on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
