### PR TITLE
Make PINOODE randomness explicit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralPDE"
 uuid = "315f7962-48a3-4962-8226-d0f33b1235f0"
-version = "6.2.5"
+version = "6.3.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]

--- a/docs/src/tutorials/pino_ode.md
+++ b/docs/src/tutorials/pino_ode.md
@@ -42,7 +42,10 @@ strategy = StochasticTraining(20)
 opt = Adam(0.03)
 
 # Define `PINNODE`
-alg = PINOODE(deeponet, opt, bounds, num_params; strategy = strategy)
+alg = PINOODE(
+    deeponet, opt, bounds, num_params;
+    strategy = strategy, rng = MersenneTwister(1)
+)
 
 # Solve the ODE problem using the PINOODE algorithm.
 # `sol` is a `PDETimeSeriesSolution` (the parameters are extra PDE

--- a/src/pino_ode_solve.jl
+++ b/src/pino_ode_solve.jl
@@ -1,9 +1,12 @@
 """
 	PINOODE(chain,
 	    opt,
-	    bounds;
+	    bounds,
+	    number_of_parameters;
 	    init_params = nothing,
-	    strategy = nothing
+	    strategy = nothing,
+	    additional_loss = nothing,
+	    rng = Random.default_rng(),
 	    kwargs...)
 
 Algorithm for solving paramentric ordinary differential equations using a physics-informed
@@ -23,6 +26,7 @@ neural operator, which is used as a solver for a parametrized `ODEProblem`.
                              which thus uses the random initialization provided by the neural network library.
 * `strategy`: The strategy for training the neural network.
 * `additional_loss`: additional loss function added to the default one. For example, add training on data.
+* `rng`: Random number generator used for model initialization and stochastic sampling.
 * `kwargs`: Extra keyword arguments are splatted to the Optimization.jl `solve` call.
 
 ## References
@@ -38,6 +42,7 @@ neural operator, which is used as a solver for a parametrized `ODEProblem`.
     init_params
     strategy <: Union{Nothing, AbstractTrainingStrategy}
     additional_loss <: Union{Nothing, Function}
+    rng
     kwargs
 end
 
@@ -49,12 +54,23 @@ function PINOODE(
         init_params = nothing,
         strategy = nothing,
         additional_loss = nothing,
+        rng = Random.default_rng(),
         kwargs...
     )
     chain isa AbstractLuxLayer || (chain = FromFluxAdaptor()(chain))
     return PINOODE(
         chain, opt, bounds, number_of_parameters,
+        init_params, strategy, additional_loss, rng, kwargs
+    )
+end
+
+function PINOODE(
+        chain, opt, bounds, number_of_parameters,
         init_params, strategy, additional_loss, kwargs
+    )
+    return PINOODE(
+        chain, opt, bounds, number_of_parameters,
+        init_params, strategy, additional_loss, Random.default_rng(), kwargs
     )
 end
 
@@ -67,13 +83,13 @@ function PINOPhi(model::AbstractLuxLayer, st)
     return PINOPhi(model, StatefulLuxLayer{false}(model, nothing, st))
 end
 
-function generate_pino_phi_θ(chain::AbstractLuxLayer, ::Nothing)
-    θ, st = LuxCore.setup(Random.default_rng(), chain)
+function generate_pino_phi_θ(chain::AbstractLuxLayer, ::Nothing, rng)
+    θ, st = LuxCore.setup(rng, chain)
     return PINOPhi(chain, st), θ
 end
 
-function generate_pino_phi_θ(chain::AbstractLuxLayer, init_params)
-    st = LuxCore.initialstates(Random.default_rng(), chain)
+function generate_pino_phi_θ(chain::AbstractLuxLayer, init_params, rng)
+    st = LuxCore.initialstates(rng, chain)
     return PINOPhi(chain, st), init_params
 end
 
@@ -196,7 +212,8 @@ function initial_condition_loss(
 end
 
 function get_trainset(
-        strategy::GridTraining, chain::DeepONet, bounds, number_of_parameters, tspan
+        strategy::GridTraining, chain::DeepONet, bounds, number_of_parameters, tspan;
+        rng = Random.default_rng()
     )
     dt = strategy.dx
     p_ = [range(start = b[1], length = number_of_parameters, stop = b[2]) for b in bounds]
@@ -208,7 +225,8 @@ function get_trainset(
 end
 
 function get_trainset(
-        strategy::GridTraining, chain::Chain, bounds, number_of_parameters, tspan
+        strategy::GridTraining, chain::Chain, bounds, number_of_parameters, tspan;
+        rng = Random.default_rng()
     )
     dt = strategy.dx
     tspan_ = tspan[1]:dt:tspan[2]
@@ -230,51 +248,55 @@ end
 
 function get_trainset(
         strategy::StochasticTraining, chain::DeepONet,
-        bounds, number_of_parameters, tspan
+        bounds, number_of_parameters, tspan;
+        rng = Random.default_rng()
     )
     p = reduce(
         vcat,
         [
-            (bound[2] .- bound[1]) .* rand(1, number_of_parameters) .+ bound[1]
+            (bound[2] .- bound[1]) .* rand(rng, 1, number_of_parameters) .+ bound[1]
                 for bound in bounds
         ]
     )
     # NeuralOperators 0.6+ requires 2D trunk input
-    t = (tspan[2] .- tspan[1]) .* rand(1, strategy.points) .+ tspan[1]
+    t = (tspan[2] .- tspan[1]) .* rand(rng, 1, strategy.points) .+ tspan[1]
     return (p, t)
 end
 
 function get_trainset(
         strategy::StochasticTraining, chain::Chain,
-        bounds, number_of_parameters, tspan
+        bounds, number_of_parameters, tspan;
+        rng = Random.default_rng()
     )
     (number_of_parameters != strategy.points) &&
         throw(error("number_of_parameters should be the same strategy.points for StochasticTraining"))
     p = reduce(
         vcat,
         [
-            (bound[2] .- bound[1]) .* rand(1, number_of_parameters) .+ bound[1]
+            (bound[2] .- bound[1]) .* rand(rng, 1, number_of_parameters) .+ bound[1]
                 for bound in bounds
         ]
     )
-    t = (tspan[2] .- tspan[1]) .* rand(1, strategy.points, 1) .+ tspan[1]
+    t = (tspan[2] .- tspan[1]) .* rand(rng, 1, strategy.points, 1) .+ tspan[1]
     return (p, t)
 end
 
 function generate_loss(
-        strategy::GridTraining, prob::ODEProblem, phi, bounds, number_of_parameters, tspan
+        strategy::GridTraining, prob::ODEProblem, phi, bounds, number_of_parameters, tspan;
+        rng = Random.default_rng()
     )
-    x = get_trainset(strategy, phi.smodel.model, bounds, number_of_parameters, tspan)
+    x = get_trainset(strategy, phi.smodel.model, bounds, number_of_parameters, tspan; rng)
     return function loss(θ, _)
         return initial_condition_loss(phi, prob, x, θ) + physics_loss(phi, prob, x, θ)
     end
 end
 
 function generate_loss(
-        strategy::StochasticTraining, prob::ODEProblem, phi, bounds, number_of_parameters, tspan
+        strategy::StochasticTraining, prob::ODEProblem, phi, bounds, number_of_parameters, tspan;
+        rng = Random.default_rng()
     )
     return function loss(θ, _)
-        x = get_trainset(strategy, phi.smodel.model, bounds, number_of_parameters, tspan)
+        x = get_trainset(strategy, phi.smodel.model, bounds, number_of_parameters, tspan; rng)
         return initial_condition_loss(phi, prob, x, θ) + physics_loss(phi, prob, x, θ)
     end
 end
@@ -458,7 +480,7 @@ function SciMLBase.__solve(
     (; tspan, u0, f) = prob
     (;
         chain, opt, bounds, number_of_parameters,
-        init_params, strategy, additional_loss,
+        init_params, strategy, additional_loss, rng,
     ) = alg
 
     if !(chain isa AbstractLuxLayer)
@@ -469,7 +491,7 @@ function SciMLBase.__solve(
         end
     end
 
-    phi, init_params = generate_pino_phi_θ(chain, init_params)
+    phi, init_params = generate_pino_phi_θ(chain, init_params, rng)
 
     init_params = ComponentArray(init_params)
 
@@ -480,15 +502,15 @@ function SciMLBase.__solve(
         if chain isa DeepONet
             # Use length(bounds) as branch input dimension - this is the number of parameters
             in_dim = length(bounds)
-            u = rand(in_dim, number_of_parameters)
+            u = rand(rng, in_dim, number_of_parameters)
             # NeuralOperators 0.6+ requires 2D trunk input
-            v = rand(1, 10)
+            v = rand(rng, 1, 10)
             x = (u, v)
             phi(x, init_params)
         end
         if chain isa Chain
             in_dim = chain.layers.layer_1.in_dims
-            x = rand(in_dim, number_of_parameters)
+            x = rand(rng, in_dim, number_of_parameters)
             phi(x, init_params)
         end
     catch err
@@ -506,7 +528,7 @@ function SciMLBase.__solve(
     end
 
     inner_f = generate_loss(
-        strategy, prob, phi, bounds, number_of_parameters, tspan
+        strategy, prob, phi, bounds, number_of_parameters, tspan; rng
     )
 
     function total_loss(θ, _)
@@ -533,7 +555,9 @@ function SciMLBase.__solve(
     optprob = OptimizationProblem(optf, init_params)
     res = solve(optprob, opt; callback, maxiters, alg.kwargs...)
 
-    (p, t) = get_trainset(strategy, phi.smodel.model, bounds, number_of_parameters, tspan)
+    (p, t) = get_trainset(
+        strategy, phi.smodel.model, bounds, number_of_parameters, tspan; rng
+    )
     interp = PINOODEInterpolation(phi, res.u)
     u = interp(p, t)
     metadata = PINOODEMetadata(p)

--- a/test/PINOODE/pino_ode__example_chain_du_cos_p_t.jl
+++ b/test/PINOODE/pino_ode__example_chain_du_cos_p_t.jl
@@ -37,7 +37,8 @@ using ModelingToolkit, NeuralPDE, SciMLBase
 using Test
 
 @testset "Example Chain du = cos(p * t)" begin
-    using ModelingToolkit, NeuralPDE, SciMLBase, Lux, OptimizationOptimisers, NeuralOperators, Random
+    using ModelingToolkit, NeuralPDE, SciMLBase, Lux, OptimizationOptimisers, NeuralOperators, Random,
+        StableRNGs
     using SciMLBase: SciMLBase, PDETimeSeriesSolution
     equation = (u, p, t) -> cos(p * t)
     tspan = (0.0, 1.0)
@@ -46,15 +47,19 @@ using Test
     chain = Chain(
         Dense(2 => 10, Lux.tanh_fast), Dense(10 => 10, Lux.tanh_fast), Dense(10 => 1)
     )
-    x = rand(2, 50, 10)
-    θ, st = Lux.setup(Random.default_rng(), chain)
-    b = chain(x, θ, st)[1]
-
     bounds = [(pi, 2pi)]
     number_of_parameters = 300
     strategy = StochasticTraining(300)
     opt = OptimizationOptimisers.Adam(0.01)
-    alg = PINOODE(chain, opt, bounds, number_of_parameters; strategy = strategy)
+    alg = PINOODE(
+        chain, opt, bounds, number_of_parameters;
+        strategy, rng = StableRNG(1)
+    )
+    legacy_alg = PINOODE(
+        chain, opt, bounds, number_of_parameters,
+        nothing, strategy, nothing, (;)
+    )
+    @test legacy_alg isa PINOODE
     sol = solve(prob, alg, verbose = false, maxiters = 3000)
 
     # Solution type contract: a `PINOODE` solve is a PDE solve where the
@@ -79,19 +84,39 @@ using Test
     predict_sol = sol.interp(p, t)
     @test ground_solution ≈ predict_sol rtol = 0.08
 
-    p = sol.p
-    ground_solution = ground_analytic.(u0, p, [1.0])
-    predict_sol = sol(1.0)
-    @test ground_solution ≈ predict_sol rtol = 0.08
-
-    p = sol.p
-    t = rand(size(p)...)
+    p = reshape(collect(range(pi, 2pi; length = 100)), 1, :)
+    t = fill(1.0, size(p))
     ground_solution = ground_analytic.(u0, p, t)
-    predict_sol = sol(t)
+    predict_sol = sol(p, t)
+    @test ground_solution ≈ predict_sol rtol = 0.08
+    @test sol(1.0) == sol.interp(sol.p, fill(1.0, size(sol.p)))
+
+    t = reshape(collect(range(0.0, 1.0; length = length(p))), size(p))
+    ground_solution = ground_analytic.(u0, p, t)
+    predict_sol = sol.interp(p, t)
     @test ground_solution ≈ predict_sol rtol = 0.08
 
     # Explicit PDE-style (p, t) call form.
     @test sol(p, t) == predict_sol
+    training_t = reshape(collect(range(0.0, 1.0; length = length(sol.p))), size(sol.p))
+    @test sol(training_t) == sol(sol.p, training_t)
+
+    function short_solve(ambient_seed, algorithm_seed)
+        Random.seed!(ambient_seed)
+        short_chain = Chain(Dense(2 => 3, tanh), Dense(3 => 1))
+        short_alg = PINOODE(
+            short_chain, opt, bounds, 4;
+            strategy = StochasticTraining(4), rng = StableRNG(algorithm_seed)
+        )
+        return solve(prob, short_alg, verbose = false, maxiters = 1)
+    end
+
+    first_sol = short_solve(1, 7)
+    second_sol = short_solve(2, 7)
+    different_sol = short_solve(1, 8)
+    @test first_sol.p == second_sol.p
+    @test first_sol.u == second_sol.u
+    @test first_sol.p != different_sol.p
 end
 
 #Test DeepONet


### PR DESCRIPTION
> **Review gate:** Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`PINOODE` now accepts a documented `rng` keyword and uses that generator for Lux setup, stochastic training samples, dimension probes, and the final sampled solution grid. The default remains `Random.default_rng()`, while callers can obtain reproducible behavior with a fresh explicitly seeded generator. The previous full positional constructor remains supported.

The convergence and RNG-isolation tests use `StableRNG`, while `Random.seed!` is retained only to perturb the ambient generator and prove that an explicit algorithm RNG isolates the solve. Fixed evaluation grids remove test-input randomness without loosening the existing elementwise `rtol = 0.08` assertions.

Because this adds public API, the package version moves from 6.2.5 to 6.3.0. `StableRNGs` was already a test dependency on current master and is not added as a runtime dependency by this PR.

## Verification

The exact three-assertion `StableRNG` isolation regression fails on clean current master (`72a73eb36bef5b6b5904c56884feac3af3cfc1f0`):

```text
$ ~/.juliaup/bin/julia +1.11 --startup-file=no \
    --project=.tmp/pino-before-env .tmp/pino_stablerng_regression.jl
Expression: first_sol.p == second_sol.p
Expression: first_sol.u == second_sol.u
Expression: first_sol.p != different_sol.p
Test Summary:               | Fail  Total     Time
PINOODE StableRNG isolation |    3      3  1m10.3s
ERROR: Some tests did not pass: 0 passed, 3 failed, 0 errored, 0 broken.
```

The identical script passes against this PR commit:

```text
Test Summary:               | Pass  Total     Time
PINOODE StableRNG isolation |    3      3  1m09.7s
```

The complete PINOODE group passed on this commit with Julia 1.11:

```text
$ GROUP=PINOODE ~/.juliaup/bin/julia +1.11 --startup-file=no \
    --project=. -e 'using Pkg; Pkg.test()'
pino_ode__example_chain_du_cos_p_t.jl                            | 17/17
pino_ode__example_deeponet_du_cos_p_t.jl                         |  3/3
pino_ode__example_du_cos_p_t_sin_p_t.jl                          |  6/6
pino_ode__example_du_cos_p_t_u.jl                                |  1/1
pino_ode__example_multiple_parameters_deeponet_du_p1_cos_p2_t.jl |  2/2
pino_ode__example_multiple_parameters_hain_du_p1_cos_p2_t.jl     |  2/2
pino_ode__example_with_data_du_p_t_2.jl                          |  1/1
     Testing NeuralPDE tests passed
```

The same complete group passed with Julia LTS 1.10.12. The changed file passed 17/17, all other file totals matched the Julia 1.11 run, and the command ended with `Testing NeuralPDE tests passed`:

```text
$ GROUP=PINOODE ~/.juliaup/bin/julia +lts --startup-file=no -e \
    'using Pkg; Pkg.activate(".tmp/pino-lts-env"); Pkg.develop(path=pwd());
     Pkg.test("NeuralPDE"; julia_args=["--startup-file=no"])'
```

QA passed on the final tree:

```text
$ GROUP=QA ~/.juliaup/bin/julia +1.11 --startup-file=no \
    --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
QA/qa.jl      |   80     80  11m24.1s
     Testing NeuralPDE tests passed
```

Runic 1.10 on all changed Julia/Markdown files, `typos` on all changed files, and `git diff --check` exited 0.

An earlier documentation build passed on a source-equivalent aggregate validation tree containing this public-API change and the separate NNODE correction needed by current-master documentation examples:

```text
$ TMPDIR=$PWD/.tmp ~/.juliaup/bin/julia +1.11 \
    --startup-file=no --project=docs docs/make.jl
[ Info: Automatic `version="7.1.0"` for inventory from ../Project.toml
Warning: Documenter could not auto-detect the building environment. Skipping deployment.
exit 0; wall time 5h28m44.2s
```

## Not verified

- GPU execution and allowed-to-fail GPU jobs were not run locally.
- `GROUP=Everything` was not run.
- The docs build cannot pass independently on current master because of the separate NNODE regression; the aggregate build is stated explicitly above.

## Reviewer judgment points

- `rng` is stored on the algorithm and consumed by a solve. Reproducibility therefore means constructing algorithms with equivalent fresh seeded generators; reusing one already-consumed generator intentionally continues its stream.
- This draft targets the current 6.x line with the required minor bump. If the NNODE 7.0 draft merges first, this branch must be rebased and versioned 7.1.0 before merge.

## Links

- Historical failing PINOODE job: https://github.com/SciML/NeuralPDE.jl/actions/runs/32093838848/job/95581711894
- Historical passing PINOODE job: https://github.com/SciML/NeuralPDE.jl/actions/runs/32093838848/job/95581711800
- Test-introducing commit: https://github.com/SciML/NeuralPDE.jl/commit/18b332595f1a6091ce56c69cf0dab514c8a462ce
- Current master used for failing-before evidence: https://github.com/SciML/NeuralPDE.jl/commit/72a73eb36bef5b6b5904c56884feac3af3cfc1f0
- NNODE correction: https://github.com/SciML/NeuralPDE.jl/pull/1136

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a0501c-815c-7cf1-93c4-ddb4fab68924)
