### PR TITLE
Seed inverse NNSDE Wiener paths

### DIFF
--- a/test/NNSDE1/nn_sde__test_2_gbm_sde.jl
+++ b/test/NNSDE1/nn_sde__test_2_gbm_sde.jl
@@ -3,7 +3,6 @@ using Test
 
 @testset "Test-2 GBM SDE" begin
     using OrdinaryDiffEq, Random, Lux, Optimisers, DiffEqNoiseProcess, Distributions
-    using OptimizationOptimJL: BFGS
     using MonteCarloMeasurements: Particles, pmean
     Random.seed!(100)
 
@@ -21,8 +20,8 @@ using Test
     dt = 1 / 50.0f0
     abstol = 1.0e-12
     autodiff = false
-    kwargs = (; verbose = true, dt = dt, abstol, maxiters = 500)
-    opt = BFGS()
+    kwargs = (; verbose = true, dt = dt, abstol, maxiters = 2000)
+    opt = Adam(0.01)
     numensemble = 500
 
     sol_2 = solve(

--- a/test/NNSDE1/nn_sde__test_4_gbm_sde_inverse_weak_strong_solving.jl
+++ b/test/NNSDE1/nn_sde__test_4_gbm_sde_inverse_weak_strong_solving.jl
@@ -28,14 +28,21 @@ using Test
     ts = collect(tspan[1]:dt:tspan[2])
     num_time_steps = length(ts)
 
-    # We want n=num_samples strong solutions defined at timepoints.
-    W_samples = Array{Float64}(undef, num_time_steps, num_samples)
-    for i in 1:num_samples
-        W = WienerProcess(0.0, 0.0)
-        probtemp = NoiseProblem(W, (0.0, 1.0))
-        Np_sol = solve(probtemp; dt = dt)
-        W_samples[:, i] = Np_sol.u
+    function wiener_samples(num_time_steps, num_samples, dt; seed_offset = 0)
+        samples = Array{Float64}(undef, num_time_steps, num_samples)
+        for i in 1:num_samples
+            W = WienerProcess(0.0, 0.0)
+            probtemp = NoiseProblem(W, (0.0, 1.0); seed = seed_offset + i)
+            Np_sol = solve(probtemp; dt)
+            samples[:, i] = Np_sol.u
+        end
+        return samples
     end
+
+    # We want n=num_samples strong solutions defined at timepoints.
+    W_samples = wiener_samples(num_time_steps, num_samples, dt)
+    @test W_samples == wiener_samples(num_time_steps, num_samples, dt)
+    Random.seed!(100)
 
     analytic_sol(u0, p, t, W) = u0 * exp((p[1] - p[2]^2 / 2) * t + p[2] * W)
     analytic_solution_samples = Array{Float64}(undef, num_time_steps, num_samples)
@@ -91,13 +98,9 @@ using Test
     # testing dataset must be for the same timepoints as solution
     num_samples = 500
     num_time_steps = length(ts)
-    W_samples = Array{Float64}(undef, num_time_steps, num_samples)
-    for i in 1:num_samples
-        W = WienerProcess(0.0, 0.0)
-        probtemp = NoiseProblem(W, (0.0, 1.0))
-        Np_sol = solve(probtemp; dt = 1 / N_solve)
-        W_samples[:, i] = Np_sol.u
-    end
+    W_samples = wiener_samples(
+        num_time_steps, num_samples, 1 / N_solve; seed_offset = num_samples
+    )
 
     temp_rands = hcat([randn(num_samples) for _ in 1:n_z]...)'
     phi_inputs = [


### PR DESCRIPTION
Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

`Random.seed!(100)` did not control the Wiener trajectories in the inverse NNSDE test: `NoiseProblem` reseeds its copied noise process from system entropy when its `seed` is left at zero. This makes both the training paths and the independently generated validation paths vary between otherwise identical runs.

This change gives every path an explicit `NoiseProblem` seed, uses disjoint seed ranges for training and validation, and asserts that the same path-generation call is exactly repeatable. It changes no tolerance, public API, package dependency, or production source.

This is stacked on https://github.com/SciML/NeuralPDE.jl/pull/1146 because clean master currently stops earlier in NNSDE test 2. The RNG change is the distinct second commit `b6b7a9998ce4d81667e472fd71dd32e6036d1c9b`; after the dependency merges, this branch should be rebased so the draft contains only that commit.

## Investigation

A reduced control showed that two unseeded `NoiseProblem` solves differ even after the same global `Random.seed!`, while explicit per-problem seeds reproduce exactly:

```text
uncontrolled_equal=false
uncontrolled_endpoints=(-0.5621598251122956, 0.04919298115426579)
controlled_equal=true
controlled_endpoint=0.3895873815555833
```

A runtime bisect of DiffEqNoiseProcess identified `db6dc112afe62504bd7f1dc8e69e44b13d141fdb`, merged through https://github.com/SciML/DiffEqNoiseProcess.jl/pull/251. That intentional change switched the unseeded branch from the global RNG to system entropy; later documentation recommends explicit `NoiseProblem` seeds when deterministic noise is required.

The motivating old statistical threshold failure (`1.5156073718898693 < 1.5`) was observed while validating the stacked test suite, but it did **not** reproduce in my 10/10 clean direct runs: all 80/80 old assertions passed. Those nominally seeded runs nevertheless ended with materially different training losses from 5.65819 to 9.10788, confirming that the trajectory source was uncontrolled. I am not claiming that the old statistical assertion itself failed locally.

## Failing before / passing after

I temporarily removed only the new `seed = seed_offset + i` keyword and ran the same new assertion with fail-fast enabled:

```text
Expression: W_samples == wiener_samples(num_time_steps, num_samples, dt)
Test Summary:                                 | Fail  Total   Time
Test-4 GBM SDE Inverse, weak & strong solving |    1      1  11.2s
ERROR: Some tests did not pass: 0 passed, 1 failed, 0 errored, 0 broken.
```

After restoring the explicit seeds, the same file passed twice on Julia 1.11.9:

```text
Test-4 GBM SDE Inverse, weak & strong solving | 9 / 9 | 5m32.5s
Test-4 GBM SDE Inverse, weak & strong solving | 9 / 9 | 5m30.3s
```

Both runs ended at loss `8.44424`, and their normalized training logs were byte-identical. Julia 1.10.12 also passed 9/9 in 13m31.9s with the same final loss.

## Verification

Full stacked `NNSDE1` group, using the repository's `test/runtests.jl` routing:

```text
Julia 1.11.9:  test 1 2/2; test 2 11/11; test 3 8/8; test 4 9/9; total 30/30
Julia 1.10.12: test 1 2/2; test 2 11/11; test 3 8/8; test 4 9/9; total 30/30
```

These two full-group runs used an ignored validation environment holding AMD 0.5.3 because AMD 0.5.4 plus SparseColumnPivotedQR 2.1.7 then failed on clean master with `SS_Int` before the tests. No AMD constraint is included in this PR.

For QA, the unchanged suite initially produced 79/80 under normal Project-only Aqua resolution because it selected AMD 0.5.4 with SparseColumnPivotedQR 2.1.7 and hit that same clean-master `SS_Int` error. The identical suite passed 80/80 when a temporary, uncommitted overlay held AMD exactly at 0.5.3 (reexports 56/56, QA 20/20, logging hooks 4/4). The overlay was then fully removed.

SparseColumnPivotedQR 2.1.8 has since been registered with the public AMD compatibility fix. After updating General, I ran the normal unpinned command:

```sh
GROUP=QA julia +1.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

Its root manifest and Aqua-generated clean manifest both resolved AMD 0.5.4 with SparseColumnPivotedQR 2.1.8:

```text
Test Summary: | Pass  Total      Time
QA/qa.jl      |   80     80  25m35.1s
Testing NeuralPDE tests passed
```

The first cold-cache invocation exhausted a 3,600-second wrapper during precompilation without a test failure; the successful warm-cache rerun above used a 7,200-second wrapper.

Formatting and spelling:

```text
Runic 1.10.0 --check --diff: pass
typos --force-exclude <changed file>: pass
git diff --check: pass
```

Docs were not built because this changes no docs, docstrings, or public API. GPU, downstream, Julia pre, and other allowed-to-fail jobs were not run locally.

## Links

- Dependency PR: https://github.com/SciML/NeuralPDE.jl/pull/1146
- DiffEqNoiseProcess introducing commit: https://github.com/SciML/DiffEqNoiseProcess.jl/commit/db6dc112afe62504bd7f1dc8e69e44b13d141fdb
- DiffEqNoiseProcess PR: https://github.com/SciML/DiffEqNoiseProcess.jl/pull/251
- SparseColumnPivotedQR fix: https://github.com/SciML/SparseColumnPivotedQR.jl/pull/71
- SparseColumnPivotedQR 2.1.8 registration: https://github.com/JuliaRegistries/General/commit/b14ac2171580dc3d28c2f078555cda593f325921
- RNG commit: https://github.com/ChrisRackauckas-Claude/NeuralPDE.jl/commit/b6b7a9998ce4d81667e472fd71dd32e6036d1c9b

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
