### PR TITLE
Release NeuralPDE 6.3.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralPDE"
 uuid = "315f7962-48a3-4962-8226-d0f33b1235f0"
-version = "6.3.0"
+version = "6.3.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `NeuralPDE` 6.3.0 -> 6.3.1 (patch).

Source files changed since 6.3.0:
- `src/ode_solve.jl`
- `src/training_strategies.jl`

Commits:
- Handle empty QuadratureTraining prototype batches (#1141)
- fix: preserve standard NNODE RHS evaluation (#1139)
- Use exact GBM reference moments in NNSDE batch tests (#1151)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
