### PR TITLE
fix: respect parameter precision in NNODE time differences

### DIFF
--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -222,6 +222,18 @@ end
 
 @inline (rhs::BatchedRHS)(u, p, t) = rhs.f(u, p, t)
 
+_explicit_batched_rhs(::Any) = nothing
+_explicit_batched_rhs(rhs::AbstractBatchedRHS) = rhs
+_explicit_batched_rhs(f::ODEFunction) = _explicit_batched_rhs(f.f)
+
+function _loss_rhs(f, ode_batch_eval, dev)
+    if ode_batch_eval
+        rhs = _explicit_batched_rhs(f)
+        rhs === nothing || return rhs
+    end
+    return dev isa CPUDevice ? f : BatchedRHS(f)
+end
+
 """
     inner_loss(phi, f, autodiff, t, θ, p, param_estim)
 
@@ -338,10 +350,12 @@ function generate_loss(
     ts = collect(tspan[1]:(strategy.dx):tspan[2])
     autodiff && throw(ArgumentError("autodiff not supported for GridTraining."))
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts)
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return function (θ, _)
+            dev = safe_get_device(θ)
+            ts_ = safe_expand(dev, ts)
+            rhs = _loss_rhs(f, ode_batch_eval, dev)
+            return inner_loss(phi, rhs, autodiff, ts_, θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end
@@ -359,10 +373,10 @@ function generate_loss(
         T = promote_type(eltype(tspan[1]), eltype(tspan[2]))
         ts = (tspan[2] - tspan[1]) .* rand(T, strategy.points) .+ tspan[1]
         if batch
-            dev = safe_get_device(phi)
+            dev = safe_get_device(θ)
             ts = safe_expand(dev, ts)
-            f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-            inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+            rhs = _loss_rhs(f, ode_batch_eval, dev)
+            inner_loss(phi, rhs, autodiff, ts, θ, p, param_estim)
         else
             sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
         end
@@ -387,10 +401,12 @@ function generate_loss(
     end
 
     if batch
-        dev = safe_get_device(phi)
-        ts = safe_expand(dev, ts)
-        f = ode_batch_eval || not(dev == cdev) ? BatchedRHS(f) : f  # forces vectorized computation on gpu
-        return (θ, _) -> inner_loss(phi, f, autodiff, ts, θ, p, param_estim)
+        return function (θ, _)
+            dev = safe_get_device(θ)
+            ts_ = safe_expand(dev, ts)
+            rhs = _loss_rhs(f, ode_batch_eval, dev)
+            return inner_loss(phi, rhs, autodiff, ts_, θ, p, param_estim)
+        end
     else
         return (θ, _) -> sum([inner_loss(phi, f, autodiff, t, θ, p, param_estim) for t in ts])
     end

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -210,7 +210,7 @@ function ode_dfdx(phi::ODEPhi, t, θ, autodiff::Bool)
         t isa Number && return ForwardDiff.derivative(Base.Fix2(phi, θ), t)
         return ForwardDiff.jacobian(Base.Fix2(phi, θ), t)
     end
-    ϵ = sqrt(eps(eltype(t)))
+    ϵ = sqrt(max(eps(eltype(t)), eps(real(eltype(θ)))))
     return (phi(t .+ ϵ, θ) .- phi(t, θ)) ./ ϵ
 end
 
@@ -255,7 +255,7 @@ function inner_loss(
     dxdtguess = if autodiff
         vec(ode_dfdx(phi, ts, θ, true))
     else
-        ϵ = sqrt(eps(eltype(ts)))
+        ϵ = sqrt(max(eps(eltype(ts)), eps(real(eltype(θ)))))
         vec((phi(dev, ts .+ ϵ, θ) .- out_matrix) ./ ϵ)
     end
 
@@ -283,7 +283,7 @@ function inner_loss(
     dxdtguess = if autodiff
         ode_dfdx(phi, ts, θ, true)
     else
-        ϵ = sqrt(eps(eltype(ts)))
+        ϵ = sqrt(max(eps(eltype(ts)), eps(real(eltype(θ)))))
         (phi(dev, ts .+ ϵ, θ) .- out) ./ ϵ
     end
 

--- a/test/NNODE/nnode__ode_batch_eval.jl
+++ b/test/NNODE/nnode__ode_batch_eval.jl
@@ -1,0 +1,47 @@
+using NeuralPDE, SciMLBase
+using ChainRulesCore: ignore_derivatives
+using Test
+
+@testset "ODE RHS batch evaluation" begin
+    using Lux, Optimisers, Random
+
+    Random.seed!(100)
+    batch_widths = Int[]
+    record_batch(x) = begin
+        ignore_derivatives() do
+            x isa AbstractMatrix && push!(batch_widths, size(x, 2))
+        end
+        return x
+    end
+    chain = Chain(WrappedFunction(record_batch), Dense(1, 4, tanh), Dense(4, 2))
+    strategy = StochasticTraining(4)
+
+    @test NNODE(chain, Adam(0.01); strategy).ode_batch_eval
+
+    @testset "ordinary pointwise RHS" begin
+        function pointwise_rhs(u::AbstractVector, p, t::Number)
+            x, y = u
+            return [y, -x]
+        end
+
+        prob = ODEProblem(pointwise_rhs, [1.0, 0.0], (0.0, 1.0))
+        sol = solve(
+            prob, NNODE(chain, Adam(0.01); strategy);
+            verbose = false, maxiters = 1, saveat = [0.5]
+        )
+        @test length(sol(0.5)) == 2
+    end
+    @test strategy.points in batch_widths
+
+    @testset "internal batched RHS" begin
+        batched_rhs(u::AbstractVector, p, t::Number) = error("pointwise evaluation used")
+        batched_rhs(u::AbstractMatrix, p, t::AbstractVector) = vcat(u[2:2, :], -u[1:1, :])
+
+        prob = ODEProblem(NeuralPDE.BatchedRHS(batched_rhs), [1.0, 0.0], (0.0, 1.0))
+        sol = solve(
+            prob, NNODE(chain, Adam(0.01); strategy);
+            verbose = false, maxiters = 1, saveat = [0.5]
+        )
+        @test length(sol(0.5)) == 2
+    end
+end

--- a/test/NNODE/time_derivative_precision.jl
+++ b/test/NNODE/time_derivative_precision.jl
@@ -1,0 +1,21 @@
+using NeuralPDE, Lux, ComponentArrays, Random, Zygote, Test
+
+@testset "NNODE finite time derivative parameter gradients" begin
+    for T in (Float32, Float64), S in (Float32, Float64), scalar in (true, false)
+        chain = Chain(Dense(1, 1))
+        _, st = Lux.setup(Random.default_rng(), chain)
+        theta = ComponentArray(;
+            depvar = (; layer_1 = (; weight = zeros(T, 1, 1), bias = ones(T, 1)))
+        )
+        phi = NeuralPDE.ODEPhi(chain, zero(S), scalar ? zero(S) : zeros(S, 1), st)
+        for time in (S(0.4), S[0.4])
+            loss = p -> sum(abs2, NeuralPDE.ode_dfdx(phi, time, p, false))
+            gradient = only(Zygote.gradient(loss, theta))
+            @test gradient.depvar.layer_1.bias ≈ T[2] rtol = 1.0e-3
+        end
+        rhs = NeuralPDE.BatchedRHS((u, p, t) -> zero(u))
+        loss = p -> NeuralPDE.inner_loss(phi, rhs, false, S[0.4], p, nothing, false)
+        gradient = only(Zygote.gradient(loss, theta))
+        @test gradient.depvar.layer_1.bias ≈ T[2] rtol = 1.0e-3
+    end
+end


### PR DESCRIPTION
Float32 network parameters evaluated at Float64 times can produce a zero parameter gradient through NNODE's finite time derivative: the time-only step is too small for the network's parameter precision. Select the step from the larger of the time and real parameter epsilons at all three numerical derivative sites. The regression covers scalar/vector states, scalar/vector times, and explicit batched RHS losses across all Float32/Float64 combinations.

Depends on https://github.com/SciML/NeuralPDE.jl/pull/1144 (tested prerequisite commit https://github.com/SciML/NeuralPDE.jl/commit/3b712620db8562930410184dacabaa9476e0a40a). The precision change itself is three source lines plus one 24-assertion regression file. Please ignore this draft until reviewed by @ChrisRackauckas.

The prerequisite branch lives in the fork, so this upstream draft initially includes its commit in the comparison against master. The precision change is isolated in https://github.com/ChrisRackauckas-Claude/NeuralPDE.jl/commit/a51b3a4713f0b17f80e611cad54b3a62ee1571a2; this branch should be rebased onto master after the prerequisite merges. It does not replace or combine the two fixes into one commit.

Verification used Julia 1.11.9. Exact same regression, against the unmodified prerequisite source:

```bash
cd NeuralPDE-batched-rhs-qa-clean
TMPDIR="$PWD/.validation/tmp" timeout 7200 /home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no --project=. ../NeuralPDE-nnode-time-stacked/test/NNODE/time_derivative_precision.jl > .validation/precision-before.log 2>&1
```

```text
Test Summary:                                    | Pass  Fail  Total     Time
NNODE finite time derivative parameter gradients |   18     6     24  1m31.6s
```

All six failures are Float32-parameter/Float64-time cases: the observed bias gradient is zero instead of the analytic value 2. With the fix applied, using the same assertions and unchanged `rtol=1e-3`:

```bash
cd NeuralPDE-nnode-time-stacked
TMPDIR="$PWD/.validation/tmp" timeout 7200 /home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no --project=. test/NNODE/time_derivative_precision.jl > .validation/precision-after.log 2>&1
```

```text
Test Summary:                                    | Pass  Total     Time
NNODE finite time derivative parameter gradients |   24     24  1m31.1s
```

Native full NNODE and QA commands (both exited 0):

```bash
TMPDIR="$PWD/.validation/tmp" JULIA_NUM_PRECOMPILE_TASKS=1 GROUP=NNODE timeout 14400 /home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no --heap-size-hint=8G --project=. -e 'using Pkg; Pkg.test(; julia_args=["--heap-size-hint=8G"])' > .validation/nnode-official.log 2>&1
TMPDIR="$PWD/.validation/tmp" JULIA_NUM_PRECOMPILE_TASKS=1 GROUP=QA timeout 14400 /home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no --heap-size-hint=8G --project=. -e 'using Pkg; Pkg.test(; julia_args=["--heap-size-hint=8G"])' > .validation/qa-official.log 2>&1
```

Full NNODE passed 77 assertions across all 16 files, including complex numbers (4/4), the batching regression (4/4), and the precision regression (24/24). Terminal tails:

```text
Test Summary:                      | Pass  Total   Time
NNODE/time_derivative_precision.jl |   24     24  56.1s
     Testing NeuralPDE tests passed

Test Summary: | Pass  Total     Time
QA/qa.jl      |   80     80  5m46.1s
     Testing NeuralPDE tests passed
```

Formatting and spelling checks exited 0:

```bash
TMPDIR="$PWD/.validation/tmp" /home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no --project=../corleone-runic-env -e 'using Runic; exit(Runic.main(["--check", "src/ode_solve.jl", "test/NNODE/time_derivative_precision.jl"]))'
typos src/ode_solve.jl test/NNODE/time_derivative_precision.jl
git diff --check
```

Not verified: GPU execution, other Julia versions, downstream packages, or test groups outside NNODE/QA. No docs build was run: this change adds no public name, docstring, or documentation changes. No dependencies, test tolerances, skips, or warning-only settings changed.

## Links

- Batching prerequisite: https://github.com/SciML/NeuralPDE.jl/pull/1144
- Tested prerequisite commit: https://github.com/SciML/NeuralPDE.jl/commit/3b712620db8562930410184dacabaa9476e0a40a
- Precision-only commit: https://github.com/ChrisRackauckas-Claude/NeuralPDE.jl/commit/a51b3a4713f0b17f80e611cad54b3a62ee1571a2

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session ID: 01a0598f-11b9-72d1-91d9-b2fbb186557d).
