### PR TITLE
Handle empty QuadratureTraining prototype batches

### DIFF
--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -478,6 +478,7 @@ function get_loss_function(
     ) -> begin
         function integrand(x, θ)
             x = x |> dev |> EltypeAdaptor{eltypeθ}()
+            isempty(x) && return similar(x, recursive_eltype(θ), 0)
             return sum(abs2, view(loss_(x, θ), 1, :), dims = 2) #./ size_x
         end
         integral_function = BatchIntegralFunction(integrand, max_batch = strategy.batch)

--- a/test/CUDA/nnpde_cuda__quadrature_empty_batch.jl
+++ b/test/CUDA/nnpde_cuda__quadrature_empty_batch.jl
@@ -1,35 +1,29 @@
-using CUDA, ComponentArrays, Lux, LuxCUDA, ModelingToolkit, NeuralPDE, Random, Test
-using DomainSets: Interval
+using CUDA, NeuralPDE, SciMLBase, Test
 
-@testset "QuadratureTraining with Float64 CUDA parameters" begin
-    @parameters x y
-    @variables u(..)
-    Dxx = Differential(x)^2
-    Dyy = Differential(y)^2
-    equation = Dxx(u(x, y)) + Dyy(u(x, y)) ~ -sinpi(x) * sinpi(y)
-    boundary_conditions = [
-        u(0, y) ~ 0.0,
-        u(1, y) ~ 0.0,
-        u(x, 0) ~ 0.0,
-        u(x, 1) ~ 0.0,
-    ]
-    domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
-    chain = Chain(
-        Dense(2 => 18, tanh),
-        Dense(18 => 18, tanh),
-        Dense(18 => 1)
-    )
-    parameters = Lux.initialparameters(Random.default_rng(), chain) |>
-        ComponentArray |> gpu_device() .|> Float64
-    discretization = PhysicsInformedNN(
-        chain, QuadratureTraining(); init_params = parameters
-    )
-    @named pde_system = PDESystem(
-        equation, boundary_conditions, domains, [x, y], [u(x, y)]
-    )
-    problem = discretize(pde_system, discretization)
-    loss = problem.f(problem.u0, problem.p)
-    CUDA.synchronize()
+mutable struct EmptyBatchProbe <: SciMLBase.AbstractIntegralAlgorithm
+    prototype::Any
+end
 
-    @test isfinite(loss)
+function SciMLBase.solve(
+        prob::SciMLBase.IntegralProblem, alg::EmptyBatchProbe; kwargs...
+    )
+    alg.prototype = prob.f(CUDA.zeros(Float64, 1, 0), prob.p)
+    return (; u = CUDA.ones(Float64, 1))
+end
+
+@testset "QuadratureTraining skips CUDA empty prototype batches" begin
+    probe = EmptyBatchProbe(nothing)
+    residuals = function (x, θ)
+        isempty(x) && error("residual cannot evaluate an empty CUDA batch")
+        return θ .* x
+    end
+    parameters = CUDA.fill(2.0, 1)
+    strategy = QuadratureTraining(quadrature_alg = probe)
+    loss = NeuralPDE.get_loss_function(
+        parameters, residuals, [0.0], [1.0], Float64, strategy
+    )
+
+    @test only(Array(loss(parameters))) == 1.0
+    @test probe.prototype isa CuArray{Float64, 1}
+    @test isempty(probe.prototype)
 end

--- a/test/CUDA/nnpde_cuda__quadrature_empty_batch.jl
+++ b/test/CUDA/nnpde_cuda__quadrature_empty_batch.jl
@@ -1,0 +1,35 @@
+using CUDA, ComponentArrays, Lux, LuxCUDA, ModelingToolkit, NeuralPDE, Random, Test
+using DomainSets: Interval
+
+@testset "QuadratureTraining with Float64 CUDA parameters" begin
+    @parameters x y
+    @variables u(..)
+    Dxx = Differential(x)^2
+    Dyy = Differential(y)^2
+    equation = Dxx(u(x, y)) + Dyy(u(x, y)) ~ -sinpi(x) * sinpi(y)
+    boundary_conditions = [
+        u(0, y) ~ 0.0,
+        u(1, y) ~ 0.0,
+        u(x, 0) ~ 0.0,
+        u(x, 1) ~ 0.0,
+    ]
+    domains = [x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
+    chain = Chain(
+        Dense(2 => 18, tanh),
+        Dense(18 => 18, tanh),
+        Dense(18 => 1)
+    )
+    parameters = Lux.initialparameters(Random.default_rng(), chain) |>
+        ComponentArray |> gpu_device() .|> Float64
+    discretization = PhysicsInformedNN(
+        chain, QuadratureTraining(); init_params = parameters
+    )
+    @named pde_system = PDESystem(
+        equation, boundary_conditions, domains, [x, y], [u(x, y)]
+    )
+    problem = discretize(pde_system, discretization)
+    loss = problem.f(problem.u0, problem.p)
+    CUDA.synchronize()
+
+    @test isfinite(loss)
+end

--- a/test/Interface/interface__abstract_contracts.jl
+++ b/test/Interface/interface__abstract_contracts.jl
@@ -1,4 +1,6 @@
 using DomainSets: Interval
+using ForwardDiff: derivative
+using Integrals: CubatureJLh
 using ModelingToolkit, NeuralPDE, SciMLBase
 using Test
 
@@ -61,6 +63,26 @@ end
 
         @test strategy isa NeuralPDE.AbstractTrainingStrategy
         @test loss([1.5, 2.0]) == 0.5
+    end
+
+    @testset "QuadratureTraining skips empty prototype batches" begin
+        calls = Ref(0)
+        residuals = function (x, θ)
+            isempty(x) && error("loss function cannot evaluate an empty batch")
+            calls[] += 1
+            return θ[1] .* x
+        end
+        strategy = QuadratureTraining(
+            quadrature_alg = CubatureJLh(), reltol = 1.0e-8, abstol = 1.0e-8,
+            maxiters = 10_000, batch = 16
+        )
+        loss = get_loss_function(
+            [2.0], residuals, [0.0], [1.0], Float64, strategy
+        )
+
+        @test only(loss([2.0])) ≈ 4 / 3
+        @test derivative(t -> only(loss([t])), 2.0) ≈ 4 / 3
+        @test calls[] > 0
     end
 
     @testset "NeuralPDEAlgorithm" begin


### PR DESCRIPTION
## What changed and why

`Integrals.BatchIntegralFunction` now probes batched integrands with an empty input while constructing its output prototype. `QuadratureTraining` forwarded that `N × 0` input into the user residual, which reaches Lux and cuBLASLt in the PINN benchmarks and fails before integration begins. The integrand now returns an empty output with the parameter's recursive element type for that prototype call, preserving ForwardDiff dual parameters without evaluating the residual.

This adds a CPU regression covering both the primal loss and ForwardDiff derivative, plus a V100 test that invokes the CUDA empty-prototype path directly through the public quadrature interfaces. The focused CUDA test deliberately avoids evaluating a complete `QuadratureTraining` integral because that strategy is documented as not GPU-compatible.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Failure discrimination

With the finalized tests present and only the one-line source guard removed, I ran:

```bash
GROUP=Interface timeout 3600 julia +1.11 --project=.validation/root-env \
  -e 'using Pkg; Pkg.test("NeuralPDE")'
```

The new test failed before invoking the residual on a nonempty batch:

```text
QuadratureTraining skips empty prototype batches: Error During Test
  Expression: only(loss([2.0])) ≈ 4 / 3
  loss function cannot evaluate an empty batch

QuadratureTraining skips empty prototype batches: Error During Test
  Expression: derivative(t -> only(loss([t])), 2.0) ≈ 4 / 3
  loss function cannot evaluate an empty batch

Interface/interface__abstract_contracts.jl | Pass 18 | Fail 1 | Error 2 | Total 21
```

With the guard restored, the identical Interface group passed:

```text
Interface/interface__abstract_contracts.jl | 21  21  12m44.4s
Interface/precompile_workload.jl            |  2   2       1.1s
Testing NeuralPDE tests passed
```

## Other verification

```text
GROUP=QA julia +1.11 --project=.validation/root-env -e 'using Pkg; Pkg.test("NeuralPDE")'
QA/qa.jl | 80  80  28m26.6s
Testing NeuralPDE tests passed

Runic --check: passed for all three changed Julia files
typos: passed for all three changed Julia files
git diff --check: passed
V100 CUDA group: focused regression passed 3/3 in 1.7s; full job passed in 24m01s
```

This host has no CUDA-capable device, so local validation used the CPU path. The repository CUDA group subsequently passed on the self-hosted V100; the focused regression passed 3/3 in 1.7 seconds and the complete job passed in 24m01s. No public API or documentation changed, so no docs build was run.

The failure was introduced when NeuralPDE migrated from the older Integrals API; Integrals 3 makes no empty prototype call, while current Integrals does. The clean-master audit identified the first affected NeuralPDE commit and release independently.

## Links

- Passing V100 CUDA job: https://github.com/SciML/NeuralPDE.jl/actions/runs/33845180179/job/100935537182
- Production DiffEqGPU failure: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33485364377/job/99784121624
- Production PINN failure: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33485364377/job/99784121658
- Introducing NeuralPDE commit: https://github.com/SciML/NeuralPDE.jl/commit/e59478a79bf4fe04148cd7f67c4d8ebc39f59916
- Introducing NeuralPDE PR: https://github.com/SciML/NeuralPDE.jl/pull/783
- First affected release: https://github.com/SciML/NeuralPDE.jl/releases/tag/v5.10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512

