### PR TITLE
fix: reject equations and boundary conditions with no dependent variable

### DIFF
--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -398,6 +398,30 @@ function get_numeric_integral(pinnrep::PINNRepresentation)
 end
 
 """
+    __check_nontrivial(eqs, dict_indvars, dict_depvars, kind)
+
+Throw an `ArgumentError` for an equation or boundary condition with no dependent
+variable, such as `0 ~ 0`. Its argument list is empty, which `get_bounds` would
+otherwise reduce over and fail.
+"""
+function __check_nontrivial(eqs, dict_indvars, dict_depvars, kind)
+    args = get_argument(eqs, dict_indvars, dict_depvars)
+    depvars = collect(keys(dict_depvars))
+    for (eq, arg) in zip(eqs, args)
+        isempty(arg) || continue
+        throw(
+            ArgumentError(
+                "the $(kind) `$(eq)` does not depend on any of the dependent " *
+                    "variables $(depvars), so no training points can be generated " *
+                    "for it. Remove trivially satisfied entries such as `0 ~ 0` " *
+                    "from the `PDESystem`."
+            )
+        )
+    end
+    return nothing
+end
+
+"""
     prob = symbolic_discretize(pde_system::PDESystem, discretization::AbstractPINN)
 
 `symbolic_discretize` is the lower level interface to `discretize` for inspecting internals.
@@ -474,6 +498,9 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ab
     adaloss === nothing && (adaloss = NonAdaptiveLoss{eltype(flat_init_params)}())
 
     eqs isa Array || (eqs = [eqs])
+
+    __check_nontrivial(eqs, dict_indvars, dict_depvars, "equation")
+    __check_nontrivial(bcs, dict_indvars, dict_depvars, "boundary condition")
 
     pde_indvars = if strategy isa QuadratureTraining
         get_argument(eqs, dict_indvars, dict_depvars)

--- a/test/direct_function__trivial_bc_0_0_errors_in_discretize.jl
+++ b/test/direct_function__trivial_bc_0_0_errors_in_discretize.jl
@@ -1,7 +1,7 @@
 using ModelingToolkit, NeuralPDE, SciMLBase
 using Test
 
-@testset "Trivial BC [0 ~ 0] fails for some training strategies" begin
+@testset "Trivial BC [0 ~ 0] errors in discretize" begin
     using ModelingToolkit, NeuralPDE, SciMLBase, Optimization, OptimizationOptimisers, Lux
     import DomainSets: Interval
     @parameters x
@@ -12,7 +12,12 @@ using Test
     domain = [x ∈ Interval(0.0, 2.0)]
     chain = Chain(Dense(1, 10, tanh), Dense(10, 10, tanh), Dense(10, 1))
 
-    for strategy in (StochasticTraining(1000), QuasiRandomTraining(1000))
+    strategies = (
+        GridTraining(0.01), StochasticTraining(1000),
+        QuasiRandomTraining(1000), QuadratureTraining(),
+    )
+
+    for strategy in strategies
         discretization = PhysicsInformedNN(chain, strategy)
         @named pde_system = PDESystem(eq, bc, domain, [x], [u(x)])
         @test_throws ArgumentError discretize(pde_system, discretization)

--- a/test/direct_function__trivial_equation_errors_in_discretize.jl
+++ b/test/direct_function__trivial_equation_errors_in_discretize.jl
@@ -1,0 +1,25 @@
+using ModelingToolkit, NeuralPDE, SciMLBase
+using Test
+
+@testset "Trivial equation [0 ~ 0] errors in discretize" begin
+    using ModelingToolkit, NeuralPDE, SciMLBase, Optimization, OptimizationOptimisers, Lux
+    import DomainSets: Interval
+    @parameters x
+    @variables u(..)
+
+    eq = [0 ~ 0]
+    bc = [u(0.0) ~ 2.5]
+    domain = [x ∈ Interval(0.0, 2.0)]
+    chain = Chain(Dense(1, 10, tanh), Dense(10, 10, tanh), Dense(10, 1))
+
+    strategies = (
+        GridTraining(0.01), StochasticTraining(1000),
+        QuasiRandomTraining(1000), QuadratureTraining(),
+    )
+
+    for strategy in strategies
+        discretization = PhysicsInformedNN(chain, strategy)
+        @named pde_system = PDESystem(eq, bc, domain, [x], [u(x)])
+        @test_throws ArgumentError discretize(pde_system, discretization)
+    end
+end


### PR DESCRIPTION
Fixes #1104.

## Problem

The Core test asserts `@test_throws ArgumentError discretize(...)` for a trivial
`[0 ~ 0]` boundary condition, but throws `MethodError` on Julia 1.10 (`lts`).

## Fix

Validate in `symbolic_discretize`, before strategy dispatch, and throw NeuralPDE's `ArgumentError` naming the offending entry.
`GridTraining` and `QuadratureTraining` previously built a zero-column training set and empty bounds respectively, discretizing silently and failing later in
  `solve`. All four strategies now fail identically and early. Only entries
  referencing no dependent variable are rejected.

Equations get the same guard. `get_bounds` reduces over `pde_args` at `:311` and
`bound_args` at `:318` with textually identical `mapreduce` calls, and the two failures
are essentially identical.

## Verification

| | 1.10.12 | 1.12.7 |
|---|---|---|
| `direct_function__trivial_bc_0_0_errors_in_discretize.jl` | 4/4 | 4/4 |
| `direct_function__trivial_equation_errors_in_discretize.jl` | 4/4 | 4/4 |
| `direct_function__empty_boundary_condition_fails_in_solve_phase.jl` | 4/4 | 4/4 |

## Scope

This only fixes #1104, does not close #911.
