### PR TITLE
Handle zero-dimensional PINN residuals

### DIFF
--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -224,6 +224,7 @@ function generate_training_sets(
     dict_var_span_ = Dict([Symbol(d.variables) => bc for (d, bc) in zip(domains, bc_data)])
 
     bcs_train_sets = map(bound_args) do bt
+        isempty(bt) && return _zero_dimensional_coordinates(eltypeθ)
         span = get.((dict_var_span,), bt, bt)
         return reduce(hcat, vec(map(collect, Iterators.product(span...)))) |>
             EltypeAdaptor{eltypeθ}()
@@ -232,6 +233,7 @@ function generate_training_sets(
     pde_args = get_argument(eqs, dict_indvars, dict_depvars)
 
     pde_train_sets = map(pde_args) do bt
+        isempty(bt) && return _zero_dimensional_coordinates(eltypeθ)
         span = get.((dict_var_span_,), bt, bt)
         return reduce(hcat, vec(map(collect, Iterators.product(span...)))) |>
             EltypeAdaptor{eltypeθ}()
@@ -308,6 +310,7 @@ function get_bounds(domains, eqs, bcs, eltypeθ, dict_indvars, dict_depvars, str
 
     pde_args = get_argument(eqs, dict_indvars, dict_depvars)
     pde_bounds = map(pde_args) do pde_arg
+        isempty(pde_arg) && return (eltypeθ[], eltypeθ[])
         bds = mapreduce(s -> get(dict_span, s, fill(s, 2)), hcat, pde_arg)
         bds = eltypeθ.(bds)
         return bds[1, :], bds[2, :]
@@ -315,6 +318,7 @@ function get_bounds(domains, eqs, bcs, eltypeθ, dict_indvars, dict_depvars, str
 
     bound_args = get_argument(bcs, dict_indvars, dict_depvars)
     bcs_bounds = map(bound_args) do bound_arg
+        isempty(bound_arg) && return (eltypeθ[], eltypeθ[])
         bds = mapreduce(s -> get(dict_span, s, fill(s, 2)), hcat, bound_arg)
         bds = eltypeθ.(bds)
         return bds[1, :], bds[2, :]
@@ -583,7 +587,8 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ab
             weighted_bc_losses = adaloss.bc_loss_weights .* bc_losses
 
             sum_weighted_pde_losses = sum(weighted_pde_losses)
-            sum_weighted_bc_losses = sum(weighted_bc_losses)
+            sum_weighted_bc_losses = isempty(weighted_bc_losses) ?
+                zero(sum_weighted_pde_losses) : sum(weighted_bc_losses)
             weighted_loss_before_additional = sum_weighted_pde_losses +
                 sum_weighted_bc_losses
 

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -14,6 +14,8 @@ corresponding to the grid spacing in each dimension.
     dx
 end
 
+_zero_dimensional_coordinates(::Type{T}) where {T} = Matrix{T}(undef, 0, 1)
+
 # dataset must have depvar values for same values of indvars
 function get_dataset_train_points(eqs, train_sets, pinnrep)
     dict_depvar_input = pinnrep.dict_depvar_input
@@ -241,6 +243,7 @@ StochasticTraining(points; bcs_points = points) = StochasticTraining(points, bcs
 
 function generate_random_points(points, bound, eltypeθ)
     lb, ub = bound
+    isempty(lb) && return _zero_dimensional_coordinates(eltypeθ)
     return rand(eltypeθ, length(lb), points) .* (ub .- lb) .+ lb
 end
 
@@ -371,6 +374,11 @@ function get_loss_function(
     init_params = init_params isa PINNRepresentation ? init_params.init_params : init_params
     dev = safe_get_device(init_params)
 
+    if isempty(bound[1])
+        coordinates = dev(_zero_dimensional_coordinates(eltypeθ))
+        return θ -> mean(abs2, loss_function(coordinates, θ))
+    end
+
     return if resampling
         θ -> begin
             sets = @ignore_derivatives QuasiMonteCarlo.sample(
@@ -456,7 +464,9 @@ function get_loss_function(
     dev = safe_get_device(init_params)
 
     if length(lb) == 0
-        return (θ) -> mean(abs2, loss_function(dev(rand(eltypeθ, 1, 10)), θ))
+        # Fixed numeric arguments use the first row to inherit the batch shape.
+        coordinates = dev(zeros(eltypeθ, 1, 1))
+        return θ -> mean(abs2, loss_function(coordinates, θ))
     end
 
     area = eltypeθ(prod(abs.(ub .- lb)))

--- a/test/direct_function__empty_boundary_condition_fails_in_solve_phase.jl
+++ b/test/direct_function__empty_boundary_condition_fails_in_solve_phase.jl
@@ -1,7 +1,7 @@
 using ModelingToolkit, NeuralPDE, SciMLBase
 using Test
 
-@testset "Empty boundary condition [] fails in solve phase" begin
+@testset "Empty boundary conditions" begin
     using ModelingToolkit, NeuralPDE, SciMLBase, Optimization, OptimizationOptimisers, Lux
     import DomainSets: Interval
     @parameters x
@@ -13,14 +13,19 @@ using Test
     chain = Chain(Dense(1, 10, tanh), Dense(10, 10, tanh), Dense(10, 1))
 
     for strategy in (
-            GridTraining(0.01),
-            StochasticTraining(1000),
-            QuasiRandomTraining(1000),
-            QuadratureTraining(),
+            GridTraining(0.5),
+            StochasticTraining(16),
+            QuasiRandomTraining(16),
+            QuasiRandomTraining(16; resampling = false, minibatch = 2),
+            QuadratureTraining(
+                reltol = 0.01, abstol = 0.01, maxiters = 100, batch = 16
+            ),
         )
         discretization = PhysicsInformedNN(chain, strategy)
         @named pde_system = PDESystem(eq, bc, domain, [x], [u(x)])
         prob = discretize(pde_system, discretization)
-        @test_throws MethodError solve(prob, Adam(0.05), maxiters = 10)
+        @test isfinite(prob.f(prob.u0, prob.p))
+        sol = solve(prob, Adam(0.01), maxiters = 2)
+        @test isfinite(sol.objective)
     end
 end

--- a/test/direct_function__trivial_bc_0_0_fails_for_some_training_strategies.jl
+++ b/test/direct_function__trivial_bc_0_0_fails_for_some_training_strategies.jl
@@ -1,7 +1,7 @@
 using ModelingToolkit, NeuralPDE, SciMLBase
 using Test
 
-@testset "Trivial BC [0 ~ 0] fails for some training strategies" begin
+@testset "Dependent-variable-free boundary conditions" begin
     using ModelingToolkit, NeuralPDE, SciMLBase, Optimization, OptimizationOptimisers, Lux
     import DomainSets: Interval
     @parameters x
@@ -12,9 +12,36 @@ using Test
     domain = [x ∈ Interval(0.0, 2.0)]
     chain = Chain(Dense(1, 10, tanh), Dense(10, 10, tanh), Dense(10, 1))
 
-    for strategy in (StochasticTraining(1000), QuasiRandomTraining(1000))
+    strategies = (
+        GridTraining(0.5),
+        StochasticTraining(16),
+        QuasiRandomTraining(16),
+        QuasiRandomTraining(16; resampling = false, minibatch = 2),
+        QuadratureTraining(reltol = 0.01, abstol = 0.01, maxiters = 100, batch = 16),
+    )
+
+    for strategy in strategies
         discretization = PhysicsInformedNN(chain, strategy)
         @named pde_system = PDESystem(eq, bc, domain, [x], [u(x)])
-        @test_throws ArgumentError discretize(pde_system, discretization)
+        representation = symbolic_discretize(pde_system, discretization)
+        bc_loss = only(representation.loss_functions.bc_loss_functions)(
+            representation.flat_init_params
+        )
+        @test sum(bc_loss) == 0
+
+        prob = discretize(pde_system, discretization)
+        @test isfinite(prob.f(prob.u0, prob.p))
+        sol = solve(prob, Adam(0.01), maxiters = 2)
+        @test isfinite(sol.objective)
+    end
+
+    for strategy in strategies
+        discretization = PhysicsInformedNN(chain, strategy)
+        @named pde_system = PDESystem(eq, [0 ~ 1], domain, [x], [u(x)])
+        representation = symbolic_discretize(pde_system, discretization)
+        bc_loss = only(representation.loss_functions.bc_loss_functions)(
+            representation.flat_init_params
+        )
+        @test sum(bc_loss) == 1
     end
 end


### PR DESCRIPTION
> **Review gate:** Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Conditions that do not reference an independent variable now receive a typed coordinate batch instead of failing while constructing training data or bounds. Grid, stochastic, and quasi-random training use the single point in a zero-dimensional space (`0 × 1`); quadrature preserves the generated-function convention for fixed numeric arguments with a typed `1 × 1` batch. Empty boundary-condition collections now contribute a zero with the PDE loss type instead of attempting `sum(Any[])`.

The regression tests cover empty boundary conditions and both zero and nonzero constant residuals across every training strategy, including both quasi-random resampling modes. The nonzero case verifies that constant residuals are evaluated, not discarded.

Fixes https://github.com/SciML/NeuralPDE.jl/issues/911.

## Verification

Failing before the fix on clean commit `635ba392`, with only the new tests applied:

```text
$ TMPDIR=$PWD/.tmp GROUP=Core timeout 3600 ~/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; julia_args=["--threads=8", "--startup-file=no"])'
MethodError: no method matching zero(::Type{Any})
...
Test Summary:                                                          | Error  Total   Time
Core/direct_function__empty_boundary_condition_fails_in_solve_phase.jl |     2      2  50.8s
ERROR: Some tests did not pass: 0 passed, 0 failed, 2 errored, 0 broken.
```

Passing on the final code with Julia LTS:

```text
$ TMPDIR=$PWD/.tmp GROUP=Core timeout 3600 ~/.juliaup/bin/julia +lts --startup-file=no -e 'using Pkg; Pkg.activate(".tmp/core-lts-env"); Pkg.develop(path=pwd()); Pkg.test("NeuralPDE"; julia_args=["--threads=8", "--startup-file=no"])'
Test Summary:                                                          | Pass  Total     Time
Core/direct_function__empty_boundary_condition_fails_in_solve_phase.jl |   10     10  4m12.1s
Test Summary:                                                              | Pass  Total   Time
Core/direct_function__trivial_bc_0_0_fails_for_some_training_strategies.jl |   20     20  16.0s
     Testing NeuralPDE tests passed
```

Passing on the final code with Julia 1.12:

```text
$ TMPDIR=$PWD/.tmp GROUP=Core timeout 3600 ~/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; julia_args=["--threads=8", "--startup-file=no"])'
Test Summary:                                                          | Pass  Total     Time
Core/direct_function__empty_boundary_condition_fails_in_solve_phase.jl |   10     10  8m10.3s
Test Summary:                                                              | Pass  Total   Time
Core/direct_function__trivial_bc_0_0_fails_for_some_training_strategies.jl |   20     20  21.2s
     Testing NeuralPDE tests passed
```

The first implementation used a `0 × 1` batch for quadrature too. The PR's exact downgraded NNPDE1 job exposed the fixed-numeric-argument convention:

```text
BoundsError: attempt to access 0×1 Matrix{Float64} at index [[1], 1:1]
Test Summary:                                | Pass  Error  Total   Time
NNPDE1/nnpde__nnpde_translating_from_flux.jl |    1      1      2  1m24.1s
```

After preserving the quadrature convention, the same locked downgraded environment passes that test, and the complete locked NNPDE1 group exits successfully:

```text
$ TMPDIR=$PWD/.tmp GROUP=NNPDE1 timeout 3600 ~/.juliaup/bin/julia +lts --startup-file=no --project=. -e 'import Pkg; Pkg.test(; julia_args=["--threads=8","--startup-file=no","--check-bounds=yes","--compiled-modules=yes","--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=false)'
Test Summary:                                | Pass  Total     Time
NNPDE1/nnpde__nnpde_translating_from_flux.jl |    2      2  4m30.8s
```

QA on the final code:

```text
$ TMPDIR=$PWD/.tmp GROUP=QA timeout 3600 ~/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; julia_args=["--threads=8", "--startup-file=no"])'
Test Summary: | Pass  Total      Time
QA/qa.jl      |   80     80  11m02.3s
     Testing NeuralPDE tests passed
```

`typos` over all changed files and `git diff --check` exited 0. Runic 1.10 passes `src/training_strategies.jl` and both changed tests. Its full check of `src/discretize.jl` reports only formatting already present on clean master; that mechanical cleanup is being kept in a separate formatter-only PR.

## Not verified

- GPU execution was not run locally. The new typed coordinate batches still use the existing device adaptation path.
- `GROUP=Everything` was not run.
- The docs build was not run because this changes no public API, docstring, or documentation source.

## Reviewer judgment point

A zero-dimensional coordinate space has one point, represented as `0 × 1` for strategies whose generated residual has no coordinate access. Quadrature-generated residuals for fixed numeric arguments still index the first row to inherit batch shape, so that path receives a typed `1 × 1` zero batch.

## Links

- Issue: https://github.com/SciML/NeuralPDE.jl/issues/911
- First-revision downgraded failure: https://github.com/SciML/NeuralPDE.jl/actions/runs/33292864617/job/99207435892
- Clean-master Runic 1.10 failure observed on the first revision: https://github.com/SciML/NeuralPDE.jl/actions/runs/33292864634/job/99207435996

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a0501c-815c-7cf1-93c4-ddb4fab68924)
