### PR TITLE
Add 32-bit Interface CI lane via test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -4,6 +4,12 @@ versions = ["lts", "1"]
 [Interface]
 versions = ["1.11", "lts"]
 
+["Interface 32-bit"]
+group = "Interface"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
 [ODEBPINN]
 versions = ["1.11", "lts"]
 


### PR DESCRIPTION

## Summary
- Add a `["Interface 32-bit"]` matrix-only alias (`group = "Interface"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- No `[Core]` group in this matrix; alias targets the primary `Interface` lane.

## Test plan
- [ ] CI shows a job with `, x86)` for this group
- [ ] Job green, or failure is a real Int32/WordSize bug to fix
