### PR TITLE
Make DGM Poisson convergence test deterministic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -105,6 +105,7 @@ SafeTestsets = "0.1"
 SciMLBase = "3.18.0"
 SciMLPublic = "1"
 SciMLTesting = "2.4"
+StableRNGs = "1"
 Statistics = "1.10"
 StochasticDiffEq = "7"
 SymbolicIndexingInterface = "0.3.48"
@@ -135,9 +136,10 @@ OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 TensorBoardLogger = "899adc3e-224a-11e9-021f-63837185c80f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AdvancedHMC", "Boltz", "CUDA", "DiffEqNoiseProcess", "FastGaussQuadrature", "Flux", "InteractiveUtils", "LineSearches", "LogDensityProblems", "LuxCUDA", "LuxCore", "LuxLib", "MCMCChains", "Optim", "OptimizationOptimJL", "OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "StochasticDiffEq", "TensorBoardLogger", "Test"]
+test = ["AdvancedHMC", "Boltz", "CUDA", "DiffEqNoiseProcess", "FastGaussQuadrature", "Flux", "InteractiveUtils", "LineSearches", "LogDensityProblems", "LuxCUDA", "LuxCore", "LuxLib", "MCMCChains", "Optim", "OptimizationOptimJL", "OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "StableRNGs", "StochasticDiffEq", "TensorBoardLogger", "Test"]

--- a/test/DGM/dgm__poisson_s_equation.jl
+++ b/test/DGM/dgm__poisson_s_equation.jl
@@ -2,9 +2,10 @@ using ModelingToolkit, NeuralPDE, SciMLBase
 using Test
 
 @testset "Poisson's equation" begin
-    using ModelingToolkit, Optimization, OptimizationOptimisers, Distributions,
-        LinearAlgebra
+    using ComponentArrays, Distributions, Lux, ModelingToolkit, Optimization,
+        OptimizationOptimisers, LinearAlgebra, StableRNGs
     import DomainSets: Interval, infimum, supremum
+    import QuasiMonteCarlo: LatinHypercubeSample
 
     @parameters x y
     @variables u(..)
@@ -22,8 +23,15 @@ using Test
     # Space and time domains
     domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
 
-    strategy = QuasiRandomTraining(256, minibatch = 32)
-    discretization = DeepGalerkin(2, 1, 20, 3, tanh, tanh, identity, strategy)
+    rng = StableRNG(18)
+    strategy = QuasiRandomTraining(
+        256; sampling_alg = LatinHypercubeSample(rng), resampling = false, minibatch = 1
+    )
+    chain = NeuralPDE.DGM(2, 1, 20, 3, tanh, tanh, identity)
+    init_params, init_states = Lux.setup(rng, chain)
+    discretization = PhysicsInformedNN(
+        chain, strategy; init_params = ComponentArray{Float64}(init_params), init_states
+    )
 
     @named pde_system = PDESystem(eq, bcs, domains, [x, y], [u(x, y)])
     prob = discretize(pde_system, discretization)
@@ -44,5 +52,8 @@ using Test
     u_predict = [first(phi([x, y], res.u)) for x in xs for y in ys]
     u_real = [analytic_sol_func(x, y) for x in xs for y in ys]
 
-    @test u_real ≈ u_predict atol = 0.4
+    rmse_scale = sqrt(length(u_real))
+    rmse_limit = 0.4 / rmse_scale
+    @test norm(u_real) / rmse_scale > rmse_limit
+    @test norm(u_real - u_predict) / rmse_scale ≤ rmse_limit
 end


### PR DESCRIPTION
> **Review gate:** Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The DGM Poisson convergence test now uses `StableRNGs.jl` for both Lux network initialization and its Latin-hypercube sampler. It trains on one fixed quasi-random design (`resampling = false, minibatch = 1`), retains the exact existing global-norm acceptance boundary expressed as RMSE, and includes a zero-predictor negative control.

`StableRNGs.jl` is an MIT-licensed test-only dependency in `[extras]` and `[targets]`; it does not become a runtime dependency.

The prior `QuasiRandomTraining(256, minibatch = 32)` used the default `resampling = true`; in that mode `minibatch` is ignored and every optimizer evaluation draws a new design. Both initialization and training therefore depended on ambient RNG state.

## Verification

Failing before the fix on clean commit `635ba392`, after setting the ambient seed to the recorded adverse seed 18:

```text
$ TMPDIR=$PWD/.tmp GROUP=DGM timeout 3600 ~/.juliaup/bin/julia +1.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; julia_args=["--threads=8", "--startup-file=no"])'
Test Summary:                  | Fail  Total     Time
DGM/dgm__poisson_s_equation.jl |    1      1  2m11.7s
ERROR: Some tests did not pass: 0 passed, 1 failed, 0 errored, 0 broken.
```

The failed run's global-norm assertion corresponds to RMSE `0.00401975990406911`, above the unchanged boundary `0.4 / sqrt(10201) = 0.0039603960396039604`.

Focused StableRNG Poisson test on commit `ccb37a76`:

```text
Test Summary:      | Pass  Total     Time
Poisson's equation |    2      2  3m36.3s
```

Complete DGM group on the exact commit with Julia 1.11:

```text
Test Summary:                                      | Pass  Total      Time
DGM/dgm__black_scholes_pde_european_call_option.jl |    1      1  16m00.0s
Test Summary:                 | Pass  Total     Time
DGM/dgm__burger_s_equation.jl |    1      1  7m47.7s
Test Summary:                  | Pass  Total     Time
DGM/dgm__poisson_s_equation.jl |    2      2  2m42.1s
     Testing NeuralPDE tests passed
```

QA on Julia 1.11:

```text
Test Summary: | Pass  Total      Time
QA/qa.jl      |   80     80  22m58.2s
     Testing NeuralPDE tests passed
```

Runic 1.10 on both changed files, `typos` on the diff, and `git diff --check` all exited 0 with no output.

## Not yet verified

- The exact-commit Julia LTS DGM group is still running locally.
- GPU execution and allowed-to-fail GPU jobs were not run locally.
- `GROUP=Everything` was not run.
- The docs build was not run because this changes only a private test and test dependency metadata.

## Reviewer judgment point

The test retains the exact old acceptance boundary: `norm(error) ≤ 0.4` over 10,201 grid values is written as `RMSE ≤ 0.4 / sqrt(10201)`. This is a metric clarification, not a tolerance increase. A zero prediction has RMSE about `0.02508` and fails the added negative control.

## Links

- Historical passing run: https://github.com/SciML/NeuralPDE.jl/actions/runs/32519247903
- Historical failing run: https://github.com/SciML/NeuralPDE.jl/actions/runs/32664388864
- Historical failing Julia 1.11 job: https://github.com/SciML/NeuralPDE.jl/actions/runs/32664388864/job/97260349527

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a0501c-815c-7cf1-93c4-ddb4fab68924)
