### PR TITLE
Preserve NNSDE parameter gradients across mixed time precision

### DIFF
--- a/src/NN_SDE_solve.jl
+++ b/src/NN_SDE_solve.jl
@@ -235,7 +235,7 @@ function ∂u_∂t(
     autodiff &&
         return ForwardDiff.jacobian(t -> phi(vcat(t, inputs[2:end, :]), θ), inputs[1, :])
 
-    ϵ = sqrt(eps(eltype(inputs)))
+    ϵ = sqrt(max(eps(eltype(inputs)), eps(real(eltype(θ)))))
     return (phi(vcat(inputs[1, :]' .+ ϵ, inputs[2:end, :]), θ) .- phi(inputs, θ)) ./ ϵ
 end
 

--- a/test/NNSDE1/time_derivative_precision.jl
+++ b/test/NNSDE1/time_derivative_precision.jl
@@ -1,0 +1,14 @@
+using NeuralPDE, Lux, LuxCore, ComponentArrays, StableRNGs, Zygote, Test
+
+@testset "NNSDE finite time derivative preserves parameter gradients" begin
+    for T in (Float32, Float64), S in (Float32, Float64)
+        chain = Chain(Dense(2, 1))
+        st = LuxCore.initialstates(StableRNG(0), chain)
+        theta = ComponentArray(; depvar = (; layer_1 = (; weight = zeros(T, 1, 2), bias = ones(T, 1))))
+        phi = NeuralPDE.SDEPhi(chain, zero(S), zero(S), st)
+        inputs = reshape(S[0.4, 0], 2, 1)
+        loss(p) = sum(abs2, NeuralPDE.∂u_∂t(inputs, (phi, p, false)))
+        gradient = only(Zygote.gradient(loss, theta))
+        @test gradient.depvar.layer_1.bias ≈ T[2] rtol = 1.0e-3
+    end
+end


### PR DESCRIPTION
## Change

Choose the NNSDE finite time-difference step using both input and parameter precision. With `Float64` inputs and `Float32` neural parameters, the former `Float64`-sized step makes the `Float32` reverse-mode parameter-gradient contributions cancel: a linear model's squared-derivative loss has gradient 0 instead of 2.

This changes one internal step-size expression and adds a four-case regression. It does not change the stochastic interpretation, drift, optimizer, iteration budget, assertions, or tolerances.

## Dependency and review scope

The explicit-RNG and StableRNG prerequisite has merged as https://github.com/SciML/NeuralPDE.jl/pull/1159. This draft is now narrowed to one precision-only commit on current master: https://github.com/ChrisRackauckas-Claude/NeuralPDE.jl/commit/8bf8c35be3cbfa9d20367acc846c49ba8b404816.

`StableRNGs` remains test-only and is MIT licensed. The precision fixture uses `StableRNG(0)` for Lux state initialization and does not depend on the Julia default RNG.

## Failing before / passing after

The exact same official `test/NNSDE1/time_derivative_precision.jl` was run against unfixed source and fixed source in isolated environments:

```text
Before: 3 passed, 1 failed, 4 total (exit 1)
Expression: gradient.depvar.layer_1.bias ≈ T[2]
Evaluated: Float32[0.0] ≈ Float32[2.0] (rtol=0.001)

After: 4 passed, 4 total (exit 0)
```

The four cases cross `Float32`/`Float64` inputs with `Float32`/`Float64` parameters. A separate no-SciML Zygote linear-model control also produced gradient 0 before and 2 after. A ForwardDiff compatibility control passed 4/4.

## Native verification

The following ran on exact head `8bf8c35be3cbfa9d20367acc846c49ba8b404816`, based on current master `b13e4b03b6f138ce2601ddff8701d26a98b0bf5e`:

```text
GROUP=NNSDE1 timeout 7200 ~/.juliaup/bin/julia +1.11 --project -e 'using Pkg; Pkg.test()'
48 reference moments + 4 explicit RNG + 2 autodiff + 11 GBM + 8 additive + 9 inverse + 4 precision = 86 passed
Testing NeuralPDE tests passed (exit 0)

GROUP=QA timeout 7200 ~/.juliaup/bin/julia +1.12 --project -e 'using Pkg; Pkg.test()'
QA/qa.jl | 80 passed, 80 total | 5m44.7s
Testing NeuralPDE tests passed (exit 0)

~/.juliaup/bin/julia +1.12 --project=~/.julia/environments/runic -m Runic --check <changed files>
exit 0

typos <changed files>
exit 0

git diff --check origin/master...HEAD
exit 0
```

An earlier precision tree passed the full docs build in 5h05m42s. I did not rerun that build after narrowing: this commit changes neither docs nor public API. GPU, prerelease, and downstream groups were not run locally.

The separate historical BFGS fixture still has an Itô-equation mismatch; this precision correction does not claim to solve it. That investigation is tracked at https://github.com/SciML/NeuralPDE.jl/issues/1148.

Please ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: unknown); local session ID 01a0501c-815c-7cf1-93c4-ddb4fab68924. No shareable conversation URL is exposed.
