### PR TITLE
Remove trailing whitespace so Runic --check passes

### DIFF
--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -339,7 +339,7 @@ function generate_loss(
     autodiff && throw(ArgumentError("autodiff not supported for GridTraining."))
     if batch
         dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts) 
+        ts = safe_expand(dev, ts)
         f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
         return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
     else
@@ -360,7 +360,7 @@ function generate_loss(
         ts = (tspan[2] - tspan[1]) .* rand(T, strategy.points) .+ tspan[1]
         if batch
             dev = safe_get_device(phi)
-            ts = safe_expand(dev, ts) 
+            ts = safe_expand(dev, ts)
             f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
             inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
         else
@@ -388,7 +388,7 @@ function generate_loss(
 
     if batch
         dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts) 
+        ts = safe_expand(dev, ts)
         f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
         return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
     else


### PR DESCRIPTION
Workflow-adjacent source only. Master FormatCheck (Runic 1.x) fails on three trailing spaces in `src/ode_solve.jl`.

## What changed

Runic `--inplace` on the default-branch tree. Three `ts = safe_expand(dev, ts)` lines lost a trailing space. No behavior change.

## Verification

Before (Runic 1.9.0 `--check --diff`): exit 1, those three lines.

After: `julia -m Runic --check --extensions=jl .` exit 0. `typos` exit 0.

Did not wait for GitHub Actions.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)