### PR TITLE
fix: preserve pointwise ODE RHS semantics in batched NNODE losses

### DIFF
--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -222,6 +222,18 @@ end
 
 @inline (rhs::BatchedRHS)(u, p, t) = rhs.f(u, p, t)
 
+_explicit_batched_rhs(::Any) = nothing
+_explicit_batched_rhs(rhs::AbstractBatchedRHS) = rhs
+_explicit_batched_rhs(f::ODEFunction) = _explicit_batched_rhs(f.f)
+
+function _loss_rhs(f, ode_batch_eval, dev)
+    if ode_batch_eval
+        rhs = _explicit_batched_rhs(f)
+        rhs === nothing || return rhs
+    end
+    return dev isa CPUDevice ? f : BatchedRHS(f)
+end
+
 """
     inner_loss(phi, f, autodiff, t, θ, p, param_estim)
 
@@ -338,10 +350,12 @@ function generate_loss(
     ts = collect(tspan[1]:(strategy.dx):tspan[2])
     autodiff && throw(ArgumentError("autodiff not supported for GridTraining."))
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts)
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return function (θ, _)
+            dev = safe_get_device(θ)
+            ts_ = safe_expand(dev, ts)
+            rhs = _loss_rhs(f, ode_batch_eval, dev)
+            return inner_loss(phi, rhs, autodiff, ts_, θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end
@@ -359,10 +373,10 @@ function generate_loss(
         T = promote_type(eltype(tspan[1]), eltype(tspan[2]))
         ts = (tspan[2] - tspan[1]) .* rand(T, strategy.points) .+ tspan[1]
         if batch
-            dev = safe_get_device(phi)
+            dev = safe_get_device(θ)
             ts = safe_expand(dev, ts)
-            f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-            inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+            rhs = _loss_rhs(f, ode_batch_eval, dev)
+            inner_loss(phi, rhs, autodiff, ts, θ, p, param_estim)
         else
             sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
         end
@@ -387,10 +401,12 @@ function generate_loss(
     end
 
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts)
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return function (θ, _)
+            dev = safe_get_device(θ)
+            ts_ = safe_expand(dev, ts)
+            rhs = _loss_rhs(f, ode_batch_eval, dev)
+            return inner_loss(phi, rhs, autodiff, ts_, θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end

--- a/test/NNODE/nnode__ode_batch_eval.jl
+++ b/test/NNODE/nnode__ode_batch_eval.jl
@@ -1,0 +1,47 @@
+using NeuralPDE, SciMLBase
+using ChainRulesCore: ignore_derivatives
+using Test
+
+@testset "ODE RHS batch evaluation" begin
+    using Lux, Optimisers, Random
+
+    Random.seed!(100)
+    batch_widths = Int[]
+    record_batch(x) = begin
+        ignore_derivatives() do
+            x isa AbstractMatrix && push!(batch_widths, size(x, 2))
+        end
+        return x
+    end
+    chain = Chain(WrappedFunction(record_batch), Dense(1, 4, tanh), Dense(4, 2))
+    strategy = StochasticTraining(4)
+
+    @test NNODE(chain, Adam(0.01); strategy).ode_batch_eval
+
+    @testset "ordinary pointwise RHS" begin
+        function pointwise_rhs(u::AbstractVector, p, t::Number)
+            x, y = u
+            return [y, -x]
+        end
+
+        prob = ODEProblem(pointwise_rhs, [1.0, 0.0], (0.0, 1.0))
+        sol = solve(
+            prob, NNODE(chain, Adam(0.01); strategy);
+            verbose = false, maxiters = 1, saveat = [0.5]
+        )
+        @test length(sol(0.5)) == 2
+    end
+    @test strategy.points in batch_widths
+
+    @testset "internal batched RHS" begin
+        batched_rhs(u::AbstractVector, p, t::Number) = error("pointwise evaluation used")
+        batched_rhs(u::AbstractMatrix, p, t::AbstractVector) = vcat(u[2:2, :], -u[1:1, :])
+
+        prob = ODEProblem(NeuralPDE.BatchedRHS(batched_rhs), [1.0, 0.0], (0.0, 1.0))
+        sol = solve(
+            prob, NNODE(chain, Adam(0.01); strategy);
+            verbose = false, maxiters = 1, saveat = [0.5]
+        )
+        @test length(sol(0.5)) == 2
+    end
+end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Keep `ode_batch_eval = true` as NNODE's default while preserving the ordinary SciML ODE RHS contract: `f(u, p, t)` receives one state vector and one scalar time. The neural model and loss points are still evaluated as a batch, but the loss maps an ordinary `ODEFunction` over the batch instead of silently redefining its input shapes.

The existing internal `AbstractBatchedRHS`/`BatchedRHS` path still invokes an explicitly marked RHS once with a state matrix and time vector. Device selection now comes from the optimization parameters, and stochastic loss construction no longer mutates its captured RHS.

SciMLBase does not provide a vectorized-ODE-RHS trait, so this bug fix does not add or expose a public marker API. A separately designed public batching trait could be considered later.

This differs from https://github.com/SciML/NeuralPDE.jl/pull/1142, which repairs the explicit opt-out path and changes the complex regression to `ode_batch_eval = false`; it does not make an ordinary RHS work under the requested default.

## Cause

Bisection identified https://github.com/SciML/NeuralPDE.jl/commit/dd792519540cde8c3957612a0c5354116002da61 as the first bad commit. Its direct parent, https://github.com/SciML/NeuralPDE.jl/commit/62ff9be858681e374ffa1b9cff037d50e7da3e97, passes the pointwise-RHS reproducer. The introducing change made batched evaluation the default by wrapping every RHS in `BatchedRHS`, causing ordinary `ODEFunction`s to receive matrices and time vectors.

## Regression evidence

The new test checks all three relevant contracts:

- `ode_batch_eval` remains enabled by default;
- an ordinary vector/scalar RHS succeeds while the neural model observes the four-point batch;
- the existing internal `BatchedRHS` marker retains direct matrix/vector invocation.

On clean current master (`b37b171910a588efe230c0a9ef9c048d6e32eaed`), the exact test fails:

```text
ordinary pointwise RHS: Error During Test
MethodError: no method matching pointwise_rhs(::Matrix{Float64}, ::SciMLBase.NullParameters, ::Vector{Float64})
Closest candidates:
  pointwise_rhs(!Matched::AbstractVector, ::Any, !Matched::Number)

Test Summary:            | Pass  Error  Total     Time
ODE RHS batch evaluation |    3      1      4  1m35.4s
  ordinary pointwise RHS |           1      1  1m13.7s
  internal batched RHS   |    1             1    20.3s
ERROR: Some tests did not pass: 3 passed, 0 failed, 1 errored, 0 broken.
```

The exact same test on this branch passes:

```text
Test Summary:            | Pass  Total     Time
ODE RHS batch evaluation |    4      4  1m35.1s
```

Both discriminator runs used normal Julia compilation semantics for the tested code. Compiled package caches and package images were disabled because unrelated concurrent Julia jobs were writing the shared depot.

## Verification

The complete NNODE group passed on Julia 1.11:

```text
$ GROUP=NNODE TMPDIR="$PWD/.task_tmp" JULIA_PKG_PRECOMPILE_AUTO=0 \
    julia +1.11 --startup-file=no --compiled-modules=no --pkgimages=no \
    --project=. -e 'using Pkg; Pkg.test()'

Test Summary:            | Pass  Total     Time
ODE RHS batch evaluation |    4      4  1m35.1s
Test Summary:       | Pass  Total      Time
ODE Complex Numbers |    4      4  18m25.6s
...
Test Summary:          | Pass  Total   Time
NNODE/nnode__vector.jl |   12     12  24.1s
     Testing NeuralPDE tests passed
```

QA ran all 80 assertions twice with the no-cache flags. Both runs passed 79 and failed only Aqua's environment-sensitive `Persistent tasks` assertion because FFTW 1.10.0 failed inside Aqua's explicit precompile child:

```text
could not load symbol "fftw_version":
.../bin/julia: undefined symbol: fftw_version

Test Summary:                                  | Pass  Fail  Total      Time
QA/qa.jl                                       |   79     1     80  72m29.7s
  Reexported public API stays in scope         |   56           56      2.2s
  Quality Assurance                            |   19     1     20  62m14.6s
    Method ambiguity                           |    1            1  11m00.9s
    Stale dependencies                         |    1            1   9m33.5s
    Persistent tasks                           |          1      1  40m52.6s
    ExplicitImports                            |    6            6     38.6s
    Public API documentation                   |    2            2      0.2s
  Public logging hooks                         |    4            4      0.5s
```

Direct no-cache loading of FFTW succeeds. A bounded normal-compilation QA retry then precompiled NeuralPDE and all remaining dependencies successfully (confirming the FFTW error was induced by the no-cache precompile mode), but Aqua's dummy persistent-task compiler remained idle in `ep_poll`; that retry was stopped rather than consuming the slot indefinitely. The source/API checks above all passed, and no QA test was skipped, disabled, or altered.

Final mechanical checks exited zero:

```text
$ julia +1.12 -m Runic --check src/ode_solve.jl test/NNODE/nnode__ode_batch_eval.jl
$ git diff --check
$ git diff -- src/ode_solve.jl | typos -
$ git diff --no-index /dev/null test/NNODE/nnode__ode_batch_eval.jl | typos -
```

The final audit found no added comment lines and no new `export`/`public` declarations. No docs build was needed because this changes no docs, docstrings, or public API.

## Not verified locally

- GPU execution was unavailable. The pre-existing non-CPU forced-batched path is preserved; CUDA CI remains the hardware gate.
- `GROUP=Everything`, downstream packages, and allowed-to-fail jobs were not run.
- QA's Aqua persistent-task assertion did not reach a passing terminal locally for the environment reasons above.

## Links

- This regression's introducing PR: https://github.com/SciML/NeuralPDE.jl/pull/1101
- Introducing commit: https://github.com/SciML/NeuralPDE.jl/commit/dd792519540cde8c3957612a0c5354116002da61
- Passing parent commit: https://github.com/SciML/NeuralPDE.jl/commit/62ff9be858681e374ffa1b9cff037d50e7da3e97
- Default-changing draft 1136: https://github.com/SciML/NeuralPDE.jl/pull/1136
- Default-changing draft 1139 and review request to retain batching: https://github.com/SciML/NeuralPDE.jl/pull/1139
- Opt-out-only draft 1142: https://github.com/SciML/NeuralPDE.jl/pull/1142
- Hosted complex-number failure: https://github.com/SciML/NeuralPDE.jl/actions/runs/33395044908/job/99514529083

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
