### PR TITLE
fix: preserve standard NNODE RHS evaluation

### DIFF
--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -40,7 +40,7 @@ abstract type NeuralPDEAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 
 """
     NNODE(chain, opt, init_params = nothing; strategy = nothing, autodiff = false,
-        batch = true, ode_batch_eval = true, param_estim = false, additional_loss = nothing,
+        batch = true, ode_batch_eval = false, param_estim = false, additional_loss = nothing,
         dataset = [], estim_collocate = false, kwargs...)
 
 Algorithm for solving ordinary differential equations using a neural network. This is a
@@ -82,6 +82,9 @@ standard `ODEProblem`.
            neural network is done at individual time points one at a time. This is not
            applicable to `QuadratureTraining` where `batch` is passed in the `strategy`
            which is the number of points it can parallelly compute the integrand.
+* `ode_batch_eval`: Whether the ODE right-hand side accepts batched state and time arrays.
+                    Defaults to `false`. GPU execution enables batched evaluation
+                    automatically.
 * `param_estim`: Boolean to indicate whether parameters of the differential equations are
                  learnt along with parameters of the neural network.
 * `strategy`: The training strategy used to choose the points for the evaluations.
@@ -143,7 +146,7 @@ end
 
 function NNODE(
         chain, opt, init_params = nothing; strategy = nothing, autodiff = false,
-        batch = true, ode_batch_eval = true, param_estim = false, additional_loss = nothing,
+        batch = true, ode_batch_eval = false, param_estim = false, additional_loss = nothing,
         dataset = [], estim_collocate = false, kwargs...
     )
     chain isa AbstractLuxLayer || (chain = FromFluxAdaptor()(chain))
@@ -338,10 +341,11 @@ function generate_loss(
     ts = collect(tspan[1]:(strategy.dx):tspan[2])
     autodiff && throw(ArgumentError("autodiff not supported for GridTraining."))
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts)
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return (θ, _) -> begin
+            dev = safe_get_device(θ)
+            batch_f = ode_batch_eval || dev != cdev ? BatchedRHS(f) : f
+            inner_loss(phi, batch_f, autodiff, safe_expand(dev, ts), θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end
@@ -359,10 +363,10 @@ function generate_loss(
         T = promote_type(eltype(tspan[1]), eltype(tspan[2]))
         ts = (tspan[2] - tspan[1]) .* rand(T, strategy.points) .+ tspan[1]
         if batch
-            dev = safe_get_device(phi)
+            dev = safe_get_device(θ)
             ts = safe_expand(dev, ts)
-            f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-            inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+            batch_f = ode_batch_eval || dev != cdev ? BatchedRHS(f) : f
+            inner_loss(phi, batch_f, autodiff, ts, θ, p, param_estim)
         else
             sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
         end
@@ -387,10 +391,11 @@ function generate_loss(
     end
 
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts)
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return (θ, _) -> begin
+            dev = safe_get_device(θ)
+            batch_f = ode_batch_eval || dev != cdev ? BatchedRHS(f) : f
+            inner_loss(phi, batch_f, autodiff, safe_expand(dev, ts), θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end

--- a/test/NNODE/nnode__ode_complex_numbers.jl
+++ b/test/NNODE/nnode__ode_complex_numbers.jl
@@ -6,7 +6,7 @@ using Test
 
     Random.seed!(100)
 
-    function bloch_equations(u, p, t)
+    function bloch_equations(u::AbstractVector, p, t)
         Ω, Δ, Γ = p
         γ = Γ / 2
         ρ₁₁, ρ₂₂, ρ₁₂, ρ₂₁ = u


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

NNODE now keeps ordinary pointwise ODE right-hand sides as the default on CPU. Batched RHS evaluation remains available through `ode_batch_eval = true` and is still selected automatically for GPU parameter arrays. Device detection now uses the current parameter array inside each batch loss closure, avoiding the `UnknownDevice` result obtained from inspecting the model wrapper.

The regression test restricts its RHS to `AbstractVector`, so it fails if NNODE silently passes a state matrix under the default API.

The regression was introduced by https://github.com/SciML/NeuralPDE.jl/commit/dd792519540cde8c3957612a0c5354116002da61 from https://github.com/SciML/NeuralPDE.jl/pull/1101.

## Failing before

Command:

```sh
julia +1.12.6 --project test/NNODE/nnode__ode_complex_numbers.jl
```

Result on the unfixed code:

```text
MethodError: no method matching bloch_equations(::Matrix{ComplexF64}, ::Vector{Float64}, ::Vector{Float64})
Test Summary:       | Pass  Error  Total   Time
ODE Complex Numbers |    1      3      4  58.9s
```

## Passing after

The same focused command on current `master` plus this commit:

```text
Test Summary:       | Pass  Total      Time
ODE Complex Numbers |    4      4  30m58.2s
```

Additional local verification on Julia 1.12.6:

- `GROUP=NNODE julia --project -e 'using Pkg; Pkg.test()'`: all 14 NNODE files passed (49 tests total), including complex numbers 4/4 and the related stochastic batch case 4/4.
- `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`: `QA/qa.jl | 80/80`, `Testing NeuralPDE tests passed`.
- Runic 1.10.0 check on both changed files: passed.
- `git diff | typos -`: passed.
- `git diff --check`: passed.

## Incomplete validation

- `julia +1.12.6 --project=docs docs/make.jl` used the local checkout via `Pkg.develop(PackageSpec(path=pwd()))`. It exercised the affected NNODE documentation and many later examples without a documentation error, but the complete build did not finish: a 2-hour run and a second 4-hour run both reached their outer shell limits. The 4-hour run ended with `rc=124` late in `tutorials/param_estim.md`. This is not reported as a docs pass.
- GPU execution was not run locally because no GPU validation was available.
- Downstream and allowed-to-fail jobs were not run locally.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d).
