### PR TITLE
test: stabilize the SDEPINN OU initialization

### DIFF
--- a/test/NNSDE2/nn_sde_weaksolve__ou_process.jl
+++ b/test/NNSDE2/nn_sde_weaksolve__ou_process.jl
@@ -3,9 +3,8 @@ using Test
 
 @testset "OU process" begin
     using ModelingToolkit, NeuralPDE, SciMLBase, Lux, Optimization, OptimizationOptimJL, Optimisers
-    using OrdinaryDiffEq, Random, Distributions, Integrals, Cubature
+    using OrdinaryDiffEq, Distributions, Integrals, Cubature, StableRNGs
     using OptimizationOptimJL: BFGS
-    Random.seed!(100)
 
     α = -1
     β = 1
@@ -25,6 +24,7 @@ using Test
             inn, 1, Lux.logcosh
         )
     ) |> f64
+    initial_parameters = Lux.initialparameters(StableRNG(100), chain)
 
     # problem setting
     dx = 0.02
@@ -36,6 +36,7 @@ using Test
         chain = chain,
         optimalg = BFGS(),
         norm_loss_alg = HCubatureJL(),
+        initial_parameters = initial_parameters,
         x_0 = x_0,
         x_end = x_end,
         distrib = Normal(u0, σ_var_bc)


### PR DESCRIPTION
## Change

Initialize the SDEPINN OU test network with `StableRNG(100)` and pass those parameters through the existing public `initial_parameters` keyword. This removes the fixture's dependence on Julia's default RNG implementation without changing the solver, optimizer, 300-iteration budget, or `1e-2` MSE assertion.

`StableRNGs.jl` remains an existing test-only dependency and is MIT licensed.

## Failing before / passing after

The unmodified current-master test failed in the Julia 1.11 `NNSDE2` job:

```text
Expression: mean(vcat([abs2.(diff_i) for diff_i = diff]...)) < 0.01
Evaluated: 0.01532684215167825 < 0.01
```

Failure: https://github.com/SciML/NeuralPDE.jl/actions/runs/34686342804/job/103536837688

The same unmodified test has passed locally, so the hosted stochastic failure is not reliably reproducible on this machine. The fixed current-master tree passed the complete local `NNSDE2` group with the source and assertion unchanged:

```text
NNSDE2/nn_sde_weaksolve__gbm_sde.jl | 1 passed | 5m19.7s
NNSDE2/nn_sde_weaksolve__ou_process.jl | 1 passed | 4m05.5s
Testing NeuralPDE tests passed
```

The earlier hosted run of this StableRNG fixture also passed both Julia 1.11 and LTS `NNSDE2` lanes. The newly rebased branch has fresh CI pending.

## Native verification

The following ran on exact head `c40dbad7408f8935ccf18a67bcea4eaaa78d5cd6`, based on current master `76f6d4984b87faddcc3b982fe8c5443ab251af0d`:

```text
GROUP=NNSDE2 timeout 7200 ~/.juliaup/bin/julia +1.11 --project -e 'using Pkg; Pkg.test()'
2 passed, 2 total
Testing NeuralPDE tests passed

GROUP=QA timeout 7200 ~/.juliaup/bin/julia +1.12 --project -e 'using Pkg; Pkg.test()'
QA/qa.jl | 80 passed, 80 total | 5m01.5s
Testing NeuralPDE tests passed

Runic check: exit 0
typos on the changed file: exit 0
git diff --check origin/master...HEAD: exit 0
```

CUDA, prerelease, and downstream groups were not run locally. This changes one CPU test fixture only; it adds no public API or documentation.

Please ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: unknown); local session ID 01a0501c-815c-7cf1-93c4-ddb4fab68924. No shareable conversation URL is exposed.
