### PR TITLE
Use exact GBM reference moments in NNSDE batch tests

### DIFF
--- a/test/NNSDE1/gbm_reference_moments.jl
+++ b/test/NNSDE1/gbm_reference_moments.jl
@@ -1,0 +1,12 @@
+using Test, Distributions, Statistics
+
+include("../helpers/gbm_reference.jl")
+
+@testset "GBM independent-reference squared errors" begin
+    u0, alpha, beta = 0.5, 1.2, 1.1
+    for t in (0.0, 0.02, 0.4, 1.0), prediction in (-2.0, 0.0, 0.5, 3.0), n in (1, 2, 2000)
+        reference = LogNormal(log(u0) + (alpha - beta^2 / 2) * t, beta * sqrt(t))
+        expected = var(reference) / n + abs2(mean(reference) - prediction)
+        @test gbm_reference_squared_error(u0, alpha, beta, t, prediction, n) ≈ expected
+    end
+end

--- a/test/NNSDE1/nn_sde__test_2_gbm_sde.jl
+++ b/test/NNSDE1/nn_sde__test_2_gbm_sde.jl
@@ -1,8 +1,10 @@
 using ModelingToolkit, NeuralPDE, SciMLBase
 using Test
 
+include("../helpers/gbm_reference.jl")
+
 @testset "Test-2 GBM SDE" begin
-    using OrdinaryDiffEq, Random, Lux, Optimisers, DiffEqNoiseProcess, Distributions
+    using OrdinaryDiffEq, Random, Lux, Optimisers, Distributions
     using MonteCarloMeasurements: Particles, pmean
     Random.seed!(100)
 
@@ -43,7 +45,6 @@ using Test
     u1 = sol_1.estimated_sol[1]
     u2 = sol_2.estimated_sol[1]
 
-    analytic_sol(u0, p, t, W) = u0 * exp((α - β^2 / 2) * t + β * W)
     function W_kkl(t, z1, z2, z3)
         √2 * (
             z1 * sin((1 - 1 / 2) * π * t) / ((1 - 1 / 2) * π) +
@@ -63,13 +64,6 @@ using Test
     z3_samples = rand(Normal(0, 1), num_samples)
 
     num_time_steps = length(ts)
-    W_samples = Array{Float64}(undef, num_time_steps, num_samples)
-    for i in 1:num_samples
-        W = WienerProcess(0.0, 0.0)
-        probtemp = NoiseProblem(W, (0.0, 1.0))
-        Np_sol = solve(probtemp; dt = dt)
-        W_samples[:, i] = Np_sol.u
-    end
 
     temp_rands = hcat(z1_samples, z2_samples, z3_samples)'
     phi_inputs = [
@@ -77,7 +71,6 @@ using Test
             for i in 1:num_samples
     ]
 
-    analytic_solution_samples = Array{Float64}(undef, num_time_steps, num_samples)
     truncated_solution_samples = Array{Float64}(undef, num_time_steps, num_samples)
     predicted_solution_samples_1 = Array{Float64}(undef, num_time_steps, num_samples)
     predicted_solution_samples_2 = Array{Float64}(undef, num_time_steps, num_samples)
@@ -85,8 +78,6 @@ using Test
     for j in 1:num_samples
         for i in 1:num_time_steps
             # for each sample, pass each timepoints and get output
-            analytic_solution_samples[i, j] = analytic_sol(u₀, 0, ts[i], W_samples[i, j])
-
             predicted_solution_samples_1[i, j] = sol_1.rode_solution.interp.phi(
                 phi_inputs[j][:, i], sol_1.rode_solution.interp.θ
             )
@@ -101,10 +92,6 @@ using Test
     end
 
     # strong ensemble solution tests
-    strong_analytic_solution = [
-        Particles(analytic_solution_samples[i, :])
-            for i in eachindex(ts)
-    ]
     strong_truncated_solution = [
         Particles(truncated_solution_samples[i, :])
             for i in eachindex(ts)
@@ -118,35 +105,38 @@ using Test
             for i in eachindex(ts)
     ]
 
-    error_1 = sum(abs2, strong_analytic_solution .- strong_predicted_solution_1)
-    error_2 = sum(abs2, strong_analytic_solution .- strong_predicted_solution_2)
+    error_1 = sum(gbm_reference_squared_error.(u₀, α, β, ts, strong_predicted_solution_1))
+    error_2 = sum(gbm_reference_squared_error.(u₀, α, β, ts, strong_predicted_solution_2))
     @test pmean(error_1) > pmean(error_2) - 10.0
 
     @test pmean(sum(abs2.(strong_predicted_solution_1 .- strong_truncated_solution))) + 10.0 >
         pmean(sum(abs2.(strong_predicted_solution_2 .- strong_truncated_solution)))
 
     # weak ensemble solution tests
-    mean_analytic_solution = mean(analytic_solution_samples, dims = 2)
+    # Retain the variance of the original finite reference ensemble's sample mean.
+    weak_reference_error(prediction) = gbm_reference_squared_error.(
+        u₀, α, β, reshape(ts, :, 1), prediction, num_samples
+    )
     mean_truncated_solution = mean(truncated_solution_samples, dims = 2)
     mean_predicted_solution_1 = mean(predicted_solution_samples_1, dims = 2)
     mean_predicted_solution_2 = mean(predicted_solution_samples_2, dims = 2)
 
     # testing over different Z_i sample sizes
-    error_1 = sum(abs2, mean_analytic_solution .- pmean(u1))
-    error_2 = sum(abs2, mean_analytic_solution .- pmean(u2))
+    error_1 = sum(weak_reference_error(pmean(u1)))
+    error_2 = sum(weak_reference_error(pmean(u2)))
     @test error_1 > error_2 - 4.0
 
-    MSE_1 = mean(abs2.(mean_analytic_solution .- pmean(u1)))
-    MSE_2 = mean(abs2.(mean_analytic_solution .- pmean(u2)))
+    MSE_1 = mean(weak_reference_error(pmean(u1)))
+    MSE_2 = mean(weak_reference_error(pmean(u2)))
     @test MSE_2 < MSE_1 + 0.1
     @test MSE_2 < 2.0e-1
 
-    error_1 = sum(abs2, mean_analytic_solution .- mean_predicted_solution_1)
-    error_2 = sum(abs2, mean_analytic_solution .- mean_predicted_solution_2)
+    error_1 = sum(weak_reference_error(mean_predicted_solution_1))
+    error_2 = sum(weak_reference_error(mean_predicted_solution_2))
     @test error_1 > error_2 - 4.0
 
-    MSE_1 = mean(abs2.(mean_analytic_solution .- mean_predicted_solution_1))
-    MSE_2 = mean(abs2.(mean_analytic_solution .- mean_predicted_solution_2))
+    MSE_1 = mean(weak_reference_error(mean_predicted_solution_1))
+    MSE_2 = mean(weak_reference_error(mean_predicted_solution_2))
     @test MSE_2 < MSE_1 + 0.1
     @test MSE_2 < 2.0e-1
 

--- a/test/helpers/gbm_reference.jl
+++ b/test/helpers/gbm_reference.jl
@@ -1,0 +1,5 @@
+function gbm_reference_squared_error(u0, alpha, beta, t, prediction, num_samples = 1)
+    reference_mean = u0 * exp(alpha * t)
+    reference_variance = u0^2 * exp(2alpha * t) * expm1(beta^2 * t)
+    return reference_variance / num_samples + abs2(reference_mean - prediction)
+end


### PR DESCRIPTION
## Change

Replace independently sampled GBM reference paths in the batch-comparison test with their conditional expected squared errors. Every existing assertion and threshold is unchanged. This is test-only; solver behavior, optimizers, iteration budgets and trained prediction samples are unchanged.

For an independent GBM reference X at time t, its mean is μ=u₀ exp(αt) and variance is v=u₀² exp(2αt) expm1(β²t). The expected squared error against a fixed prediction P is v+(μ−P)². The original weak reference is a mean of n=2000 independent paths, so its expected squared error is v/n+(μ−Q)². The implementation retains v/n in both relative comparisons and absolute MSE bounds; it does not substitute an easier population-mean error. Time correlations do not enter the sum of squared errors.

## Discriminating evidence

The original reference sampler was replayed without retraining against one fixed precision-corrected checkpoint over 20 predefined reference-noise panels, with path seeds 2000*(panel−1)+i. Prediction-byte equality is asserted across panels. All 11 original assertions run in each panel, plus one prediction-hash assertion:

```text
Original sampled reference: 221 passed, 19 failed, 240 total
Exact expected reference:  240 passed, 0 failed, 240 total
```

Five failures were the first summed-error ordering; its sampled margin ranged −1.74287 to 7.27901 despite identical predictions. Its exact expected margin is +1.1829785593498343. The remaining 14 failures were weak relative-error comparisons. No thresholds were changed. The separately captured clean-main checkpoint passed 240/240 with both references; this is not a claim that a single passing stochastic run proves stability.

Precision checkpoint SHA256: 15412fbc1b600a5cec092690aa2315489c2ca027ce693a1ad707034244902911. Prediction SHA256: ae218c131b7c8a72ea2da176bf6d74c8cc200103015f75898e1fee702b61c227. The underlying mixed-precision derivative correction is separate from this test-only change.

## Verification

Maintainer-access reproduction bundle with synthetic checkpoints, pinned environment, replay scripts and actual logs: https://github.com/ChrisRackauckas/InternalJunk/pull/97. All four 20-panel replays were rerun from that packaged environment and reproduced the counts above.

- New official 48-case test compares the helper against Distributions.LogNormal mean/variance, including time zero, negative/central/tail predictions and n=1,2,2000: 48/48 passed.
- Independent no-SciML numerical integration of the lognormal moments and squared errors: 72/72 passed.
- Independent Monte Carlo: 100000 reference means of size 2000 at times 0, 0.2, 1 and zero/mean/four-sigma-tail predictions, fixed Xoshiro(1234): 9/9 predefined 6-standard-error checks passed; largest absolute z score 1.029.
- Edited official fixture replay on the identical saved precision checkpoint: 12/12 passed (11 existing assertions plus prediction hash).
- Runic, typos and git diff --check passed.
- `GROUP=NNSDE1 julia +1.11 --startup-file=no --project -e 'using Pkg; Pkg.test()'`: oracle-only **77/77 passed**, exit 0 (48 moment checks + 29 existing checks).
- `GROUP=QA julia +1.11 --startup-file=no --project -e 'using Pkg; Pkg.test()'`: oracle-only **80/80 passed**, exit 0.
- The separately validated prospective oracle+precision stack also passed native NNSDE1 **81/81** and QA **80/80**, both exit 0. This is additional evidence, not a combined source change in this PR.

GPU, prerelease and downstream groups were not run. No docs or public API changes.

Please ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: unknown); local session 01a070d3-c5e0-7593-b73b-83c0b64b334d, agent /root/mtk_bipartite_resume. No shareable conversation URL is exposed.
