### PR TITLE
fix: restore the documented reexported public API stripped in #1106

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -46,4 +46,5 @@ pages = [
         "developer/debugging.md",
         "developer/interfaces.md",
     ],
+    "API" => "api.md",
 ]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,62 @@
+# API
+
+NeuralPDE's own public API — the solver algorithms (`NNODE`, `NNDAE`, `BNNODE`,
+`PINOODE`, `NNSDE`, `SDEPINN`, `DeepGalerkin`), the `PhysicsInformedNN` discretization,
+the training strategies and the adaptive loss functions — is documented
+in the Manual: [ODE solvers](manual/ode.md), [DAE solvers](manual/dae.md),
+[PINN discretizations](manual/pinns.md), [Bayesian PINNs](manual/bpinns.md),
+[physics-informed neural operators](manual/pino_ode.md) and
+[neural adapters](manual/neural_adapters.md).
+
+This page documents the *reexported* surface instead: names that `using NeuralPDE`
+brings into scope but that another package owns and documents.
+
+## Reexported symbolic front end
+
+Writing down a `PDESystem` is the normal documented entry point to NeuralPDE, so
+`using NeuralPDE` also brings in the symbolic front end needed to express one. These
+names are owned and documented by
+[ModelingToolkit](https://docs.sciml.ai/ModelingToolkit/stable/) (several of them
+re-exported by ModelingToolkit from
+[Symbolics](https://docs.sciml.ai/Symbolics/stable/)):
+
+  - Declaring symbols: `@parameters`, `@variables`, `@named`, `@register_symbolic`
+  - Systems: `PDESystem`, `mtkcompile`, `@mtkcompile`, `unknowns`
+  - Operators: `Differential`, `Integral`
+  - Domain endpoints: `infimum`, `supremum`
+  - The `ModelingToolkit` module itself
+
+Anything else from ModelingToolkit or Symbolics must be imported from that package
+directly — for example `System`, `equations`, `parameters` and `observed` are
+system-manipulation API that NeuralPDE does not use in its own documented workflow, so
+they are deliberately not reexported. Interval domains still come from
+[DomainSets](https://juliaapproximation.github.io/DomainSets.jl/stable/)
+(`using DomainSets: Interval`), which NeuralPDE does not reexport.
+
+## Reexported SciML common interface
+
+`using NeuralPDE` also brings in the parts of the SciML common interface needed to
+build a problem, solve it and inspect the result, so they do not have to be imported
+separately. These names are owned and documented by
+[SciMLBase](https://docs.sciml.ai/SciMLBase/stable/):
+
+  - Problems: `ODEProblem`, `DAEProblem`, `SDEProblem`, `NoiseProblem`,
+    `OptimizationProblem`
+  - Functions: `ODEFunction`, `ODEInputFunction`, `OptimizationFunction`
+  - Solutions: `ODESolution`, `PDETimeSeriesSolution`
+  - Solving and discretizing: `solve`, `init`, `remake`, `discretize`,
+    `symbolic_discretize`
+  - Return status: `ReturnCode`
+  - The `SciMLBase` module itself
+
+Anything else from SciMLBase must be imported from SciMLBase directly. In particular
+the ensemble interface, the callback types and the integrator interface are not
+reexported: NeuralPDE's solvers train a network rather than step an integrator, so
+those names are not part of its documented use.
+
+!!! note
+    
+    This list is kept in sync in three places: the reexport `export` blocks in
+    `src/NeuralPDE.jl`, the `REEXPORTS` tuple in `test/qa/qa.jl` (which is what
+    `run_qa`'s `reexports_allow` is given, and which a test checks against
+    `names(NeuralPDE)`), and this page.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -30,7 +30,7 @@ Anything else from ModelingToolkit or Symbolics must be imported from that packa
 directly — for example `System`, `equations`, `parameters` and `observed` are
 system-manipulation API that NeuralPDE does not use in its own documented workflow, so
 they are deliberately not reexported. Interval domains still come from
-[DomainSets](https://juliaapproximation.github.io/DomainSets.jl/stable/)
+[DomainSets](https://github.com/JuliaApproximation/DomainSets.jl)
 (`using DomainSets: Interval`), which NeuralPDE does not reexport.
 
 ## Reexported SciML common interface

--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -29,6 +29,11 @@ using RuntimeGeneratedFunctions: RuntimeGeneratedFunctions, @RuntimeGeneratedFun
 using SciMLBase: SciMLBase, BatchIntegralFunction, IntegralProblem,
     OptimizationFunction, OptimizationProblem, ReturnCode, discretize,
     isinplace, solve, symbolic_discretize, ODEProblem
+# Part of the SciML common interface that NeuralPDE reexports (see the second `export`
+# block below) so that `using NeuralPDE` on its own is enough to follow the tutorials:
+# build a problem, solve it and inspect the result.
+using SciMLBase: DAEProblem, NoiseProblem, ODEFunction, ODEInputFunction, ODESolution,
+    PDETimeSeriesSolution, SDEProblem, init, remake
 using SciMLPublic: @public
 using Statistics: Statistics, mean
 using QuasiMonteCarlo: QuasiMonteCarlo, LatinHypercubeSample
@@ -39,6 +44,10 @@ using Zygote: Zygote
 using ModelingToolkit: ModelingToolkit, PDESystem, Differential, toexpr
 using ModelingToolkitBase: @named, @parameters, get_dvs, get_ivs
 using Symbolics: Symbolics, arguments, Num, expand_derivatives, @variables
+# Part of the symbolic front end that NeuralPDE reexports (see the second `export` block
+# below) so that `using NeuralPDE` on its own is enough to write down a `PDESystem`.
+using ModelingToolkitBase: @mtkcompile, mtkcompile, unknowns
+using Symbolics: Integral, @register_symbolic
 using SymbolicUtils: SymbolicUtils, unwrap
 using SymbolicIndexingInterface: SymbolicIndexingInterface
 
@@ -187,6 +196,19 @@ export AbstractAdaptiveLoss, NonAdaptiveLoss, GradientScaleAdaptiveLoss,
     MiniMaxAdaptiveLoss, SoftAdaptAdaptiveLoss, ReLoBRaLoAdaptiveLoss
 
 export LogOptions
+
+# Reexported public API of the SciML common interface and the ModelingToolkit/Symbolics
+# symbolic front end. `using NeuralPDE` used to supply these through
+# `@reexport using SciMLBase, ModelingToolkit`, which was removed in c9400f12 and took
+# the documented surface with it. These are the names NeuralPDE's own documentation,
+# README and tests use, plus the ones downstream SciML packages were relying on; every
+# one of them stays owned and documented upstream. Kept in sync with `REEXPORTS` in
+# `test/qa/qa.jl`.
+export SciMLBase, DAEProblem, NoiseProblem, ODEFunction, ODEInputFunction, ODEProblem,
+    ODESolution, OptimizationFunction, OptimizationProblem, PDETimeSeriesSolution,
+    ReturnCode, SDEProblem, init, remake, solve
+export ModelingToolkit, Differential, Integral, PDESystem, infimum, mtkcompile, supremum,
+    unknowns, @mtkcompile, @named, @parameters, @register_symbolic, @variables
 
 @public logscalar, logvector
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,9 +3,35 @@ using SciMLTesting, NeuralPDE, Test
 # Load every weak dependency so run_qa also scans NeuralPDE's package extensions.
 using AdvancedHMC, LogDensityProblems, MCMCChains, TensorBoardLogger
 
+# Kept in sync with the reexport `export` blocks in src/NeuralPDE.jl. These are the
+# upstream names `using NeuralPDE` is documented to supply on its own.
+const REEXPORTS = (
+    # SciML common interface (SciMLBase)
+    :SciMLBase, :DAEProblem, :NoiseProblem, :ODEFunction, :ODEInputFunction, :ODEProblem,
+    :ODESolution, :OptimizationFunction, :OptimizationProblem, :PDETimeSeriesSolution,
+    :ReturnCode, :SDEProblem, :discretize, :init, :remake, :solve, :symbolic_discretize,
+    # Symbolic front end (ModelingToolkit / ModelingToolkitBase / Symbolics)
+    :ModelingToolkit, :Differential, :Integral, :PDESystem, :infimum, :mtkcompile,
+    :supremum, :unknowns, Symbol("@mtkcompile"), Symbol("@named"), Symbol("@parameters"),
+    Symbol("@register_symbolic"), Symbol("@variables"),
+)
+
+@testset "Reexported public API stays in scope" begin
+    exported = Set(names(NeuralPDE))
+    for name in REEXPORTS
+        @test name in exported
+        @test isdefined(NeuralPDE, name)
+    end
+end
+
 run_qa(
     NeuralPDE;
-    reexports_allow = (:discretize, :symbolic_discretize),
+    reexports_allow = REEXPORTS,
+    # `infimum`/`supremum` are reexported from the symbolic front end but carry no
+    # docstring upstream: IntervalSets declares them and ModelingToolkit/Symbolics
+    # reexport them undocumented, so the docstring is owed by IntervalSets.jl. They
+    # are described on the reexport page in docs/src/api.md instead.
+    api_docs_kwargs = (; ignore = (:infimum, :supremum)),
     ei_kwargs = (;
         # Retain the reviewed Base.mapany, Base.Broadcast.dottable,
         # SymbolicUtils._iszero, and Symbolics.variables calls. ForwardDiff does not


### PR DESCRIPTION
## What stripped the surface

[`c9400f12`](https://github.com/SciML/NeuralPDE.jl/commit/c9400f12684c42ef528b1aabc88475a36537bb83)
("Enforce SciMLTesting 2.4 public API QA", #1106) deleted

```julia
@reexport using SciMLBase, ModelingToolkit
```

from `src/NeuralPDE.jl`. That shipped in **v6.2.2**.

Deleting the reexport silently strips NeuralPDE's public surface. On master today:

```julia
julia> using NeuralPDE

julia> length(names(NeuralPDE))
38          # no solve, no ODEProblem, no @named, no @parameters, no PDESystem
```

NeuralPDE's own CI never noticed, because the same commit rewrote all 100+ of its
test files and doc pages from `using NeuralPDE, ...` to
`using ModelingToolkit, NeuralPDE, SciMLBase, ...`. Downstream did notice:
NeuralLyapunov's ROA, Policy_search, Benchmarking and GPU test groups plus three of
its docs pages fail with `UndefVarError` for `@named`, `@mtkcompile`, `mtkcompile`,
`unknowns`, `SciMLBase`, `ODEFunction`, `ODEInputFunction`, `ODEProblem` and
`symbolic_discretize`.

## The fix

Not a blanket `@reexport` (that put ~1000 names in scope, including problem and
solution types for equation classes NeuralPDE cannot touch), and not leaving the
surface stripped. An **explicit `export` list** of exactly the names normal documented
use of NeuralPDE requires — 30 of them.

### Evidence used to pick the list

1. **NeuralPDE's own docs, README and tests as they stood at `c9400f12^`** — every
   identifier in a code block there that resolves to a name exported by SciMLBase or
   ModelingToolkit and not by NeuralPDE. That mechanical intersection produced 62
   candidates, which I filtered by inspecting each one's actual call site (dropping
   prose hits like "parameters", "equations", "complete", "value", and internals like
   `__solve`, `has_analytic`, `interp_summary`, `calculate_solution_errors!`,
   `AbstractDiscretizationMetadata`).
2. **Names the QA sweep itself had to add explicit imports for** — the
   `using ModelingToolkit, NeuralPDE, SciMLBase` lines c9400f12 inserted into every
   test file are direct evidence those two packages' names used to arrive via the
   reexport. `PDETimeSeriesSolution` for instance is asserted on in the PINOODE tests
   and had to gain `using SciMLBase: SciMLBase, PDETimeSeriesSolution`.
3. **The confirmed NeuralLyapunov breakage** — `@named`, `@mtkcompile`, `mtkcompile`,
   `unknowns`, `SciMLBase`, `ODEFunction`, `ODEInputFunction`, `ODEProblem`,
   `symbolic_discretize`.

### The list

**SciML common interface** (owned by [SciMLBase](https://docs.sciml.ai/SciMLBase/stable/)):

`SciMLBase`, `DAEProblem`, `NoiseProblem`, `ODEFunction`, `ODEInputFunction`,
`ODEProblem`, `ODESolution`, `OptimizationFunction`, `OptimizationProblem`,
`PDETimeSeriesSolution`, `ReturnCode`, `SDEProblem`, `discretize`, `init`, `remake`,
`solve`, `symbolic_discretize`

**Symbolic front end** (owned by
[ModelingToolkit](https://docs.sciml.ai/ModelingToolkit/stable/) /
ModelingToolkitBase / [Symbolics](https://docs.sciml.ai/Symbolics/stable/)):

`ModelingToolkit`, `Differential`, `Integral`, `PDESystem`, `infimum`, `mtkcompile`,
`supremum`, `unknowns`, `@mtkcompile`, `@named`, `@parameters`, `@register_symbolic`,
`@variables`

(`discretize` and `symbolic_discretize` were already exported and already in
`reexports_allow`; they are folded into the same list so there is one list, not two.)

### Deliberately excluded

- ModelingToolkit's `System`, `equations`, `parameters`, `observed` and the rest of
  the system-manipulation API — NeuralPDE's documented workflow builds a `PDESystem`
  and hands it to `discretize`; it never manipulates a compiled system.
- SciMLBase's ensemble interface, callback types and integrator interface — NeuralPDE's
  solvers train a network, they do not step an integrator.
- `DomainSets.Interval` — NeuralPDE's docs have always written
  `using DomainSets: Interval` explicitly, and DomainSets is a different owner again.

Each restored name is imported from the module that actually declares it public
(`ModelingToolkitBase` for `@mtkcompile`/`mtkcompile`/`unknowns`, `Symbolics` for
`Integral`/`@register_symbolic`, `SciMLBase` for the common interface), not funnelled
through a facade.

## Documenting the reexports

New rendered page `docs/src/api.md`, wired into `docs/pages.jl` as "API". It lists the
reexported names **grouped by role**, names and links the owning package for each
group, and closes each group with the explicit boundary ("Anything else from SciMLBase
must be imported from SciMLBase directly", likewise for ModelingToolkit) plus the
reasoning for the notable exclusions above. The two owners are deliberately kept in
separate sections, since `@named`/`@mtkcompile`/`unknowns`/`PDESystem` are
ModelingToolkit's while `ODEProblem`/`ODEFunction`/`solve`/`symbolic_discretize` are
SciMLBase's, and a reader needs to know which docs to go read.

## Keeping it from drifting

The same list now lives in three places that are checked against each other:

- the two reexport `export` blocks in `src/NeuralPDE.jl`,
- `const REEXPORTS` in `test/qa/qa.jl`, passed to `run_qa` as `reexports_allow` so
  strict QA accepts them as deliberate, and asserted name-by-name against
  `names(NeuralPDE)` and `isdefined(NeuralPDE, name)` by a new testset, so the
  allow-list cannot silently diverge from the exports,
- `docs/src/api.md`.

`infimum`/`supremum` have no docstring anywhere upstream (IntervalSets declares them,
ModelingToolkit/Symbolics reexport them undocumented), so they trip
`run_api_docs`'s docstring check; they are listed in
`api_docs_kwargs = (; ignore = ...)` with a comment naming IntervalSets.jl as the
package that owes the docstring, and they are described on the new API page instead.

## Verification

Run locally on Julia 1.11.8 against this branch:

- `using NeuralPDE` loads; `length(names(NeuralPDE))` goes **38 → 66**.
- All 30 approved names are in `names(NeuralPDE)` and `isdefined(NeuralPDE, name)`.
- `SciMLTesting.public_reexports(NeuralPDE; allow = REEXPORTS)` returns `Symbol[]` —
  the allow-list matches the reexported surface exactly, with nothing approved that
  is not actually exported and nothing exported that is not approved. (With
  `allow = ()` it returns exactly the 30 names, confirming the tuple is neither wide
  nor narrow.)
- `SciMLTesting.run_api_docs(NeuralPDE; ignore = (:infimum, :supremum))` — both the
  docstring and the "rendered in docs" checks pass.
- End-to-end smoke test with **only** `using NeuralPDE` (plus the documented
  `using DomainSets: Interval`): declares `@parameters`/`@variables`, builds a
  `@named ... PDESystem` with `Differential`, and constructs an `ODEProblem` with
  `solve` in scope.

The full test suite was not run locally (heavy deps, loaded machine); relying on CI
for that. The docs build was not run locally either.

`Runic` reports no changes on the touched Julia files.

## Semver

Restoring names that used to be exported is **not breaking** — nothing that worked
before stops working, code that broke at v6.2.2 starts working again. Minor bump. I
have not bumped the version; a separate release pass handles that.

## Relationship to #1120

Independent. #1120 fixes the red NNODE CI lanes (the solver algorithm structs had lost
their `SciMLBase.Abstract*Algorithm` supertypes, so `solve` silently substituted the
default ODE solver). This PR does not touch that and does not fix those lanes; it
restores the public surface stripped by #1106. Both are needed before a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
