### PR TITLE
style: apply Runic 1.10 formatting

### DIFF
--- a/ext/bpinn/PDE_BPINN.jl
+++ b/ext/bpinn/PDE_BPINN.jl
@@ -57,8 +57,8 @@ function get_lossy(pinnrep, dataset, Dict_differentials)
     # unmask Differential terms in masked_colloc_equations
     colloc_equations = [
         Symbolics.substitute.(
-                masked_colloc_equation, Ref(rev_Dict_differentials)
-            )
+            masked_colloc_equation, Ref(rev_Dict_differentials)
+        )
             for masked_colloc_equation in masked_colloc_equations
     ]
     # nested vector of data_pde_loss_functions (as in discretize.jl)
@@ -66,13 +66,13 @@ function get_lossy(pinnrep, dataset, Dict_differentials)
     # zip each colloc equation with args for each build_loss call per equation vector
     data_colloc_loss_functions = [
         [
-                build_loss_function(pinnrep, eq, pde_indvar)
+            build_loss_function(pinnrep, eq, pde_indvar)
                 for (eq, pde_indvar, integration_indvar) in zip(
                     colloc_equation,
                     pinnrep.pde_indvars,
                     pinnrep.pde_integration_vars
                 )
-            ]
+        ]
             for colloc_equation in colloc_equations
     ]
 
@@ -124,9 +124,9 @@ end
     i = 0
     Luxparams = [
         vector_to_parameters(
-                ps_new[((i += length(ps[x])) - length(ps[x]) + 1):i],
-                ps[x]
-            ) for x in names
+            ps_new[((i += length(ps[x])) - length(ps[x]) + 1):i],
+            ps[x]
+        ) for x in names
     ]
 
     a = ComponentArray(NamedTuple{ltd.names}(i for i in Luxparams))
@@ -240,13 +240,13 @@ function inference(samples, pinnrep, saveats, numensemble, ℓπ)
     span = [[ranges[indvar] for indvar in input] for input in inputs]
     timepoints = [
         hcat(
-                vec(
-                    map(
-                        points -> collect(points),
-                        Iterators.product(span[i]...)
-                    )
-                )...
-            )
+            vec(
+                map(
+                    points -> collect(points),
+                    Iterators.product(span[i]...)
+                )
+            )...
+        )
             for i in eachindex(phi)
     ]
 
@@ -281,9 +281,9 @@ function inference(samples, pinnrep, saveats, numensemble, ℓπ)
     # convert to format directly usable by lux
     estimatedLuxparams = [
         vector_to_parameters(
-                estimnnparams[Luxparams[i]],
-                initial_nnθ[names[i]]
-            ) for i in eachindex(phi)
+            estimnnparams[Luxparams[i]],
+            initial_nnθ[names[i]]
+        ) for i in eachindex(phi)
     ]
 
     # infer predictions(preds) each row - NN, each col - ith sample
@@ -294,12 +294,12 @@ function inference(samples, pinnrep, saveats, numensemble, ℓπ)
             preds,
             [
                 phi[j](
-                        timepoints[j],
-                        vector_to_parameters(
-                            samplesn[:, i][Luxparams[j]],
-                            initial_nnθ[names[j]]
-                        )
-                    ) for i in 1:numensemble
+                    timepoints[j],
+                    vector_to_parameters(
+                        samplesn[:, i][Luxparams[j]],
+                        initial_nnθ[names[j]]
+                    )
+                ) for i in 1:numensemble
             ]
         )
     end
@@ -398,9 +398,9 @@ function NeuralPDE.ahmc_bayesian_pinn_pde(
         # -1 is placeholder, removed in merge_strategy_with_loglikelihood_function function call (train_sets[:, 2:end]())
         colloc_train_sets = [
             [
-                    hcat([-1], train_sets_pde[i][:, j]...)
+                hcat([-1], train_sets_pde[i][:, j]...)
                     for i in eachindex(data_colloc_loss_functions[1])
-                ]
+            ]
                 for j in eachindex(data_colloc_loss_functions)
         ]
 
@@ -409,13 +409,13 @@ function NeuralPDE.ahmc_bayesian_pinn_pde(
         # order of indvar coords will be same as corresponding depvar coords values in dataset provided in get_lossy() call.
         pde_loss_function_points = [
             merge_strategy_with_loglikelihood_function(
-                    pinnrep,
-                    GridTraining(0.1),
-                    data_colloc_loss_functions[i],
-                    nothing;
-                    train_sets_pde = colloc_train_sets[i],
-                    train_sets_bc = nothing
-                )[1]
+                pinnrep,
+                GridTraining(0.1),
+                data_colloc_loss_functions[i],
+                nothing;
+                train_sets_pde = colloc_train_sets[i],
+                train_sets_bc = nothing
+            )[1]
                 for i in eachindex(data_colloc_loss_functions)
         ]
 
@@ -425,15 +425,15 @@ function NeuralPDE.ahmc_bayesian_pinn_pde(
             return pde_loglikelihoods = sum(
                 [
                     sum(
-                            [
-                                pde_loss_function(
-                                    θ,
-                                    phynewstd[i]
-                                )
+                        [
+                            pde_loss_function(
+                                θ,
+                                phynewstd[i]
+                            )
                                 for (i, pde_loss_function) in
                                 enumerate(pde_loss_functions)
-                            ]
-                        )
+                        ]
+                    )
                         for pde_loss_functions in pde_loss_function_points
                 ]
             )

--- a/ext/bpinn/advancedHMC_MCMC.jl
+++ b/ext/bpinn/advancedHMC_MCMC.jl
@@ -228,12 +228,12 @@ MvNormal likelihood at each `ti` in time `t` for ODE collocation residue with NN
     # of dependant variables)
     return [
         logpdf(
-                MvNormal(
-                    (nnsol[i, :] .- physsol[i, :]),
-                    Diagonal(abs2.(T(ltd.phystd[i]) .* ones(T, length(t))))
-                ),
-                zeros(T, length(t))
-            ) for i in 1:length(ltd.prob.u0)
+            MvNormal(
+                (nnsol[i, :] .- physsol[i, :]),
+                Diagonal(abs2.(T(ltd.phystd[i]) .* ones(T, length(t))))
+            ),
+            zeros(T, length(t))
+        ) for i in 1:length(ltd.prob.u0)
     ]
 end
 

--- a/src/NN_SDE_solve.jl
+++ b/src/NN_SDE_solve.jl
@@ -304,31 +304,31 @@ function inner_sde_loss(
     fs = if phi.u0 isa Number
         [
             reduce(
-                    hcat,
-                    [
-                        f(u[k][:, i][1], p_, inputs[k][1, i]) +
+                hcat,
+                [
+                    f(u[k][:, i][1], p_, inputs[k][1, i]) +
                         g(u[k][:, i][1], p_, inputs[k][1, i]) * √2 *
                         sum(
-                            inputs[k][1 + j, i] * cos((j - 1 / 2)pi * inputs[k][1, i])
+                        inputs[k][1 + j, i] * cos((j - 1 / 2)pi * inputs[k][1, i])
                             for j in 1:n_inp
-                        ) for i in 1:n_samples
-                    ]
-                ) for k in eachindex(inputs)
+                    ) for i in 1:n_samples
+                ]
+            ) for k in eachindex(inputs)
         ]
     else
         # multioutput case
         [
             reduce(
-                    hcat,
-                    [
-                        f(u[k][:, i], p_, inputs[k][1, i]) +
+                hcat,
+                [
+                    f(u[k][:, i], p_, inputs[k][1, i]) +
                         g(u[k][:, i], p_, inputs[k][1, i]) * √2 *
                         sum(
-                            inputs[k][1 + j, i] * cos((j - 1 / 2)pi * inputs[k][1, i])
+                        inputs[k][1 + j, i] * cos((j - 1 / 2)pi * inputs[k][1, i])
                             for j in 1:n_inp
-                        ) for i in 1:n_samples
-                    ]
-                ) for k in eachindex(inputs)
+                    ) for i in 1:n_samples
+                ]
+            ) for k in eachindex(inputs)
         ]
     end
 
@@ -512,10 +512,10 @@ function generate_loss(
             add_rand_coeff(ts, n_z, sub_batch)
         return [
             abs2(
-                    inner_sde_loss(
-                        phi, f, g, autodiff, input, θ, p, param_estim, train_type
-                    )
+                inner_sde_loss(
+                    phi, f, g, autodiff, input, θ, p, param_estim, train_type
                 )
+            )
                 for input in inputs
         ]
     end

--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -301,8 +301,8 @@ function get_bounds(domains, eqs, bcs, eltypeθ, dict_indvars, dict_depvars, str
     dict_span = Dict(
         [
             Symbol(d.variables) => [
-                    infimum(d.domain) + dx, supremum(d.domain) - dx,
-                ] for d in domains
+                infimum(d.domain) + dx, supremum(d.domain) - dx,
+            ] for d in domains
         ]
     )
 
@@ -504,9 +504,9 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ab
 
     symbolic_pde_loss_functions = [
         build_symbolic_loss_function(
-                pinnrep, eq;
-                bc_indvars = pde_indvar
-            )
+            pinnrep, eq;
+            bc_indvars = pde_indvar
+        )
             for (eq, pde_indvar) in zip(
                 eqs, pde_indvars,
                 pde_integration_vars
@@ -515,9 +515,9 @@ function SciMLBase.symbolic_discretize(pde_system::PDESystem, discretization::Ab
 
     symbolic_bc_loss_functions = [
         build_symbolic_loss_function(
-                pinnrep, bc;
-                bc_indvars = bc_indvar
-            )
+            pinnrep, bc;
+            bc_indvars = bc_indvar
+        )
             for (bc, bc_indvar) in zip(
                 bcs, bc_indvars,
                 bc_integration_vars

--- a/test/NNPDE2/additional_loss__lorenz_system.jl
+++ b/test/NNPDE2/additional_loss__lorenz_system.jl
@@ -42,10 +42,10 @@ using Test
 
     init_params = [
         ComponentArray{Float64}(
-                Lux.initialparameters(
-                    Random.default_rng(), chain[i]
-                )
+            Lux.initialparameters(
+                Random.default_rng(), chain[i]
             )
+        )
             for i in 1:3
     ]
 

--- a/test/NNSDE1/nn_sde__test_4_gbm_sde_inverse_weak_strong_solving.jl
+++ b/test/NNSDE1/nn_sde__test_4_gbm_sde_inverse_weak_strong_solving.jl
@@ -153,8 +153,8 @@ using Test
     truncatedsol_data_inputs = reduce(hcat, sol_1.training_sets)
     truncated_solution_strong_paths = [
         truncated_sol(
-                u₀, ideal_p, truncatedsol_data_inputs[:, i]...
-            )
+            u₀, ideal_p, truncatedsol_data_inputs[:, i]...
+        )
             for i in eachindex(ts)
     ]
 

--- a/test/PDEBPINN/bpinn_pde__bpinn_pde_inv_iii_improved_parametric_kuromo_sivashinsky_equation_solve.jl
+++ b/test/PDEBPINN/bpinn_pde__bpinn_pde_inv_iii_improved_parametric_kuromo_sivashinsky_equation_solve.jl
@@ -172,12 +172,12 @@ using Test
 
     diff_u_new = [
         [
-                abs(
-                    u_analytic(x, t) -
+            abs(
+                u_analytic(x, t) -
                     first(pmean(phi([x, t], sol_new.estimated_nn_params[1])))
-                )
+            )
                 for x in xs
-            ]
+        ]
             for t in ts
     ]
 
@@ -187,12 +187,12 @@ using Test
     ]
     diff_u_old = [
         [
-                abs(
-                    u_analytic(x, t) -
+            abs(
+                u_analytic(x, t) -
                     first(pmean(phi([x, t], sol_old.estimated_nn_params[1])))
-                )
+            )
                 for x in xs
-            ]
+        ]
             for t in ts
     ]
 

--- a/test/PINOODE/pino_ode__example_du_cos_p_t_sin_p_t.jl
+++ b/test/PINOODE/pino_ode__example_du_cos_p_t_sin_p_t.jl
@@ -63,9 +63,9 @@ using Test
             hcat,
             [
                 reduce(
-                        vcat,
-                        [ground_solution(u0, p[1, i, 1], t[1, 1, j])[1] for i in axes(p, 2)]
-                    )
+                    vcat,
+                    [ground_solution(u0, p[1, i, 1], t[1, 1, j])[1] for i in axes(p, 2)]
+                )
                     for j in axes(t, 3)
             ]
         )
@@ -73,9 +73,9 @@ using Test
             hcat,
             [
                 reduce(
-                        vcat,
-                        [ground_solution(u0, p[1, i, 1], t[1, 1, j])[2] for i in axes(p, 2)]
-                    )
+                    vcat,
+                    [ground_solution(u0, p[1, i, 1], t[1, 1, j])[2] for i in axes(p, 2)]
+                )
                     for j in axes(t, 3)
             ]
         )


### PR DESCRIPTION
> **Review gate:** Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Apply the indentation emitted by Runic 1.10 to the eight files that no longer pass the repository's format check. The behavior change begins at Runic commit `8345856ec3c4`; clean NeuralPDE master passes Runic 1.9 and fails Runic 1.10.

This is a mechanical formatter-only change: 89 lines added and 89 removed, with `git diff -w --exit-code` confirming no non-whitespace changes.

## Verification

Clean master before formatting:

```text
$ ~/.juliaup/bin/julia +1.12 --project=.tmp/runic-ci -m Runic --check <all 108 Julia/TOML files>
Runic version: 1.10.0
8 files failed formatting
```

The same 108-file check with Runic 1.9 passed. After applying Runic 1.10:

```text
$ ~/.juliaup/bin/julia +1.12 --project=.tmp/runic-ci -m Runic --check <all 108 Julia/TOML files>
Runic version: 1.10.0
Julia version: 1.12.6
108/108 files passed

$ git diff -w --exit-code
# exit 0

$ git diff --check
# exit 0

$ typos --diff
# exit 0
```

Relevant test groups on Julia 1.11:

```text
QA/qa.jl | 80 pass / 80 total | 29m59.6s
GROUP=NNPDE2 | 12 pass / 12 total | package tests passed
GROUP=NNSDE1 | 29 pass / 29 total | package tests passed
GROUP=PINOODE | 26 pass / 26 total | package tests passed
GROUP=PDEBPINN | 11 pass / 11 total | package tests passed
```

The extended PDEBPINN run used the repository group runner with a two-hour shell timeout. Its formatter-touched inverse Kuramoto–Sivashinsky file passed 2/2 in 50m13.9s; the complete group exited 0 in approximately 1h33m.

## Not verified

- `GROUP=Everything` was not run.
- GPU execution was not run locally.
- The docs build was not run because this changes no docs, docstrings, or public API.

## Reviewer judgment point

There is no intended behavior change. The whitespace-only check is the primary review invariant; the group runs cover every source or test area touched by the formatter.

## Links

- Runic behavior-change commit: https://github.com/fredrikekre/Runic.jl/commit/8345856ec3c4f4d24c0ae50cf9d01f20aa6e1719
- Previous successful NeuralPDE format run: https://github.com/SciML/NeuralPDE.jl/actions/runs/33113305445
- First observed Runic 1.10 failure: https://github.com/SciML/NeuralPDE.jl/actions/runs/33292864634

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a0501c-815c-7cf1-93c4-ddb4fab68924)
