### PR TITLE
Stabilize NNSDE batch comparison with Adam

### DIFF
--- a/test/NNSDE1/nn_sde__test_2_gbm_sde.jl
+++ b/test/NNSDE1/nn_sde__test_2_gbm_sde.jl
@@ -3,7 +3,6 @@ using Test
 
 @testset "Test-2 GBM SDE" begin
     using OrdinaryDiffEq, Random, Lux, Optimisers, DiffEqNoiseProcess, Distributions
-    using OptimizationOptimJL: BFGS
     using MonteCarloMeasurements: Particles, pmean
     Random.seed!(100)
 
@@ -21,8 +20,8 @@ using Test
     dt = 1 / 50.0f0
     abstol = 1.0e-12
     autodiff = false
-    kwargs = (; verbose = true, dt = dt, abstol, maxiters = 500)
-    opt = BFGS()
+    kwargs = (; verbose = true, dt = dt, abstol, maxiters = 2000)
+    opt = Adam(0.01)
     numensemble = 500
 
     sol_2 = solve(


### PR DESCRIPTION
## What changed

Switch the seeded NNSDE weak/strong GBM statistical comparison from `BFGS()` to the already-covered `Adam(0.01)` path and allow 2,000 iterations. Optim 2.3 intentionally changed which line-search point BFGS commits, and that selects a different local trajectory for this test even though the test is checking NNSDE statistics rather than BFGS behavior.

No production code, dependency, assertion, or tolerance changes. Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Regression evidence

The clean current master at `b37b1719` resolved Optim 2.3.1 and reproduced the reported failure on Julia 1.11.9:

```text
Test Summary:                    | Pass  Fail  Total
NNSDE1/nn_sde__test_2_gbm_sde.jl |    6     5     11

1.3213229131993984 > 4.131829083925119
0.15944762909657095 < 0.12590829241567447
0.7842268862910236 > 3.9391774999749094
0.15567014705833157 < 0.11537699777041223
0.11594114337710763 > 0.14862146801746695
```

Resolving Optim 2.2.2 while retaining LineSearches 7.8.1 and the other current dependencies made the same 11 assertions pass. This isolates the dependency change to Optim 2.3.0, specifically the intentional line-search point fix in https://github.com/JuliaNLSolvers/Optim.jl/commit/f208a0101de8505b026e9568510a65a946c11288 and https://github.com/JuliaNLSolvers/Optim.jl/pull/1283.

With this change and the current Optim 2.3.1 dependency, the same file passes:

```text
Test Summary:                    | Pass  Total      Time
NNSDE1/nn_sde__test_2_gbm_sde.jl |   11     11  18m18.0s
```

## Verification

Julia 1.11.9, `JULIA_NUM_THREADS=1`:

```sh
GROUP=NNSDE1 timeout 10800 /home/crackauc/.juliaup/bin/julia +1.11 --startup-file=no --project=. -e 'import Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=yes", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
```

The changed file passed 11/11. The full group also passed the first file 2/2 and the third file 8/8, then hit a separate clean-master failure in the unchanged fourth file:

```text
NNSDE1/nn_sde__test_4_gbm_sde_inverse_weak_strong_solving.jl | 7 pass | 1 fail
line 138: 1.5156073718898693 < 1.5
```

That fourth file passed 8/8 when run directly with current Optim 2.3.1 and also passed 8/8 with Optim 2.2.2 plus LineSearches 7.8.1. Its training traces differ materially despite the file-level seed, so Optim is not its discriminator and it is being investigated separately as uncontrolled solver/task RNG. It is not changed or masked here.

```sh
GROUP=QA /home/crackauc/.juliaup/bin/julia +1.11 --project=. -e 'import Pkg; Pkg.test(; force_latest_compatible_version=false, allow_reresolve=true)'
```

```text
Test Summary: | Pass  Total      Time
QA/qa.jl      |   80     80  14m43.7s
```

Runic `--check --diff`, `typos`, and `git diff --check` all exited successfully. Documentation was not built because the change touches no docstring, documentation, or public API. GPU, downstream, and allowed-to-fail jobs were not run locally.

The parallel NNSDE2 CI-only investigation did not reproduce locally and is documented with exact commands and controls at https://github.com/SciML/NeuralPDE.jl/issues/1145.

## Reviewer judgment

The judgment call is replacing the optimizer in this statistical regression test. BFGS remains covered by other NeuralPDE tests; this case now uses a seeded first-order trajectory that passed all 11 existing assertions without weakening them.

## Links

- Original NeuralPDE CI run: https://github.com/SciML/NeuralPDE.jl/actions/runs/33851271681
- Failing NNSDE1 job: https://github.com/SciML/NeuralPDE.jl/actions/runs/33851271681/job/100954470176
- Optim introducing commit: https://github.com/JuliaNLSolvers/Optim.jl/commit/f208a0101de8505b026e9568510a65a946c11288
- Optim introducing PR: https://github.com/JuliaNLSolvers/Optim.jl/pull/1283
- NNSDE2 investigation: https://github.com/SciML/NeuralPDE.jl/issues/1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
