### PR TITLE
Support locally bound variables in PINN integrals

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -18,6 +18,7 @@ pages = [
         "The symbolic_discretize Interface" => "tutorials/low_level.md",
         "Optimising Parameters (Solving Inverse Problems)" => "tutorials/param_estim.md",
         "Solving Integro Differential Equations" => "tutorials/integro_diff.md",
+        "Convolution Integrals" => "tutorials/integral_bound_variables.md",
         "Transfer Learning with Neural Adapter" => "tutorials/neural_adapter.md",
         "The Derivative Neural Network Approximation" => "tutorials/derivative_neural_network.md",
     ],

--- a/docs/src/tutorials/integral_bound_variables.md
+++ b/docs/src/tutorials/integral_bound_variables.md
@@ -1,0 +1,32 @@
+# Convolution integrals with a dummy variable
+
+An integration variable can be local to an `Integral`. It does not need a domain
+in the `PDESystem`, an entry in its independent variables, or an extra neural
+network input. For example, a convolution acting on `x(t)` can be written as:
+
+```@example integral_bound_variables
+using NeuralPDE, ModelingToolkit, DomainSets, Lux
+
+@parameters t tau
+@variables x(..)
+Dt = Differential(t)
+Dtau = Differential(tau)
+I = Integral(tau in ClosedInterval(0.0, t))
+K(s) = exp(-s) * cos(s)
+
+eq = Dt(Dt(x(t))) + I(K(t - tau) * Dtau(x(tau))) + x(t) ~ 0
+bcs = [x(0.0) ~ 0.0, Dt(x(0.0)) ~ 0.0]
+domains = [t ∈ Interval(0.0, 60.0)]
+@named system = PDESystem(eq, bcs, domains, [t], [x(t)])
+
+chain = Chain(Dense(1, 4), Dense(4, 1))
+discretization = PhysicsInformedNN(chain, QuasiRandomTraining(10))
+problem = discretize(system, discretization)
+nothing # hide
+```
+
+Within the integrand, `t` retains the evaluation time while `tau` runs over the
+quadrature points. Each occurrence of `x(tau)` evaluates the same network at
+`tau`; `x(t)` in the same integrand evaluates it at `t`. Differentiate `x(tau)`
+with respect to `tau` to express the derivative of the solution at the quadrature
+point. The upper limit `t` is evaluated before quadrature starts.

--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -30,7 +30,7 @@ function build_symbolic_loss_function(
         eq_params = SciMLBase.NullParameters(), param_estim = false, default_p = nothing,
         bc_indvars = pinnrep.indvars, integrand = nothing,
         dict_transformation_vars = nothing, transformation_vars = nothing,
-        integrating_depvars = pinnrep.depvars
+        integrating_depvars = pinnrep.depvars, coordinate_vars = nothing
     )
     (;
         depvars, dict_depvars, dict_depvar_input, phi, derivative, integral,
@@ -38,9 +38,14 @@ function build_symbolic_loss_function(
     ) = pinnrep
 
     if integrand isa Nothing
-        loss_function = parse_equation(pinnrep, eqs)
         this_eq_pair = pair(eqs, depvars, dict_depvars, dict_depvar_input)
         this_eq_indvars = unique(vcat(values(this_eq_pair)...))
+        if has_local_integral(toexpr(eqs), pinnrep.dict_indvars)
+            coordinate_vars = only(get_variables([eqs], pinnrep.dict_indvars, dict_depvars))
+            this_eq_indvars = coordinate_vars
+            this_eq_pair = Dict()
+        end
+        loss_function = parse_equation(pinnrep, eqs; scope_vars = this_eq_indvars, coordinate_vars)
     else
         this_eq_pair = Dict(
             map(
@@ -50,12 +55,16 @@ function build_symbolic_loss_function(
         )
         this_eq_indvars = transformation_vars isa Nothing ?
             unique(vcat(values(this_eq_pair)...)) : transformation_vars
+        if coordinate_vars !== nothing
+            this_eq_pair = Dict()
+            this_eq_indvars = transformation_vars === nothing ? coordinate_vars : transformation_vars
+        end
         loss_function = integrand
     end
 
     vars = :(cord, $θ, phi, derivative, integral, u, p)
     ex = Expr(:block)
-    if multioutput
+    if multioutput && !(coordinate_vars !== nothing && isempty(integrating_depvars))
         θ_nums = Symbol[]
         phi_nums = Symbol[]
         for v in depvars
@@ -115,7 +124,7 @@ function build_symbolic_loss_function(
     vcat_expr = Expr(:block, :($(eq_pair_expr...)))
     vcat_expr_loss_functions = Expr(:block, vcat_expr, loss_function) # TODO rename
 
-    if strategy isa QuadratureTraining
+    if strategy isa QuadratureTraining && coordinate_vars === nothing
         indvars_ex = get_indvars_ex(bc_indvars)
         left_arg_pairs, right_arg_pairs = this_eq_indvars, indvars_ex
         vars_eq = Expr(
@@ -357,7 +366,7 @@ function get_numeric_integral(pinnrep::PINNRepresentation)
         dict_depvars = dict_depvars,
     ) -> begin
         function integration_(cord, lb, ub, θ)
-            cord_ = cord
+            cord_ = copy(cord)
             function integrand_(x, p)
                 @ignore_derivatives cord_[integrating_var_id] .= x
                 return integrand_func(cord_, p, phi, derivative, nothing, u, nothing)

--- a/src/symbolic_utilities.jl
+++ b/src/symbolic_utilities.jl
@@ -83,13 +83,13 @@ get_dict_vars(vars) = Dict([Symbol(v) .=> i for (i, v) in enumerate(vars)])
 function transform_expression(
         pinnrep::PINNRepresentation, ex; is_integral = false,
         dict_transformation_vars = nothing,
-        transformation_vars = nothing
+        transformation_vars = nothing, coordinate_vars = nothing, scope_vars = pinnrep.indvars
     )
     if ex isa Expr
         ex = _transform_expression(
             pinnrep, ex; is_integral = is_integral,
             dict_transformation_vars = dict_transformation_vars,
-            transformation_vars = transformation_vars
+            transformation_vars = transformation_vars, coordinate_vars = coordinate_vars, scope_vars = scope_vars
         )
     end
     return ex
@@ -109,6 +109,24 @@ function get_limits(domain)
         return collect(map(leftendpoint, DomainSets.components(domain))),
             collect(map(rightendpoint, DomainSets.components(domain)))
     end
+end
+
+function integral_variables(integral)
+    variables = integral.domain.variables
+    variables isa Tuple && return toexpr.(collect(variables))
+    variables = toexpr(variables)
+    if variables isa Expr && variables.head == :call && variables.args[1] === tuple
+        return variables.args[2:end]
+    end
+    return [variables]
+end
+
+function has_local_integral(ex, dict_indvars)
+    ex isa Expr || return false
+    if ex.head == :call && first(ex.args) isa Symbolics.Integral
+        any(v -> !haskey(dict_indvars, v), integral_variables(first(ex.args))) && return true
+    end
+    return any(arg -> has_local_integral(arg, dict_indvars), ex.args)
 end
 
 θ = gensym("θ")
@@ -131,7 +149,8 @@ where
 """
 function _transform_expression(
         pinnrep::PINNRepresentation, ex; is_integral = false,
-        dict_transformation_vars = nothing, transformation_vars = nothing
+        dict_transformation_vars = nothing, transformation_vars = nothing,
+        coordinate_vars = nothing, scope_vars = pinnrep.indvars
     )
     (;
         indvars, depvars, dict_indvars, dict_depvars, dict_depvar_input, multioutput,
@@ -146,13 +165,15 @@ function _transform_expression(
                 depvar = _args[1]
                 num_depvar = dict_depvars[depvar]
                 indvars = _args[2:end]
+                coordinates = coordinate_vars === nothing ? Symbol(:cord, num_depvar) :
+                    Expr(:call, Expr(:$, :vcat), indvars...)
                 var_ = is_integral ? :(u) : :($(Expr(:$, :u)))
                 ex.args = if !multioutput
-                    [var_, Symbol(:cord, num_depvar), :($θ), :phi]
+                    [var_, coordinates, :($θ), :phi]
                 else
                     [
                         var_,
-                        Symbol(:cord, num_depvar),
+                        coordinates,
                         Symbol(:($θ), num_depvar),
                         Symbol(:phi, num_depvar),
                     ]
@@ -179,7 +200,14 @@ function _transform_expression(
                             enumerate(dict_depvar_input[depvar])
                     ]
                 )
-                dim_l = length(dict_interior_indvars)
+                if coordinate_vars !== nothing
+                    for (j, indvar) in enumerate(indvars)
+                        indvar isa Symbol && (dict_interior_indvars[indvar] = j)
+                    end
+                end
+                dim_l = length(dict_depvar_input[depvar])
+                coordinates = coordinate_vars === nothing ? Symbol(:cord, num_depvar) :
+                    Expr(:call, Expr(:$, :vcat), indvars...)
 
                 var_ = is_integral ? :(derivative) : :($(Expr(:$, :derivative)))
                 εs = [get_ε(dim_l, d, eltypeθ, order) for d in 1:dim_l]
@@ -187,13 +215,13 @@ function _transform_expression(
                 εs_dnv = [εs[d] for d in undv]
 
                 ex.args = if !multioutput
-                    [var_, :phi, :u, Symbol(:cord, num_depvar), εs_dnv, order, :($θ)]
+                    [var_, :phi, :u, coordinates, εs_dnv, order, :($θ)]
                 else
                     [
                         var_,
                         Symbol(:phi, num_depvar),
                         :u,
-                        Symbol(:cord, num_depvar),
+                        coordinates,
                         εs_dnv,
                         order,
                         Symbol(:($θ), num_depvar),
@@ -201,27 +229,15 @@ function _transform_expression(
                 end
                 break
             elseif e isa Symbolics.Integral
-                if _args[1].domain.variables isa Tuple
-                    integrating_variable_ = collect(_args[1].domain.variables)
-                    integrating_variable = toexpr.(integrating_variable_)
-                    integrating_var_id = [dict_indvars[i] for i in integrating_variable]
-                else
-                    integrating_variable = toexpr(_args[1].domain.variables)
-                    # In SymbolicUtils v4, a symbolic tuple may produce
-                    # Expr(:call, :tuple, :x, :y) instead of a Julia Tuple
-                    if integrating_variable isa Expr &&
-                            integrating_variable.head == :call &&
-                            integrating_variable.args[1] === tuple
-                        integrating_variable = integrating_variable.args[2:end]
-                        integrating_var_id = [
-                            dict_indvars[i]
-                                for i in integrating_variable
-                        ]
-                    else
-                        integrating_var_id = [dict_indvars[integrating_variable]]
-                    end
-                end
+                integrating_variable = integral_variables(e)
 
+                outer_vars = coordinate_vars === nothing ? scope_vars : coordinate_vars
+                inner_vars = unique(vcat(outer_vars, integrating_variable))
+                integrating_var_id = [findfirst(==(v), inner_vars) for v in integrating_variable]
+                coordinates = Expr(
+                    :call, Expr(:$, :vcat),
+                    [v in outer_vars ? v : Expr(:$, :(zeros(eltype(cord), 1, size(cord, 2)))) for v in inner_vars]...
+                )
                 integrating_depvars = []
                 integrand_expr = _args[2]
                 for d in depvars
@@ -243,18 +259,14 @@ function _transform_expression(
                     dict_depvar_input,
                     dict_depvars,
                     integrating_variable,
-                    eltypeθ
+                    eltypeθ; coordinate_vars = inner_vars
                 )
 
-                num_depvar = map(
-                    int_depvar -> dict_depvars[int_depvar],
-                    integrating_depvars
-                )
                 integrand_ = transform_expression(
                     pinnrep, _args[2];
                     is_integral = false,
                     dict_transformation_vars = dict_transformation_vars,
-                    transformation_vars = transformation_vars
+                    transformation_vars = transformation_vars, coordinate_vars = inner_vars
                 )
                 integrand__ = _dot_(integrand_)
 
@@ -266,7 +278,7 @@ function _transform_expression(
                     dict_transformation_vars = dict_transformation_vars,
                     transformation_vars = transformation_vars,
                     param_estim = false,
-                    default_p = nothing
+                    default_p = nothing, coordinate_vars = inner_vars
                 )
                 # integrand = repr(integrand)
                 lb = toexpr.(lb)
@@ -282,7 +294,7 @@ function _transform_expression(
                             integrand = _dot_(l),
                             integrating_depvars = integrating_depvars,
                             param_estim = false,
-                            default_p = nothing
+                            default_p = nothing, coordinate_vars = inner_vars
                         )
                         l_f = @RuntimeGeneratedFunction(l_expr)
                         push!(lb_, l_f)
@@ -297,7 +309,7 @@ function _transform_expression(
                             integrand = _dot_(u_),
                             integrating_depvars = integrating_depvars,
                             param_estim = false,
-                            default_p = nothing
+                            default_p = nothing, coordinate_vars = inner_vars
                         )
                         u_f = @RuntimeGeneratedFunction(u_expr)
                         push!(ub_, u_f)
@@ -305,16 +317,18 @@ function _transform_expression(
                 end
 
                 integrand_func = @RuntimeGeneratedFunction(integrand)
+                integral_params = isempty(integrating_depvars) && pinnrep.eq_params isa SciMLBase.NullParameters ?
+                    SciMLBase.NullParameters() : :($θ)
                 ex.args = [
                     :($(Expr(:$, :integral))),
                     :u,
-                    Symbol(:cord, num_depvar[1]),
+                    coordinates,
                     :phi,
                     integrating_var_id,
                     integrand_func,
                     lb_,
                     ub_,
-                    :($θ),
+                    integral_params,
                 ]
                 break
             end
@@ -323,7 +337,7 @@ function _transform_expression(
                 pinnrep, ex.args[i];
                 is_integral = is_integral,
                 dict_transformation_vars = dict_transformation_vars,
-                transformation_vars = transformation_vars
+                transformation_vars = transformation_vars, coordinate_vars = coordinate_vars, scope_vars = scope_vars
             )
         end
     end
@@ -357,13 +371,13 @@ Parse ModelingToolkit equation form to the inner representation.
       [(derivative(phi1, u1, [x, y], [[ε,0]], 1, θ1) + 4 * derivative(phi2, u, [x, y], [[0,ε]], 1, θ2)) - 0,
        (derivative(phi2, u2, [x, y], [[ε,0]], 1, θ2) + 9 * derivative(phi1, u, [x, y], [[0,ε]], 1, θ1)) - 0]
 """
-function parse_equation(pinnrep::PINNRepresentation, eq)
+function parse_equation(pinnrep::PINNRepresentation, eq; scope_vars = pinnrep.indvars, coordinate_vars = nothing)
     eq_lhs = SymbolicUtils._iszero(expand_derivatives(eq.lhs)) ? eq.lhs :
         expand_derivatives(eq.lhs)
     eq_rhs = SymbolicUtils._iszero(expand_derivatives(eq.rhs)) ? eq.rhs :
         expand_derivatives(eq.rhs)
-    left_expr = transform_expression(pinnrep, toexpr(eq_lhs))
-    right_expr = transform_expression(pinnrep, toexpr(eq_rhs))
+    left_expr = transform_expression(pinnrep, toexpr(eq_lhs); scope_vars, coordinate_vars)
+    right_expr = transform_expression(pinnrep, toexpr(eq_rhs); scope_vars, coordinate_vars)
     left_expr = _dot_(left_expr)
     right_expr = _dot_(right_expr)
     return loss_func = :($left_expr .- $right_expr)
@@ -501,6 +515,32 @@ function get_argument(eqs, _indvars::Array, _depvars::Array)
 end
 function get_argument(eqs, dict_indvars, dict_depvars)
     exprs = toexpr.(eqs)
+    function replace_bound_arguments(ex, bound = Symbol[])
+        ex isa Expr || return ex
+        if ex.head == :call && first(ex.args) isa Symbolics.Integral
+            op = first(ex.args)
+            variables = integral_variables(op)
+            local_vars = filter(v -> !haskey(dict_indvars, v), variables)
+            isempty(local_vars) && return ex
+            lb, ub = get_limits(op.domain.domain)
+            return Expr(:call, :+, replace_bound_arguments(ex.args[2], vcat(bound, local_vars)), toexpr.(lb)..., toexpr.(ub)...)
+        end
+        if ex.head == :call && haskey(dict_depvars, first(ex.args))
+            args = filter(ex.args[2:end]) do arg
+                !any(v -> arg == v || (arg isa Expr && !isempty(find_thing_in_expr(arg, v))), bound)
+            end
+            length(args) == length(ex.args) - 1 && return ex
+            free_vars = filter(collect(keys(dict_indvars))) do v
+                any(ex.args[2:end]) do arg
+                    arg == v || (arg isa Expr && !isempty(find_thing_in_expr(arg, v)))
+                end
+            end
+            return Expr(:call, :+, Expr(:call, first(ex.args), args...), free_vars...)
+        end
+        return Expr(ex.head, map(arg -> replace_bound_arguments(arg, bound), ex.args)...)
+    end
+    original_exprs = exprs
+    exprs = replace_bound_arguments.(exprs)
     vars = map(exprs) do expr
         _vars = map(depvar -> find_thing_in_expr(expr, depvar), collect(keys(dict_depvars)))
         f_vars = filter(x -> !isempty(x), _vars)
@@ -520,6 +560,14 @@ function get_argument(eqs, dict_indvars, dict_depvars)
             else
                 true
             end
+        end
+    end
+    for (i, (original, expr)) in enumerate(zip(original_exprs, exprs))
+        if original != expr
+            args_[i] = [
+                v for (v, _) in sort!(collect(dict_indvars); by = last)
+                    if !isempty(find_thing_in_expr(expr, v))
+            ]
         end
     end
     return args_ # TODO for all arguments

--- a/src/transform_inf_integral.jl
+++ b/src/transform_inf_integral.jl
@@ -80,7 +80,7 @@ function transform_inf_integral(
         lb, ub, integrating_ex, integrating_depvars,
         dict_depvar_input, dict_depvars, integrating_variable,
         eltypeθ; dict_transformation_vars = nothing,
-        transformation_vars = nothing
+        transformation_vars = nothing, coordinate_vars = nothing
     )
     lb_ = Symbolics.tosymbol.(lb)
     ub_ = Symbolics.tosymbol.(ub)
@@ -121,10 +121,20 @@ function transform_inf_integral(
             end
         end
 
-        dict_transformation_vars, transformation_vars,
-            integrating_var_transformation = transform_inf_expr(
-            integrating_depvars, dict_depvar_input, dict_depvars, integrating_variable, transform_indvars
-        )
+        if coordinate_vars === nothing
+            dict_transformation_vars, transformation_vars,
+                integrating_var_transformation = transform_inf_expr(
+                integrating_depvars, dict_depvar_input, dict_depvars, integrating_variable, transform_indvars
+            )
+        else
+            integrating_var_transformation = [gensym(:τ) for _ in integrating_variable]
+            dict_transformation_vars = Dict(
+                v => transform_indvars(τ, i)
+                    for (i, (v, τ)) in enumerate(zip(integrating_variable, integrating_var_transformation))
+            )
+            replacements = Dict(zip(integrating_variable, integrating_var_transformation))
+            transformation_vars = [get(replacements, v, v) for v in coordinate_vars]
+        end
 
         ϵ = 1 / 20 #cbrt(eps(eltypeθ))
 

--- a/test/IntegroDiff/integral_bound_variables.jl
+++ b/test/IntegroDiff/integral_bound_variables.jl
@@ -1,0 +1,118 @@
+using ComponentArrays, DomainSets, Lux, ModelingToolkit, NeuralPDE, Random, SciMLBase,
+    Test, Zygote
+
+function linear_integral_parameters(chain)
+    params = ComponentArray{Float64}(Lux.initialparameters(Xoshiro(123), chain))
+    params.layer_1.weight .= 1
+    params.layer_1.bias .= 0
+    return params
+end
+
+@testset "Integral bound variables" begin
+    @parameters t tau
+    @variables x(..)
+    I = Integral(tau in ClosedInterval(0.0, t))
+    J = Integral(tau in ClosedInterval(t / 2, t))
+    F = Integral(tau in ClosedInterval(0.0, 1.0))
+    Dtau = Differential(tau)
+    chain = Chain(Dense(1, 1))
+    init_params = linear_integral_parameters(chain)
+    cord = reshape([0.2, 0.6, 0.9], 1, :)
+    cases = [
+        ("convolution", I((t - tau) * x(tau)), t^3 / 6, cord .^ 3 ./ 6),
+        ("distinct calls", I(x(tau) + x(t)), 3t^2 / 2, 3 .* cord .^ 2 ./ 2),
+        ("shifted argument", I((t - tau) * x(t - tau)), t^3 / 3, cord .^ 3 ./ 3),
+        ("fixed limits", F(x(tau)), 1 / 2, fill(1 / 2, size(cord))),
+        ("variable limits", J(x(tau)), 3t^2 / 8, 3 .* cord .^ 2 ./ 8),
+        ("derivative", I((t - tau) * Dtau(x(tau))), t^2 / 2, cord .^ 2 ./ 2),
+        ("no dependent variable", I(t - tau), t^2 / 2, zero(cord)),
+    ]
+    for strategy in (GridTraining(0.2), QuasiRandomTraining(5), QuadratureTraining())
+        for (name, integral, expected, weight_derivative) in cases
+            @testset "$(typeof(strategy)): $name" begin
+                discretization = PhysicsInformedNN(chain, strategy; init_params)
+                @named sys = PDESystem(
+                    [integral ~ expected], [x(0.0) ~ 0.0],
+                    [t ∈ Interval(0.0, 1.0)], [t], [x(t)]
+                )
+                rep = symbolic_discretize(sys, discretization)
+                θ = rep.flat_init_params
+                residual = only(rep.loss_functions.datafree_pde_loss_functions)
+                @test residual(cord, θ) ≈ zeros(1, 3) atol = 1.0e-8
+                @test rep.loss_functions.full_loss_function(θ, nothing) ≈ 0 atol = 1.0e-14
+                @test cord == reshape([0.2, 0.6, 0.9], 1, :)
+                gradient = only(Zygote.gradient(p -> sum(residual(cord, p)), θ))
+                if iszero(weight_derivative)
+                    @test gradient === nothing || iszero(gradient)
+                else
+                    @test gradient.layer_1.weight[1] ≈ sum(weight_derivative)
+                end
+            end
+        end
+    end
+end
+
+@testset "Multidimensional integration variables" begin
+    @parameters t tau sigma
+    @variables x(..)
+    I = Integral((tau, sigma) in ProductDomain(ClosedInterval(0.0, t), ClosedInterval(0.0, t)))
+    chain = Chain(Dense(1, 1))
+    init_params = linear_integral_parameters(chain)
+    discretization = PhysicsInformedNN(chain, GridTraining(0.2); init_params)
+    @named sys = PDESystem(
+        [I((t - tau) * (t - sigma) * x(tau)) ~ t^5 / 12], [x(0.0) ~ 0.0],
+        [t ∈ Interval(0.0, 1.0)], [t], [x(t)]
+    )
+    rep = symbolic_discretize(sys, discretization)
+    θ = rep.flat_init_params
+    cord = reshape([0.2, 0.6, 0.9], 1, :)
+    residual = only(rep.loss_functions.datafree_pde_loss_functions)
+    @test residual(cord, θ) ≈ zeros(1, 3) atol = 1.0e-8
+    gradient = only(Zygote.gradient(p -> sum(residual(cord, p)), θ))
+    @test gradient.layer_1.weight[1] ≈ sum(cord .^ 5) / 12
+end
+
+@testset "Integral over networks with different inputs" begin
+    @parameters t s tau
+    @variables x(..) y(..)
+    I = Integral(tau in ClosedInterval(0.0, t))
+    chains = [Chain(Dense(n, 1)) for n in (1, 2)]
+    init_params = linear_integral_parameters.(chains)
+    discretization = PhysicsInformedNN(chains, GridTraining(0.2); init_params)
+    @named sys = PDESystem(
+        [y(0.0, t) + I(x(tau) + y(s, tau)) ~ 0], [x(0.0) ~ 0.0, y(0.0, s) ~ s],
+        [t ∈ Interval(0.0, 1.0), s ∈ Interval(0.0, 1.0)], [t, s], [x(t), y(t, s)]
+    )
+    rep = symbolic_discretize(sys, discretization)
+    θ = rep.flat_init_params
+    cord = [0.2 0.6 0.9; 0.3 0.5 0.7]
+    residual = only(rep.loss_functions.datafree_pde_loss_functions)
+    @test residual(cord, θ) ≈ cord[[1], :] .* (cord[[2], :] .+ cord[[1], :] .+ 1)
+    grid = 0:0.2:1
+    @test rep.loss_functions.full_loss_function(θ, nothing) ≈
+        sum(abs2, [t * (s + t + 1) for t in grid, s in grid]) / length(grid)^2
+    gradient = only(Zygote.gradient(p -> sum(residual(cord, p)), θ))
+    @test gradient.depvar.x.layer_1.weight[1] ≈ sum(cord[1, :] .^ 2) / 2
+    @test vec(gradient.depvar.y.layer_1.weight) ≈ [sum(cord[1, :] .* cord[2, :]), sum(cord[1, :] .^ 2) / 2 + sum(cord[1, :])]
+end
+
+@testset "Free variables in shifted integrand arguments" begin
+    @parameters t tau
+    @variables x(..)
+    I = Integral(tau in ClosedInterval(0.0, 1.0))
+    chain = Chain(Dense(1, 1))
+    discretization = PhysicsInformedNN(chain, GridTraining(0.2); init_params = linear_integral_parameters(chain))
+    @named sys = PDESystem(
+        [I(x(t - tau)) ~ 0], [x(0.0) ~ 0.0],
+        [t ∈ Interval(0.0, 1.0)], [t], [x(t)]
+    )
+    rep = symbolic_discretize(sys, discretization)
+    θ = rep.flat_init_params
+    cord = reshape([0.2, 0.6, 0.9], 1, :)
+    residual = only(rep.loss_functions.datafree_pde_loss_functions)
+    @test rep.pde_indvars == [[:t]]
+    @test residual(cord, θ) ≈ cord .- 1 / 2
+    @test rep.loss_functions.full_loss_function(θ, nothing) ≈ sum(abs2, (0:0.2:1) .- 1 / 2) / 6
+    gradient = only(Zygote.gradient(p -> sum(residual(cord, p)), θ))
+    @test gradient.layer_1.weight[1] ≈ sum(cord .- 1 / 2)
+end


### PR DESCRIPTION
PINN integrals such as `Integral(tau in ClosedInterval(0, t))((t - tau) * x(tau))` previously failed with `KeyError: :tau` unless the integration variable was also a PDE input. This change gives bound variables their own quadrature coordinates, preserves the outer coordinates, and evaluates each network call at its written arguments.

The regression covers fixed and variable limits, derivatives, distinct and shifted calls, literal network coordinates, parameter-free integrands, tuple integration variables, and networks with different input dimensions. A runnable convolution tutorial shows a one-input network and a dummy variable that needs no separate PDE domain.

Verification:

- Clean master, Julia 1.10.11: the same regression fails in all 21 scalar cases with `KeyError: key :tau not found` at `src/symbolic_utilities.jl:221`.
- Patched regression: all 94 assertions pass on Julia 1.10.11 (fresh process) and Julia 1.12.7.

```text
# Before: ~/.juliaup/bin/julia +1.10 --project=baseline -e 'include("NeuralPDE.jl/test/IntegroDiff/integral_bound_variables.jl")'
KeyError: key :tau not found
Integral bound variables | Error 21 Total 21 Time 12.4s

# After: ~/.juliaup/bin/julia +1.10 --project=NeuralPDE.jl -e 'include("NeuralPDE.jl/test/IntegroDiff/integral_bound_variables.jl")'
Test Summary:            | Pass  Total     Time
Integral bound variables |   84     84  3m33.4s
Test Summary:                          | Pass  Total   Time
Multidimensional integration variables |    2      2  15.5s
Test Summary:                                | Pass  Total   Time
Integral over networks with different inputs |    4      4  22.7s
Test Summary:                                 | Pass  Total   Time
Free variables in shifted integrand arguments |    4      4  14.7s
```

- An additional regression caught literal coordinates incorrectly entering the training grid. Before the correction, its training-loss check failed with `0.0 ≈ 2.0288444444444442` (3 pass, 1 fail); afterward the same four checks pass.
- The new convolution documentation example runs successfully.
- Runic, typos, and `git diff --check` pass.

Standard QA command (Julia 1.10.11):

```sh
TMPDIR="$PWD/tmp" JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=QA ~/.juliaup/bin/julia +1.10 --project=NeuralPDE.jl -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Total      Time
QA/qa.jl      |   78     78  23m47.7s
     Testing NeuralPDE tests passed
```

Full integral group (Julia 1.10.11), 102 assertions:

```sh
TMPDIR="$PWD/tmp" JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=IntegroDiff ~/.juliaup/bin/julia +1.10 --project=NeuralPDE.jl -e 'using Pkg; Pkg.test()'
```

```text
IntegroDiff/ide__integrodiff_example_1_1d.jl |    1      1  12m33.2s
IntegroDiff/ide__integrodiff_example_2_1d.jl |    1      1  37.3s
IntegroDiff/ide__integrodiff_example_3_2_inputs_1_output.jl |    1      1  3m02.2s
IntegroDiff/ide__integrodiff_example_4_2_inputs_1_output.jl |    1      1  2m42.0s
IntegroDiff/ide__integrodiff_example_5_1_input_2_outputs.jl |    2      2  1m42.5s
IntegroDiff/ide__integrodiff_example_6_infinity.jl |    1      1  3m58.8s
IntegroDiff/ide__integrodiff_example_7_infinity.jl |    1      1  14m08.3s
IntegroDiff/integral_bound_variables.jl |   94     94  3m53.8s
     Testing NeuralPDE tests passed 
```

The full docs build (`~/.juliaup/bin/julia +1.10 --compiled-modules=no --project=docs docs/make.jl`, from the package directory) encounters the existing complex-ODE example failure (`DimensionMismatch: Batched RHS returned size (4,); expected (4, 500)`). It reproduces on clean master and is tracked separately. A reduced complex-ODE example passes on parent https://github.com/SciML/NeuralPDE.jl/commit/62ff9be858681e374ffa1b9cff037d50e7da3e97 and fails on introducing commit https://github.com/SciML/NeuralPDE.jl/commit/dd792519540cde8c3957612a0c5354116002da61. No test or documentation failure was suppressed. GPU was not tested locally; CUDA CI passed. Downstream NeuralLyapunov Core passed in CI; nested integral support is outside this change.

CI integral tests passed all 102 assertions on Julia LTS and Julia 1.11:

- LTS: https://github.com/SciML/NeuralPDE.jl/actions/runs/33965715096/job/101305886692
- Julia 1.11: https://github.com/SciML/NeuralPDE.jl/actions/runs/33965715096/job/101305886925

Both NNODE CI jobs report the complex-ODE batching errors. The unchanged official `nnode__ode_complex_numbers.jl` also fails on clean current master https://github.com/SciML/NeuralPDE.jl/commit/72a73eb36bef5b6b5904c56884feac3af3cfc1f0:

```sh
TMPDIR="$PWD/tmp" JULIA_LOAD_PATH='@:@stdlib' ~/.juliaup/bin/julia +1.10 --project=complex-parent/docs -e 'using InteractiveUtils; versioninfo(); include("complex-parent/test/NNODE/nnode__ode_complex_numbers.jl")'
```

```text
StochasticTraining:       actual (4,), expected (4, 500)
GridTraining:             actual (4,), expected (4, 201)
WeightedIntervalTraining: actual (4,), expected (4, 500)
ODE Complex Numbers | Pass 1 Error 3 Total 4 Time 11m34.6s
```

QA on Julia 1.12.7 reports 79 passes and one Aqua persistent-task failure (`done.log was not created, but precompilation exited`). The same failure appears in current master CI: https://github.com/SciML/NeuralPDE.jl/actions/runs/33961655581/job/101294527722. Local Julia 1.10 QA passed all 78 checks as recorded above; standard clean-master Julia 1.12.7 QA also passed all 80 checks:

```sh
TMPDIR="$PWD/tmp" JULIA_LOAD_PATH='@:@stdlib' GROUP=QA /home/crackauc/.julia/juliaup/julia-1.12.7+0.x64.linux.gnu/bin/julia --project=qa-baseline -e 'using Pkg; Pkg.test()'
```

```text
QA/qa.jl | Pass 80 Total 80 Time 10m30.2s
Testing NeuralPDE tests passed
```

This local run had coverage disabled, unlike CI. It did not reproduce the configuration-sensitive CI failure tracked in https://github.com/SciML/NeuralPDE.jl/issues/1109. Compiler recursion diagnostics also occurred during the passing run, so they do not establish the CI child-exit cause.

The LTS NNSDE1 CI job separately failed its unchanged statistical comparison with `81.60840892032256 > 83.1666041956832`. The corresponding master CI job and PR Julia 1.11 job passed. Two full clean-master local runs passed all 29 assertions: standard Julia 1.10.11, and Julia 1.10.12 using CI's coverage/bounds/deprecation settings. The latter used:

```sh
TMPDIR="$PWD/tmp" JULIA_LOAD_PATH='@:@stdlib' JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=NNSDE1 ~/.juliaup/bin/julia +1.10.12 --project=complex-parent -e 'import Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=yes", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
```

```text
NNSDE1/nn_sde__test_1_solve_autodiff.jl | 2 2 46m46.4s
NNSDE1/nn_sde__test_2_gbm_sde.jl | 11 11 16m36.5s
NNSDE1/nn_sde__test_3_additive_noise_test_equation.jl | 8 8 11m48.2s
NNSDE1/nn_sde__test_4_gbm_sde_inverse_weak_strong_solving.jl | 8 8 3m24.3s
Testing NeuralPDE tests passed
```

I could not reproduce or fix that CI statistical failure. No assertion or tolerance was changed. These runs do not establish that the failing CI result is benign or explain its cause.

Final CI status: 32 passed, four failed (both NNODE jobs, QA, and LTS NNSDE1), documentation skipped for the draft. Both integral jobs, CUDA, and downstream NeuralLyapunov Core passed. The PR remains a draft with the above CI failures unresolved.

- NNODE LTS: https://github.com/SciML/NeuralPDE.jl/actions/runs/33965715096/job/101305886469
- NNODE Julia 1.11: https://github.com/SciML/NeuralPDE.jl/actions/runs/33965715096/job/101305886472
- NNSDE1 LTS: https://github.com/SciML/NeuralPDE.jl/actions/runs/33965715096/job/101305886724
- Passing master NNSDE1 LTS: https://github.com/SciML/NeuralPDE.jl/actions/runs/33961655581/job/101294527705


Please ignore this draft until reviewed by @ChrisRackauckas.

Links:

- PR CI: https://github.com/SciML/NeuralPDE.jl/actions/runs/33965715096
- Master CI: https://github.com/SciML/NeuralPDE.jl/actions/runs/33961655581
- CUDA CI: https://github.com/SciML/NeuralPDE.jl/actions/runs/33965715096/job/101305886484
- Downstream CI: https://github.com/SciML/NeuralPDE.jl/actions/runs/33965715013/job/101305367944
- User report: https://discourse.julialang.org/t/how-to-use-a-convolution-integral-with-neuralpde-discretize/137997/9
- Existing NNODE regression: https://github.com/SciML/NeuralPDE.jl/issues/1143
- Existing QA investigation: https://github.com/SciML/NeuralPDE.jl/issues/1109
- Existing complex-example docs fix: https://github.com/SciML/NeuralPDE.jl/pull/1142

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session: 01a070f8-131f-77d0-ad5f-9311cdee051c; transcript: /home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T05-48-21-01a070f8-131f-77d0-ad5f-9311cdee051c.jsonl).
