### PR TITLE
style: format NNODE source

### DIFF
--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -195,8 +195,8 @@ end
 
 (f::ODEPhi)(dev, t::Number, θ) = dev(f.u0) .+ (t .- f.t0) .* f.smodel(dev([t]), θ.depvar)
 
-function (f::ODEPhi)(dev, t::AbstractVector, θ) 
-   return dev(f.u0) .+ (t' .- f.t0) .* f.smodel(t', θ.depvar)
+function (f::ODEPhi)(dev, t::AbstractVector, θ)
+    return dev(f.u0) .+ (t' .- f.t0) .* f.smodel(t', θ.depvar)
 end
 """
     ode_dfdx(phi, t, θ, autodiff)
@@ -248,10 +248,12 @@ function inner_loss(
     end
 
     length(fs) == length(dxdtguess) ||
-        throw(DimensionMismatch(
+        throw(
+        DimensionMismatch(
             "Batched scalar RHS returned $(length(fs)) values; " *
-            "expected $(length(dxdtguess))."
-        ))
+                "expected $(length(dxdtguess))."
+        )
+    )
 
     return sum(abs2, fs .- dxdtguess) / length(ts)
 end
@@ -274,9 +276,11 @@ function inner_loss(
     end
 
     size(fs) == size(dxdtguess) ||
-        throw(DimensionMismatch(
+        throw(
+        DimensionMismatch(
             "Batched RHS returned size $(size(fs)); expected $(size(dxdtguess))."
-        ))
+        )
+    )
     return sum(abs2, fs .- dxdtguess) / length(ts)
 end
 


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Apply Runic to the pre-existing formatting drift in `src/ode_solve.jl`. This is intentionally a standalone mechanical change so the NNODE behavior fix in https://github.com/SciML/NeuralPDE.jl/pull/1122 does not mix formatting with behavior.

There is no behavior, dependency, public API, or documentation change.

## Verification

- `/home/crackauc/.julia/packages/Runic/pHxmA/bin/runic --check src/ode_solve.jl` — exit 0.
- `typos src/ode_solve.jl` — exit 0.
- `git diff --check origin/master...HEAD` — exit 0.
- Exact rebased branch, `GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` — 23/24; the only failure is the clean-master PINO method ambiguity already fixed independently in https://github.com/SciML/NeuralPDE.jl/pull/1123. Persistent tasks and every other QA check passed.
- The same formatting commit with the independent PINO fix overlaid: QA 24/24 in 4m30.2s, exit 0.
- Full `GROUP=NNODE julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` on the validation overlay containing this formatting commit and the independent NNODE/PINO/optimizer fixes: exit 0 after about 1h22m. The tail was `with_tstops.jl` 6/6 and `vector.jl` 12/12, followed by `Testing NeuralPDE tests passed`.

## Not verified

- Full docs were not built for this mechanical source-formatting-only diff.
- Exact-master NNODE is not a meaningful green gate yet because master still contains the independent pointwise-evaluation and optimizer-owner failures addressed separately. No test was skipped or silenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
