### PR TITLE
fix(NNODE): restore pointwise ODE RHS evaluation by default

### DIFF
--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -40,7 +40,7 @@ abstract type NeuralPDEAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 
 """
     NNODE(chain, opt, init_params = nothing; strategy = nothing, autodiff = false,
-        batch = true, ode_batch_eval = true, param_estim = false, additional_loss = nothing,
+        batch = true, ode_batch_eval = false, param_estim = false, additional_loss = nothing,
         dataset = [], estim_collocate = false, kwargs...)
 
 Algorithm for solving ordinary differential equations using a neural network. This is a
@@ -82,6 +82,9 @@ standard `ODEProblem`.
            neural network is done at individual time points one at a time. This is not
            applicable to `QuadratureTraining` where `batch` is passed in the `strategy`
            which is the number of points it can parallelly compute the integrand.
+* `ode_batch_eval`: Whether the ODE right-hand side accepts a matrix of states and a vector
+                    of times. This is always enabled on a GPU and defaults to `false` on a
+                    CPU, where ordinary pointwise ODE functions are supported.
 * `param_estim`: Boolean to indicate whether parameters of the differential equations are
                  learnt along with parameters of the neural network.
 * `strategy`: The training strategy used to choose the points for the evaluations.
@@ -143,7 +146,7 @@ end
 
 function NNODE(
         chain, opt, init_params = nothing; strategy = nothing, autodiff = false,
-        batch = true, ode_batch_eval = true, param_estim = false, additional_loss = nothing,
+        batch = true, ode_batch_eval = false, param_estim = false, additional_loss = nothing,
         dataset = [], estim_collocate = false, kwargs...
     )
     chain isa AbstractLuxLayer || (chain = FromFluxAdaptor()(chain))
@@ -338,10 +341,12 @@ function generate_loss(
     ts = collect(tspan[1]:(strategy.dx):tspan[2])
     autodiff && throw(ArgumentError("autodiff not supported for GridTraining."))
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts) 
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return function (θ, _)
+            dev = safe_get_device(θ)
+            ts_ = safe_expand(dev, ts)
+            rhs = ode_batch_eval || !(dev isa CPUDevice) ? BatchedRHS(f) : f
+            return inner_loss(phi, rhs, autodiff, ts_, θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end
@@ -359,10 +364,10 @@ function generate_loss(
         T = promote_type(eltype(tspan[1]), eltype(tspan[2]))
         ts = (tspan[2] - tspan[1]) .* rand(T, strategy.points) .+ tspan[1]
         if batch
-            dev = safe_get_device(phi)
-            ts = safe_expand(dev, ts) 
-            f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-            inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+            dev = safe_get_device(θ)
+            ts = safe_expand(dev, ts)
+            rhs = ode_batch_eval || !(dev isa CPUDevice) ? BatchedRHS(f) : f
+            inner_loss(phi, rhs, autodiff, ts, θ, p, param_estim)
         else
             sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
         end
@@ -387,10 +392,12 @@ function generate_loss(
     end
 
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts) 
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return function (θ, _)
+            dev = safe_get_device(θ)
+            ts_ = safe_expand(dev, ts)
+            rhs = ode_batch_eval || !(dev isa CPUDevice) ? BatchedRHS(f) : f
+            return inner_loss(phi, rhs, autodiff, ts_, θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -195,8 +195,8 @@ end
 
 (f::ODEPhi)(dev, t::Number, θ) = dev(f.u0) .+ (t .- f.t0) .* f.smodel(dev([t]), θ.depvar)
 
-function (f::ODEPhi)(dev, t::AbstractVector, θ) 
-   return dev(f.u0) .+ (t' .- f.t0) .* f.smodel(t', θ.depvar)
+function (f::ODEPhi)(dev, t::AbstractVector, θ)
+    return dev(f.u0) .+ (t' .- f.t0) .* f.smodel(t', θ.depvar)
 end
 """
     ode_dfdx(phi, t, θ, autodiff)
@@ -248,10 +248,12 @@ function inner_loss(
     end
 
     length(fs) == length(dxdtguess) ||
-        throw(DimensionMismatch(
+        throw(
+        DimensionMismatch(
             "Batched scalar RHS returned $(length(fs)) values; " *
-            "expected $(length(dxdtguess))."
-        ))
+                "expected $(length(dxdtguess))."
+        )
+    )
 
     return sum(abs2, fs .- dxdtguess) / length(ts)
 end
@@ -274,9 +276,11 @@ function inner_loss(
     end
 
     size(fs) == size(dxdtguess) ||
-        throw(DimensionMismatch(
+        throw(
+        DimensionMismatch(
             "Batched RHS returned size $(size(fs)); expected $(size(dxdtguess))."
-        ))
+        )
+    )
     return sum(abs2, fs .- dxdtguess) / length(ts)
 end
 

--- a/test/NNODE/nnode__ode_complex_numbers.jl
+++ b/test/NNODE/nnode__ode_complex_numbers.jl
@@ -30,6 +30,7 @@ using Test
         Dense(1, 16, tanh; init_weight = kaiming_normal(ComplexF64)),
         Dense(16, 4; init_weight = kaiming_normal(ComplexF64))
     )
+    @test !NNODE(chain, Adam(0.01)).ode_batch_eval
 
     ground_truth = solve(problem, Tsit5(), saveat = 0.01)
 


### PR DESCRIPTION
## Dependency

This PR is stacked on the standalone mechanical formatting draft https://github.com/SciML/NeuralPDE.jl/pull/1125. Until that draft merges, this branch contains its formatting commit followed by the behavior-only commit; after it merges, this PR reduces to the behavior commit alone.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The GPU optimization merged in https://github.com/SciML/NeuralPDE.jl/pull/1101 changed `ode_batch_eval` from `false` to `true` and inferred the device from `ODEPhi`. `ODEPhi` has no array payload, so `MLDataDevices.get_device(phi)` is `UnknownDevice` even when the trainable parameters are on the CPU. Ordinary pointwise ODE right-hand sides were therefore called once with a state matrix and time vector.

This restores pointwise CPU evaluation as the default, determines the device from the actual parameter container inside each loss call, and keeps automatic batched RHS evaluation for non-CPU parameters or explicit `ode_batch_eval = true`. The wrapped RHS is local to each call, avoiding mutation of the captured function in stochastic training.

## Failing before

On clean master `dd792519`, the existing complex NNODE test errored for all three batched training strategies:

```text
DimensionMismatch: Batched RHS returned size (4,); expected (4, N).
ODE Complex Numbers | Error 3 Total 3
```

The new default assertion also discriminates directly:

```text
Test Failed
Expression: !((NNODE(chain, Adam(0.01))).ode_batch_eval)
```

Simply restoring the default was not sufficient. The first partial patch still derived the device from `phi`, and the existing scalar CPU case then failed with:

```text
MethodError: no method matching exp(::Vector{Float32})
```

The measured device values explain the failure:

```text
get_device(phi) = MLDataDevices.UnknownDevice()
get_device(phi.smodel) = MLDataDevices.UnknownDevice()
safe_get_device(θ) = CPUDevice{Missing}()
```

## Passing after

Commands were run on Julia 1.12.7 with a local depot and project:

```sh
GROUP=NNODE julia --project -e 'using Pkg; Pkg.test()'
GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
```

Observed results:

- Exact scalar regression: `ODE Example 2 | Pass 4 Total 4 Time 6m53.4s`.
- Exact complex regression: `ODE Complex Numbers | Pass 5 Total 5 Time 52m17.7s`.
- Full NNODE rerun: DAE I 1/1, DAE II 1/1, Flux translation 2/2, complex 5/5 in 37m43.4s, example 2 4/4, example 3 1/1, and ODE I 4/4. The runner then reached an independent master failure: `UndefVarError: BFGS not defined` in `test/NNODE/nnode__ode_parameter_estimation.jl` after OptimizationOptimJL 0.4.19 stopped exporting that owner name.
- Every NNODE file after that independent blocker was run directly in the same locally developed environment: scalar 2/2, other strategies 3/3, weighted interval 1/1, `tstops` 6/6, and vector 12/12. The second parameter-estimation file independently has the same `BFGS` owner-import failure. Those two test-import fixes are intentionally separate from this source fix.
- Exact branch QA reports only the pre-existing `PDETimeSeriesSolution` / PINOODE ambiguity on master (23 pass, 1 fail). With the one-line ambiguity fix from the separate #1120 remediation stack temporarily overlaid, QA is `24/24` in 4m18.6s. The overlay was removed before this commit.
- Runic left every changed range unchanged; `typos --diff` and `git diff --check` exited cleanly.

## Not verified here

- No GPU was available, so the CUDA path was not executed locally. The non-CPU device branch remains explicit and always selects `BatchedRHS`.
- The full docs build is currently blocked on master by the independent OptimizationOptimJL 0.4.19 direct-owner migration across documentation examples. This commit has been handed to that focused docs branch for a temporary full-build overlay; no docs failure is being silenced here.
- The two NNODE `BFGS` test ownership fixes are being handled in a separate direct-owner PR.

AI-Agent: OpenAI Codex

Codex-Session-ID: 01a03a11-47c2-77e0-858b-167004f0b79c

## Links

- Introducing PR: https://github.com/SciML/NeuralPDE.jl/pull/1101
- Introducing commit: https://github.com/SciML/NeuralPDE.jl/commit/dd792519540cde8c3957612a0c5354116002da61
- Separate algorithm-supertype PR: https://github.com/SciML/NeuralPDE.jl/pull/1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ