### PR TITLE
fix: complete NeuralPDE algorithm and reexport remediation

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -46,4 +46,5 @@ pages = [
         "developer/debugging.md",
         "developer/interfaces.md",
     ],
+    "API" => "api.md",
 ]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,61 @@
+# API
+
+NeuralPDE's own public API — the solver algorithms (`NNODE`, `NNDAE`, `BNNODE`,
+`PINOODE`, `NNSDE`, `SDEPINN`, `DeepGalerkin`), the `PhysicsInformedNN` discretization,
+the training strategies and the adaptive loss functions — is documented
+in the Manual: [ODE solvers](manual/ode.md), [DAE solvers](manual/dae.md),
+[PINN discretizations](manual/pinns.md), [Bayesian PINNs](manual/bpinns.md),
+[physics-informed neural operators](manual/pino_ode.md) and
+[neural adapters](manual/neural_adapters.md).
+
+This page documents the *reexported* surface instead: names that `using NeuralPDE`
+brings into scope but that another package owns and documents.
+
+## Reexported symbolic front end
+
+Writing down a `PDESystem` is the normal documented entry point to NeuralPDE, so
+`using NeuralPDE` also brings in the symbolic front end needed to express one. These
+names are owned and documented by
+[ModelingToolkit](https://docs.sciml.ai/ModelingToolkit/stable/),
+[ModelingToolkitBase](https://github.com/SciML/ModelingToolkit.jl/tree/master/lib/ModelingToolkitBase),
+[Symbolics](https://docs.sciml.ai/Symbolics/stable/):
+
+  - Declaring symbols: `@parameters`, `@variables`, `@named`, `@register_symbolic`
+  - Systems: `PDESystem`, `mtkcompile`, `@mtkcompile`, `unknowns`
+  - Operators: `Differential`, `Integral`
+  - The `ModelingToolkit` module itself
+
+Anything else from ModelingToolkit, ModelingToolkitBase, or Symbolics must be imported
+from that package directly — for example `System`, `equations`, `parameters` and
+`observed` are system-manipulation API that NeuralPDE does not use in its own documented
+workflow, so they are deliberately not reexported. Interval domains and their endpoints
+still come from [DomainSets](https://github.com/JuliaApproximation/DomainSets.jl)
+(`using DomainSets: Interval, infimum, supremum`), which NeuralPDE does not reexport.
+
+## Reexported SciML common interface
+
+`using NeuralPDE` also brings in the parts of the SciML common interface needed to
+build a problem, solve it and inspect the result, so they do not have to be imported
+separately. These names are owned and documented by
+[SciMLBase](https://docs.sciml.ai/SciMLBase/stable/):
+
+  - Problems: `ODEProblem`, `DAEProblem`, `SDEProblem`, `NoiseProblem`,
+    `OptimizationProblem`
+  - Functions: `ODEFunction`, `ODEInputFunction`, `OptimizationFunction`
+  - Solutions: `ODESolution`, `PDETimeSeriesSolution`
+  - Solving and discretizing: `solve`, `init`, `remake`, `discretize`,
+    `symbolic_discretize`
+  - Return status: `ReturnCode`
+  - The `SciMLBase` module itself
+
+Anything else from SciMLBase must be imported from SciMLBase directly. In particular
+the ensemble interface, the callback types and the integrator interface are not
+reexported: NeuralPDE's solvers train a network rather than step an integrator, so
+those names are not part of its documented use.
+
+!!! note
+    
+    This list is kept in sync in three places: the reexport `export` blocks in
+    `src/NeuralPDE.jl`, the `REEXPORTS` tuple in `test/qa/qa.jl` (which is what
+    `run_qa`'s `reexports_allow` is given, and which a test checks against
+    `names(NeuralPDE)`), and this page.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -54,7 +54,7 @@ reexported: NeuralPDE's solvers train a network rather than step an integrator, 
 those names are not part of its documented use.
 
 !!! note
-    
+
     This list is kept in sync in three places: the reexport `export` blocks in
     `src/NeuralPDE.jl`, the `REEXPORTS` tuple in `test/qa/qa.jl` (which is what
     `run_qa`'s `reexports_allow` is given, and which a test checks against

--- a/docs/src/developer/interfaces.md
+++ b/docs/src/developer/interfaces.md
@@ -15,7 +15,7 @@ The concrete subtype is the dispatch extension point for
 `SciMLBase.symbolic_discretize`. Its method should translate the symbolic
 `PDESystem` into the representation consumed by its training workflow. The
 abstract type and application-facing examples are documented on the
-[PINN manual page](@ref).
+[PINN manual page](@ref "`PhysicsInformedNN` Discretizer for PDESystems").
 
 ## Training Strategies
 
@@ -24,11 +24,11 @@ NeuralPDE.AbstractTrainingStrategy
 ```
 
 A custom training strategy implements the generic `NeuralPDE.get_loss_function`
-interface, which is documented on the [developer debugging page](@ref). It
-returns a callable scalar objective. The interval form receives lower and upper
-bounds as separate arguments. `NeuralPDE.generate_training_sets` and
-`NeuralPDE.get_bounds` are optional extension points for strategies that construct
-grid or bound-based data.
+interface, which is documented on the
+[developer debugging page](@ref "Debugging PINN Solutions"). It returns a callable
+scalar objective. The interval form receives lower and upper bounds as separate
+arguments. `NeuralPDE.generate_training_sets` and `NeuralPDE.get_bounds` are optional
+extension points for strategies that construct grid or bound-based data.
 
 ```julia
 using Statistics: mean

--- a/src/NN_SDE_solve.jl
+++ b/src/NN_SDE_solve.jl
@@ -128,7 +128,7 @@ Stochastic Physics-Informed Neural Ordinary Differential Equations : https://arx
 Stochastic PDE Functionality #531 : https://github.com/SciML/NeuralPDE.jl/issues/531
 
 """
-@concrete struct NNSDE
+@concrete struct NNSDE <: SciMLBase.AbstractSDEAlgorithm
     chain <: AbstractLuxLayer
     opt
     init_params

--- a/src/NN_SDE_weaksolve.jl
+++ b/src/NN_SDE_weaksolve.jl
@@ -45,7 +45,7 @@ alg = SDEPINN(
 )
 ```
 """
-@concrete struct SDEPINN
+@concrete struct SDEPINN <: SciMLBase.AbstractSDEAlgorithm
     chain <: AbstractLuxLayer
     optimalg
     norm_loss_alg

--- a/src/NeuralPDE.jl
+++ b/src/NeuralPDE.jl
@@ -26,9 +26,10 @@ using Printf: @printf
 using Random: Random, AbstractRNG
 using RecursiveArrayTools: DiffEqArray
 using RuntimeGeneratedFunctions: RuntimeGeneratedFunctions, @RuntimeGeneratedFunction
-using SciMLBase: SciMLBase, BatchIntegralFunction, IntegralProblem,
-    OptimizationFunction, OptimizationProblem, ReturnCode, discretize,
-    isinplace, solve, symbolic_discretize, ODEProblem
+using SciMLBase: SciMLBase, BatchIntegralFunction, DAEProblem, IntegralProblem,
+    NoiseProblem, ODEFunction, ODEInputFunction, ODEProblem, ODESolution,
+    OptimizationFunction, OptimizationProblem, PDETimeSeriesSolution, ReturnCode,
+    SDEProblem, discretize, init, isinplace, remake, solve, symbolic_discretize
 using SciMLPublic: @public
 using Statistics: Statistics, mean
 using QuasiMonteCarlo: QuasiMonteCarlo, LatinHypercubeSample
@@ -36,9 +37,11 @@ using WeightInitializers: glorot_uniform, zeros32
 using Zygote: Zygote
 
 # Symbolic Stuff
-using ModelingToolkit: ModelingToolkit, PDESystem, Differential, toexpr
-using ModelingToolkitBase: @named, @parameters, get_dvs, get_ivs
-using Symbolics: Symbolics, arguments, Num, expand_derivatives, @variables
+using ModelingToolkit: ModelingToolkit, toexpr
+using ModelingToolkitBase: @mtkcompile, @named, @parameters, PDESystem, get_dvs, get_ivs,
+    mtkcompile, unknowns
+using Symbolics: Symbolics, Differential, Integral, arguments, Num, expand_derivatives,
+    @register_symbolic, @variables
 using SymbolicUtils: SymbolicUtils, unwrap
 using SymbolicIndexingInterface: SymbolicIndexingInterface
 
@@ -170,7 +173,7 @@ export NNODE, NNDAE
 export BNNODE, ahmc_bayesian_pinn_ode, ahmc_bayesian_pinn_pde
 export NNSDE
 export SDEPINN
-export PhysicsInformedNN, discretize
+export PhysicsInformedNN
 export BPINNsolution, BayesianPINN
 export DeepGalerkin
 
@@ -181,12 +184,18 @@ export GridTraining, StochasticTraining, QuadratureTraining, QuasiRandomTraining
 
 export build_loss_function, get_loss_function,
     generate_training_sets, get_variables, get_argument, get_bounds,
-    get_numeric_integral, symbolic_discretize, vector_to_parameters
+    get_numeric_integral, vector_to_parameters
 
 export AbstractAdaptiveLoss, NonAdaptiveLoss, GradientScaleAdaptiveLoss,
     MiniMaxAdaptiveLoss, SoftAdaptAdaptiveLoss, ReLoBRaLoAdaptiveLoss
 
 export LogOptions
+
+export SciMLBase, DAEProblem, NoiseProblem, ODEFunction, ODEInputFunction, ODEProblem,
+    ODESolution, OptimizationFunction, OptimizationProblem, PDETimeSeriesSolution,
+    ReturnCode, SDEProblem, discretize, init, remake, solve, symbolic_discretize
+export ModelingToolkit, Differential, Integral, PDESystem, mtkcompile, unknowns,
+    @mtkcompile, @named, @parameters, @register_symbolic, @variables
 
 @public logscalar, logvector
 

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -126,7 +126,7 @@ Lagaris, Isaac E., Aristidis Likas, and Dimitrios I. Fotiadis. "Artificial neura
 for solving ordinary and partial differential equations." IEEE Transactions on Neural
 Networks 9, no. 5 (1998): 987-1000.
 """
-@concrete struct NNODE
+@concrete struct NNODE <: NeuralPDEAlgorithm
     chain <: AbstractLuxLayer
     opt
     init_params

--- a/src/pino_ode_solve.jl
+++ b/src/pino_ode_solve.jl
@@ -397,7 +397,7 @@ end
 
 # Metadata-dispatched call: `(sol)(p, t)` is the natural PDE-style query.
 function (sol::SciMLBase.PDETimeSeriesSolution{T, N, S, <:PINOODEMetadata})(
-        p, t
+        p, t::Union{Number, AbstractArray}
     ) where {T, N, S}
     return sol.interp(p, t)
 end

--- a/src/pino_ode_solve.jl
+++ b/src/pino_ode_solve.jl
@@ -30,7 +30,7 @@ neural operator, which is used as a solver for a parametrized `ODEProblem`.
 * Sifan Wang "Learning the solution operator of parametric partial differential equations with physics-informed DeepOnets"
 * Zongyi Li "Physics-Informed Neural Operator for Learning Partial Differential Equations"
 """
-@concrete struct PINOODE
+@concrete struct PINOODE <: NeuralPDEAlgorithm
     chain
     opt
     bounds

--- a/test/Interface/interface__abstract_contracts.jl
+++ b/test/Interface/interface__abstract_contracts.jl
@@ -73,4 +73,20 @@ end
         @test sol.u == [1.0, 1.0]
         @test sol.retcode == SciMLBase.ReturnCode.Success
     end
+
+    # `DiffEqBase.extract_alg` only picks up the algorithm passed to `solve` when it
+    # is a `SciMLBase.AbstractSciMLAlgorithm`. Anything else is treated as "no
+    # algorithm given" and is silently replaced by the default solver of the loaded
+    # solver package, so the NeuralPDE solver would never run.
+    @testset "Solver algorithms subtype the SciMLBase algorithm hierarchy" begin
+        for T in (NeuralPDE.NNODE, NeuralPDE.PINOODE, NeuralPDE.BNNODE)
+            @test T <: SciMLBase.AbstractODEAlgorithm
+        end
+
+        @test NeuralPDE.NNDAE <: SciMLBase.AbstractDAEAlgorithm
+
+        for T in (NeuralPDE.NNSDE, NeuralPDE.SDEPINN)
+            @test T <: SciMLBase.AbstractSDEAlgorithm
+        end
+    end
 end

--- a/test/NNODE/nnode__nnode_translating_from_flux.jl
+++ b/test/NNODE/nnode__nnode_translating_from_flux.jl
@@ -22,6 +22,11 @@ using Test
 
     alg = NNODE(fluxchain, opt)
     @test alg.chain isa Lux.AbstractLuxLayer
+    # `NNODE` must be recognized as a SciML algorithm, otherwise `solve` silently
+    # falls back to the default ODE algorithm (see the `DiffEqBase.extract_alg`
+    # path exercised whenever OrdinaryDiffEq is loaded alongside NeuralPDE).
+    @test alg isa SciMLBase.AbstractODEAlgorithm
     sol = solve(prob, alg; verbose = false, abstol = 1.0e-10, maxiters = 200)
+    @test sol.alg isa NNODE
     @test sol.errors[:l2] < 0.5
 end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,9 +3,29 @@ using SciMLTesting, NeuralPDE, Test
 # Load every weak dependency so run_qa also scans NeuralPDE's package extensions.
 using AdvancedHMC, LogDensityProblems, MCMCChains, TensorBoardLogger
 
+# Kept in sync with the reexport `export` blocks in src/NeuralPDE.jl.
+const REEXPORTS = (
+    # SciML common interface (SciMLBase)
+    :SciMLBase, :DAEProblem, :NoiseProblem, :ODEFunction, :ODEInputFunction, :ODEProblem,
+    :ODESolution, :OptimizationFunction, :OptimizationProblem, :PDETimeSeriesSolution,
+    :ReturnCode, :SDEProblem, :discretize, :init, :remake, :solve, :symbolic_discretize,
+    # Symbolic front end (ModelingToolkit / ModelingToolkitBase / Symbolics)
+    :ModelingToolkit, :Differential, :Integral, :PDESystem, :mtkcompile, :unknowns,
+    Symbol("@mtkcompile"), Symbol("@named"), Symbol("@parameters"),
+    Symbol("@register_symbolic"), Symbol("@variables"),
+)
+
+@testset "Reexported public API stays in scope" begin
+    exported = Set(names(NeuralPDE))
+    for name in REEXPORTS
+        @test name in exported
+        @test isdefined(NeuralPDE, name)
+    end
+end
+
 run_qa(
     NeuralPDE;
-    reexports_allow = (:discretize, :symbolic_discretize),
+    reexports_allow = REEXPORTS,
     ei_kwargs = (;
         # Retain the reviewed Base.mapany, Base.Broadcast.dottable,
         # SymbolicUtils._iszero, and Symbolics.variables calls. ForwardDiff does not


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

This is an exact-head stack on https://github.com/SciML/NeuralPDE.jl/pull/1120. It keeps that PR's solver-algorithm hierarchy fix and adds the remaining remediation required after NeuralPDE 6.2.2 removed its blanket SciMLBase and ModelingToolkit reexports:

- restores the 28 names needed by NeuralPDE's documented workflows through explicit owner imports and exports;
- keeps that same surface synchronized in `test/qa/qa.jl` and a rendered API ownership page;
- disambiguates PINOODE's `(solution)(parameters, time)` call from SciMLBase's derivative-query call;
- resolves the two developer-interface Documenter references.

This deliberately supersedes the broader intermediate surface in https://github.com/SciML/NeuralPDE.jl/pull/1121: interval endpoints remain owned by DomainSets and are documented as direct imports rather than being reexported without upstream docstrings.

## Failing before

On clean master, the exact reexport probe found only the two exports that survived the stripping commit:

```text
expected=28 reexported=2 missing=26
```

The exact ambiguity probe reported one `PDETimeSeriesSolution` ambiguity between SciMLBase's derivative-query method and NeuralPDE's unconstrained two-argument PINOODE call. This is the `QA (julia 1)` failure on the parent PR.

The algorithm hierarchy failure and its discriminating fallback evidence are documented in https://github.com/SciML/NeuralPDE.jl/pull/1120. In brief, `NNODE` was discarded by `SciMLBase.extract_alg`, and OrdinaryDiffEq silently solved the problem with its default algorithm instead.

## Compatibility floors

Every registered tag of each owning dependency was inspected, and continuity was checked after the first exporting version:

| owner | registered tags checked | minimal version for this surface | version immediately below that lacks |
|---|---:|---:|---|
| SciMLBase | 564 | 3.6.0 | `PDETimeSeriesSolution` |
| ModelingToolkitBase | 106 | 1.0.0 | first registered version |
| Symbolics | 288 | 4.1.1 | `@register_symbolic` |

NeuralPDE already requires SciMLBase 3.18.0, ModelingToolkitBase 1.42.2, and Symbolics 7.26.0, so no compat change is needed. No later registered version drops any restored name.

## Passing after

The stack's merge result against current master is byte-for-byte the same tree as the locally validated rebased integration branch:

```text
merge_tree=72a595c7e759afc8559d7f81bdcb0cf2596be8ad
integration_tree=72a595c7e759afc8559d7f81bdcb0cf2596be8ad
```

Observed local results on Julia 1.12.7:

```text
GROUP=QA ...        80/80 pass in 4m34.7s
GROUP=Interface ... 20/20 pass
GROUP=PINOODE ...   all seven files pass; final file 1/1 in 11m10.4s

expected=28 reexported=28 missing=Symbol[]
relevant_pde_solution_ambiguities=0
```

The full PINOODE results were 11/11, 3/3, 6/6, 1/1, 2/2, 2/2, and 1/1 across its seven declared files. Runic reports no changes on the integration-specific Julia files; `typos --diff` and the exact merge-result `git diff --check` exit cleanly.

## Remaining independent validation

- The full documentation build is blocked on current master by OptimizationOptimJL 0.4.19 moving owner names such as `BFGS` and `LBFGS`; the required direct-owner migration is a separate focused change. A full-docs temporary overlay is still running, and this draft will be updated with its observed result.
- The repository-wide Runic check on the merge result finds only pre-existing formatting introduced in `src/ode_solve.jl` by current master. That independent source/device regression and complete-file formatting are fixed in https://github.com/SciML/NeuralPDE.jl/pull/1122. The remediation-specific files here are formatted.
- No GPU path was run locally.

AI-Agent: OpenAI Codex

Codex-Session-ID: 01a03a11-47c2-77e0-858b-167004f0b79c

## Links

- Parent algorithm PR: https://github.com/SciML/NeuralPDE.jl/pull/1120
- Superseded intermediate reexport PR: https://github.com/SciML/NeuralPDE.jl/pull/1121
- Independent NNODE source/device fix: https://github.com/SciML/NeuralPDE.jl/pull/1122
- Reexport-stripping commit: https://github.com/SciML/NeuralPDE.jl/commit/c9400f12684c42ef528b1aabc88475a36537bb83
- PINOODE method-introducing commit: https://github.com/SciML/NeuralPDE.jl/commit/1fdd9bdbfc20367ced94c6f2ae64f2fa48f9288c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
