### PR TITLE
fix(NNODE): preserve batched RHS evaluation

### DIFF
--- a/docs/src/examples/complex.md
+++ b/docs/src/examples/complex.md
@@ -36,7 +36,7 @@ ps, st = Lux.setup(rng, chain)
 
 opt = Adam(0.01)
 ground_truth = solve(problem, Tsit5(), saveat = 0.01)
-alg = NNODE(chain, opt, ps; strategy = StochasticTraining(500))
+alg = NNODE(chain, opt, ps; strategy = StochasticTraining(500), ode_batch_eval = false)
 sol = solve(problem, alg, verbose = false, maxiters = 5000, saveat = 0.01)
 ```
 

--- a/docs/src/tutorials/data_collocation_Inverse.md
+++ b/docs/src/tutorials/data_collocation_Inverse.md
@@ -82,10 +82,11 @@ This optimizer and respective algorithms are plugged into the `solve` calls for 
 opt = LBFGS(linesearch = BackTracking())
 
 alg_old = NNODE(
-    chain, opt; strategy = GridTraining(0.01), dataset = dataset, param_estim = true)
+    chain, opt; strategy = GridTraining(0.01), dataset = dataset, param_estim = true,
+    ode_batch_eval = false)
 
 alg_new = NNODE(chain, opt; strategy = GridTraining(0.01), param_estim = true,
-    dataset = dataset, estim_collocate = true)
+    dataset = dataset, estim_collocate = true, ode_batch_eval = false)
 ```
 
 Now we have all the pieces to solve the optimization problem.

--- a/docs/src/tutorials/ode_parameter_estimation.md
+++ b/docs/src/tutorials/ode_parameter_estimation.md
@@ -55,7 +55,7 @@ Next we define the optimizer and [`NNODE`](@ref) which is then plugged into the 
 ```@example param_estim_lv
 opt = LBFGS(linesearch = BackTracking())
 alg = NNODE(chain, opt, ps; strategy = WeightedIntervalTraining([0.7, 0.2, 0.1], 500),
-    param_estim = true, additional_loss)
+    param_estim = true, additional_loss, ode_batch_eval = false)
 ```
 
 Now we have all the pieces to solve the optimization problem.

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -82,6 +82,10 @@ standard `ODEProblem`.
            neural network is done at individual time points one at a time. This is not
            applicable to `QuadratureTraining` where `batch` is passed in the `strategy`
            which is the number of points it can parallelly compute the integrand.
+* `ode_batch_eval`: Whether the ODE right-hand side accepts a batch of states and a vector
+                    of times. Defaults to `true`; GPU-backed batched losses always use this
+                    mode. Set this to `false` for an ordinary pointwise ODE right-hand side
+                    on a CPU.
 * `param_estim`: Boolean to indicate whether parameters of the differential equations are
                  learnt along with parameters of the neural network.
 * `strategy`: The training strategy used to choose the points for the evaluations.
@@ -400,15 +404,19 @@ function generate_loss(
     end
 end
 
-function evaluate_tstops_loss(phi, f, autodiff::Bool, tstops, p, batch, param_estim::Bool)
-    batch && return (θ, _) -> inner_loss(phi, f, autodiff, tstops, θ, p, param_estim)
-    return (
-        θ, _,
-    ) -> sum(
-        [
-            inner_loss(phi, f, autodiff, t, θ, p, param_estim)
-                for t in tstops
-        ]
+function evaluate_tstops_loss(
+        phi, f, autodiff::Bool, tstops, p, batch, ode_batch_eval, param_estim::Bool
+    )
+    if batch
+        return function (θ, _)
+            dev = safe_get_device(θ)
+            tstops_ = safe_expand(dev, tstops)
+            rhs = ode_batch_eval || !(dev isa CPUDevice) ? BatchedRHS(f) : f
+            return inner_loss(phi, rhs, autodiff, tstops_, θ, p, param_estim)
+        end
+    end
+    return (θ, _) -> sum(
+        [inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in tstops]
     )
 end
 
@@ -567,7 +575,7 @@ function SciMLBase.__solve(
         if tstops !== nothing
             num_tstops_points = length(tstops)
             tstops_loss_func = evaluate_tstops_loss(
-                phi, f, autodiff, tstops, p, batch, param_estim
+                phi, f, autodiff, tstops, p, batch, ode_batch_eval, param_estim
             )
             tstops_loss = tstops_loss_func(θ, phi)
             if strategy isa GridTraining

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -338,10 +338,12 @@ function generate_loss(
     ts = collect(tspan[1]:(strategy.dx):tspan[2])
     autodiff && throw(ArgumentError("autodiff not supported for GridTraining."))
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts)
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return function (θ, _)
+            dev = safe_get_device(θ)
+            ts_ = safe_expand(dev, ts)
+            rhs = ode_batch_eval || !(dev isa CPUDevice) ? BatchedRHS(f) : f
+            return inner_loss(phi, rhs, autodiff, ts_, θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end
@@ -359,10 +361,10 @@ function generate_loss(
         T = promote_type(eltype(tspan[1]), eltype(tspan[2]))
         ts = (tspan[2] - tspan[1]) .* rand(T, strategy.points) .+ tspan[1]
         if batch
-            dev = safe_get_device(phi)
+            dev = safe_get_device(θ)
             ts = safe_expand(dev, ts)
-            f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-            inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+            rhs = ode_batch_eval || !(dev isa CPUDevice) ? BatchedRHS(f) : f
+            inner_loss(phi, rhs, autodiff, ts, θ, p, param_estim)
         else
             sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
         end
@@ -387,10 +389,12 @@ function generate_loss(
     end
 
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts)
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return function (θ, _)
+            dev = safe_get_device(θ)
+            ts_ = safe_expand(dev, ts)
+            rhs = ode_batch_eval || !(dev isa CPUDevice) ? BatchedRHS(f) : f
+            return inner_loss(phi, rhs, autodiff, ts_, θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end

--- a/test/NNODE/nnode__ode_batch_eval.jl
+++ b/test/NNODE/nnode__ode_batch_eval.jl
@@ -1,0 +1,41 @@
+using NeuralPDE, SciMLBase
+using Test
+
+@testset "ODE RHS batch evaluation" begin
+    using Lux, Optimisers, Random
+
+    Random.seed!(100)
+    chain = Chain(Dense(1, 4, tanh), Dense(4, 2))
+    strategy = StochasticTraining(4)
+
+    @testset "pointwise RHS opt-out" begin
+        function pointwise_rhs(u::AbstractVector, p, t::Number)
+            return [u[2], -u[1]]
+        end
+
+        prob = ODEProblem(pointwise_rhs, [1.0, 0.0], (0.0, 1.0))
+        alg = NNODE(chain, Adam(0.01); strategy, ode_batch_eval = false)
+        sol = solve(
+            prob, alg; verbose = false, maxiters = 1, saveat = [0.5],
+            tstops = [0.25, 0.75]
+        )
+        @test length(sol(0.5)) == 2
+    end
+
+    @testset "batched RHS default" begin
+        function batched_rhs(u::AbstractMatrix, p, t::AbstractVector)
+            return vcat(u[2:2, :], -u[1:1, :])
+        end
+        batched_rhs(u::AbstractVector, p, t::Number) = error("pointwise evaluation used")
+
+        prob = ODEProblem(batched_rhs, [1.0, 0.0], (0.0, 1.0))
+        alg = NNODE(chain, Adam(0.01); strategy)
+        @test alg.ode_batch_eval
+
+        sol = solve(
+            prob, alg; verbose = false, maxiters = 1, saveat = [0.5],
+            tstops = [0.25, 0.75]
+        )
+        @test length(sol(0.5)) == 2
+    end
+end

--- a/test/NNODE/nnode__ode_complex_numbers.jl
+++ b/test/NNODE/nnode__ode_complex_numbers.jl
@@ -6,7 +6,7 @@ using Test
 
     Random.seed!(100)
 
-    function bloch_equations(u, p, t)
+    function bloch_equations(u::AbstractVector, p, t)
         Ω, Δ, Γ = p
         γ = Γ / 2
         ρ₁₁, ρ₂₂, ρ₁₂, ρ₂₁ = u
@@ -30,6 +30,7 @@ using Test
         Dense(1, 16, tanh; init_weight = kaiming_normal(ComplexF64)),
         Dense(16, 4; init_weight = kaiming_normal(ComplexF64))
     )
+    @test NNODE(chain, Adam(0.01)).ode_batch_eval
 
     ground_truth = solve(problem, Tsit5(), saveat = 0.01)
 
@@ -44,7 +45,7 @@ using Test
         # Inner @testset scopes reset RNG state; match the direct solve initialization path.
         Lux.setup(Random.default_rng(), chain)
         init_params, _ = Lux.setup(Random.default_rng(), chain)
-        alg = NNODE(chain, Adam(0.01), init_params; strategy)
+        alg = NNODE(chain, Adam(0.01), init_params; strategy, ode_batch_eval = false)
         sol = solve(problem, alg; verbose = false, maxiters = 10000, saveat = 0.01)
         @test sol.u ≈ ground_truth.u rtol = 2.0e-1
     end

--- a/test/NNODE/nnode__ode_example_2.jl
+++ b/test/NNODE/nnode__ode_example_2.jl
@@ -6,7 +6,7 @@ using Test
 
     Random.seed!(100)
 
-    linear = (u, p, t) -> -u / 5 + exp(-t / 5) .* cos(t)
+    linear = (u, p, t) -> @. -u / 5 + exp(-t / 5) * cos(t)
     linear_analytic = (u0, p, t) -> exp(-t / 5) * (u0 + sin(t))
     prob = ODEProblem(
         ODEFunction(linear; analytic = linear_analytic), 0.0f0, (0.0f0, 1.0f0)

--- a/test/NNODE/nnode__ode_i.jl
+++ b/test/NNODE/nnode__ode_i.jl
@@ -4,12 +4,11 @@ using Test
 @testset "ODE I" begin
     using OrdinaryDiffEq, Random, Lux, Optimisers
 
-    linear = (
-        u,
-        p,
-        t,
-    ) -> @. t^3 + 2 * t + (t^2) * ((1 + 3 * (t^2)) / (1 + t + (t^3))) -
-        u * (t + ((1 + 3 * (t^2)) / (1 + t + t^3)))
+    function linear(u, p, t)
+        ts = t'
+        return @. ts^3 + 2 * ts + (ts^2) * ((1 + 3 * (ts^2)) / (1 + ts + (ts^3))) -
+            u * (ts + ((1 + 3 * (ts^2)) / (1 + ts + ts^3)))
+    end
     linear_analytic = (u0, p, t) -> [exp(-(t^2) / 2) / (1 + t + t^3) + t^2]
     prob = ODEProblem(
         ODEFunction(linear; analytic = linear_analytic), [1.0f0], (0.0f0, 1.0f0)

--- a/test/NNODE/nnode__ode_parameter_estimation.jl
+++ b/test/NNODE/nnode__ode_parameter_estimation.jl
@@ -31,7 +31,7 @@ using Test
     alg = NNODE(
         luxchain, BFGS(linesearch = BackTracking());
         strategy = GridTraining(0.01), dataset = dataset,
-        param_estim = true
+        param_estim = true, ode_batch_eval = false
     )
     sol = solve(prob, alg; verbose = false, abstol = 1.0e-8, maxiters = 1000, saveat = t_)
 

--- a/test/NNODE/nnode__ode_parameter_estimation_improvement.jl
+++ b/test/NNODE/nnode__ode_parameter_estimation_improvement.jl
@@ -45,7 +45,7 @@ using Test
     alg_old = NNODE(
         luxchain, BFGS(linesearch = BackTracking());
         strategy = GridTraining(0.01), dataset = dataset,
-        param_estim = true
+        param_estim = true, ode_batch_eval = false
     )
     sol_old = solve(
         prob, alg_old; verbose = false, abstol = 1.0e-12, maxiters = 2000, saveat = 0.01
@@ -53,7 +53,8 @@ using Test
 
     alg_new = NNODE(
         luxchain, BFGS(linesearch = BackTracking()); strategy = GridTraining(0.01),
-        param_estim = true, dataset = dataset, estim_collocate = true
+        param_estim = true, dataset = dataset, estim_collocate = true,
+        ode_batch_eval = false
     )
     sol_new = solve(
         prob, alg_new; verbose = false, abstol = 1.0e-12, maxiters = 2000, saveat = 0.01

--- a/test/NNODE/nnode__scalar.jl
+++ b/test/NNODE/nnode__scalar.jl
@@ -7,7 +7,7 @@ using Test
 
     Random.seed!(100)
 
-    linear = (u, p, t) -> cospi(2t)
+    linear = (u, p, t) -> @. cospi(2t)
     tspan = (0.0f0, 1.0f0)
     u0 = 0.0f0
     prob = ODEProblem(linear, u0, tspan)

--- a/test/NNODE/nnode__training_strategy_others.jl
+++ b/test/NNODE/nnode__training_strategy_others.jl
@@ -6,7 +6,7 @@ using Test
 
     Random.seed!(100)
 
-    linear = (u, p, t) -> cospi(2t)
+    linear = (u, p, t) -> @. cospi(2t)
     linear_analytic = (u, p, t) -> (1 / (2pi)) * sinpi(2t)
     tspan = (0.0, 1.0)
     dt = (tspan[2] - tspan[1]) / 99

--- a/test/NNODE/nnode__training_strategy_weightedintervaltraining.jl
+++ b/test/NNODE/nnode__training_strategy_weightedintervaltraining.jl
@@ -21,7 +21,8 @@ using Test
     )
 
     alg = NNODE(
-        chain, Adam(0.01); strategy = WeightedIntervalTraining([0.7, 0.2, 0.1], 200)
+        chain, Adam(0.01); strategy = WeightedIntervalTraining([0.7, 0.2, 0.1], 200),
+        ode_batch_eval = false
     )
 
     sol = solve(prob_oop, alg; verbose = false, maxiters = 5000, saveat = 0.01)

--- a/test/NNODE/nnode__training_strategy_with_tstops.jl
+++ b/test/NNODE/nnode__training_strategy_with_tstops.jl
@@ -37,12 +37,16 @@ using Test
             StochasticTraining(3),
         ]
         Random.seed!(100)
-        alg = NNODE(chain, Adam(0.01), deepcopy(init_params); strategy)
+        alg = NNODE(
+            chain, Adam(0.01), deepcopy(init_params); strategy, ode_batch_eval = false
+        )
         sol = solve(prob_oop, alg; verbose = false, maxiters = 1000, saveat)
         error_without_points = abs(mean(sol) - mean(true_sol))
 
         Random.seed!(100)
-        alg = NNODE(chain, Adam(0.01), deepcopy(init_params); strategy)
+        alg = NNODE(
+            chain, Adam(0.01), deepcopy(init_params); strategy, ode_batch_eval = false
+        )
         sol = solve(
             prob_oop, alg; verbose = false,
             maxiters = 10000, saveat, tstops = addedPoints


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Keep batched ODE right-hand-side evaluation as NNODE's default, while repairing the explicit `ode_batch_eval = false` path for ordinary pointwise right-hand sides on CPU. Batch losses now determine the device from the optimization parameters, use a local RHS wrapper instead of mutating a captured function, and use the intended CPU/non-CPU test instead of calling undefined `not`.

The follow-up also makes tstop losses honor the same public contract. Existing pointwise examples and tests now opt out explicitly, while examples that should exercise the default were made genuinely batch-aware. A focused regression test covers both the explicit pointwise path and the default batched path with `tstops`.

Closes https://github.com/SciML/NeuralPDE.jl/issues/1143.

## Cause

Clean bisection identified https://github.com/SciML/NeuralPDE.jl/commit/dd792519540cde8c3957612a0c5354116002da61 as the first bad commit; its parent https://github.com/SciML/NeuralPDE.jl/commit/62ff9be858681e374ffa1b9cff037d50e7da3e97 passes the minimal pointwise-RHS solve. The introducing commit made batched evaluation the default without migrating vector-only right-hand sides, and its opt-out path was unusable because `safe_get_device(phi)` inspected the model wrapper and the non-CPU test called undefined `not`.

This corrects the implementation without changing the public default or introducing an internal wrapper requirement for users. It supersedes the default-changing approaches in https://github.com/SciML/NeuralPDE.jl/pull/1136, https://github.com/SciML/NeuralPDE.jl/pull/1139, and https://github.com/SciML/NeuralPDE.jl/pull/1144.

## Failing before

On clean master with Julia 1.11.9, the existing complex-number test passed the pointwise RHS a state matrix:

```text
DimensionMismatch: Batched RHS returned size (4,), expected (4, 500).
Test Summary:       | Pass  Error  Total
ODE Complex Numbers |    1      3      4
```

With the final three-assertion tstop regression test applied to the prior PR implementation but before the tstop-loss fix, the default batched-only RHS was incorrectly evaluated pointwise:

```text
$ GROUP=NNODE timeout 3600 julia +1.11.9 --startup-file=no --compiled-modules=no --pkgimages=no --project=. test/NNODE/nnode__ode_batch_eval.jl
ErrorException: pointwise evaluation used
Test Summary:            | Pass  Error  Total     Time
ODE RHS batch evaluation |    2      1      3  1m40.3s
Elapsed: 10:31.82; exit status: 1
```

## Passing after

The exact same targeted command and three assertions pass on the final tree:

```text
Test Summary:            | Pass  Total     Time
ODE RHS batch evaluation |    3      3  1m36.7s
Elapsed: 10:03.97; exit status: 0
```

Both required Julia versions pass every NNODE test file (15 files, 53 assertions):

```text
$ GROUP=NNODE timeout 10800 julia +1.11.9 --startup-file=no --project -e 'using Pkg; Pkg.test()'
Testing NeuralPDE tests passed
Elapsed: 1:29:02; exit status: 0

$ GROUP=NNODE timeout 10800 julia +lts --startup-file=no --project -e 'using Pkg; Pkg.test()'
Testing NeuralPDE tests passed
Elapsed: 1:29:05; exit status: 0
```

QA passes 80/80:

```text
$ GROUP=QA timeout 10800 julia +1.12.7 --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
QA/qa.jl      |   80     80  25m27.1s
Testing NeuralPDE tests passed
Elapsed: 26:08.76; exit status: 0
```

The full documentation build, including every edited page, passes:

```text
$ DATADEPS_ALWAYS_ACCEPT=true GKSwstype=100 \
    JULIA_DEPOT_PATH=.validation/depot-final-docs:$HOME/.julia \
    timeout 21600 bash -c 'julia +1.12.7 --startup-file=no --project=docs -e '\''using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'\'' && julia +1.12.7 --startup-file=no --project=docs docs/make.jl'
Automatic `version="6.2.5"` for inventory from ../Project.toml
Elapsed: 5:54:46; exit status: 0
```

These final checks also exited 0:

```text
$ julia +1.11.9 --startup-file=no --project=$HOME/.julia/environments/runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check <all changed .jl files>
$ typos <all changed files>
$ git diff --check
$ git diff --cached --check
```

## Not verified locally

- GPU execution was unavailable locally. The prior draft commit's CUDA job passed at https://github.com/SciML/NeuralPDE.jl/actions/runs/33851271681/job/100954470120; CI remains the hardware gate for this follow-up.
- `GROUP=Everything`, downstream packages, Julia pre, and other allowed-to-fail jobs were not run locally.

## Links

- Draft PR: https://github.com/SciML/NeuralPDE.jl/pull/1142
- Clean-master tracker: https://github.com/SciML/NeuralPDE.jl/issues/1143
- Regression-introducing PR: https://github.com/SciML/NeuralPDE.jl/pull/1101
- Regression-introducing commit: https://github.com/SciML/NeuralPDE.jl/commit/dd792519540cde8c3957612a0c5354116002da61
- Passing parent commit: https://github.com/SciML/NeuralPDE.jl/commit/62ff9be858681e374ffa1b9cff037d50e7da3e97
- Original Julia 1.11 failure: https://github.com/SciML/NeuralPDE.jl/actions/runs/33845180179/job/100935537317
- Original Julia LTS failure: https://github.com/SciML/NeuralPDE.jl/actions/runs/33845180179/job/100935537195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
