### PR TITLE
Respect parameter precision in NNODE time differences on current master

### DIFF
--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -213,7 +213,7 @@ function ode_dfdx(phi::ODEPhi, t, θ, autodiff::Bool)
         t isa Number && return ForwardDiff.derivative(Base.Fix2(phi, θ), t)
         return ForwardDiff.jacobian(Base.Fix2(phi, θ), t)
     end
-    ϵ = sqrt(eps(eltype(t)))
+    ϵ = sqrt(max(eps(eltype(t)), eps(real(eltype(θ)))))
     return (phi(t .+ ϵ, θ) .- phi(t, θ)) ./ ϵ
 end
 
@@ -246,7 +246,7 @@ function inner_loss(
     dxdtguess = if autodiff
         vec(ode_dfdx(phi, ts, θ, true))
     else
-        ϵ = sqrt(eps(eltype(ts)))
+        ϵ = sqrt(max(eps(eltype(ts)), eps(real(eltype(θ)))))
         vec((phi(dev, ts .+ ϵ, θ) .- out_matrix) ./ ϵ)
     end
 
@@ -274,7 +274,7 @@ function inner_loss(
     dxdtguess = if autodiff
         ode_dfdx(phi, ts, θ, true)
     else
-        ϵ = sqrt(eps(eltype(ts)))
+        ϵ = sqrt(max(eps(eltype(ts)), eps(real(eltype(θ)))))
         (phi(dev, ts .+ ϵ, θ) .- out) ./ ϵ
     end
 

--- a/test/NNODE/time_derivative_precision.jl
+++ b/test/NNODE/time_derivative_precision.jl
@@ -1,0 +1,21 @@
+using NeuralPDE, Lux, ComponentArrays, Random, Zygote, Test
+
+@testset "NNODE finite time derivative parameter gradients" begin
+    for T in (Float32, Float64), S in (Float32, Float64), scalar in (true, false)
+        chain = Chain(Dense(1, 1))
+        _, st = Lux.setup(Random.default_rng(), chain)
+        theta = ComponentArray(;
+            depvar = (; layer_1 = (; weight = zeros(T, 1, 1), bias = ones(T, 1)))
+        )
+        phi = NeuralPDE.ODEPhi(chain, zero(S), scalar ? zero(S) : zeros(S, 1), st)
+        for time in (S(0.4), S[0.4])
+            loss = p -> sum(abs2, NeuralPDE.ode_dfdx(phi, time, p, false))
+            gradient = only(Zygote.gradient(loss, theta))
+            @test gradient.depvar.layer_1.bias ≈ T[2] rtol = 1.0e-3
+        end
+        rhs = NeuralPDE.BatchedRHS((u, p, t) -> zero(u))
+        loss = p -> NeuralPDE.inner_loss(phi, rhs, false, S[0.4], p, nothing, false)
+        gradient = only(Zygote.gradient(loss, theta))
+        @test gradient.depvar.layer_1.bias ≈ T[2] rtol = 1.0e-3
+    end
+end

--- a/test/NNODE/time_derivative_precision.jl
+++ b/test/NNODE/time_derivative_precision.jl
@@ -1,9 +1,9 @@
-using NeuralPDE, Lux, ComponentArrays, Random, Zygote, Test
+using NeuralPDE, Lux, ComponentArrays, StableRNGs, Zygote, Test
 
 @testset "NNODE finite time derivative parameter gradients" begin
     for T in (Float32, Float64), S in (Float32, Float64), scalar in (true, false)
         chain = Chain(Dense(1, 1))
-        _, st = Lux.setup(Random.default_rng(), chain)
+        _, st = Lux.setup(StableRNG(0), chain)
         theta = ComponentArray(;
             depvar = (; layer_1 = (; weight = zeros(T, 1, 1), bias = ones(T, 1)))
         )


### PR DESCRIPTION
## Change

Choose NNODE's finite-difference time step using both time and parameter precision. With `Float32` parameters and `Float64` times, the former `Float64`-sized step makes reverse-mode parameter-gradient contributions cancel to zero; a linear model's squared-derivative loss has gradient 0 instead of 2.

This changes three internal epsilon calculations and adds a 24-assertion, four-case regression crossing `Float32`/`Float64` times with `Float32`/`Float64` parameters. The fixture uses `StableRNG(0)` for Lux state initialization. It does not change batching defaults, training budgets, assertions, or tolerances.

## Failing before / passing after

The exact same `test/NNODE/time_derivative_precision.jl` was run against current-master source and fixed source:

```text
Before: 18 passed, 6 failed, 24 total (exit 1)
Expression: gradient.depvar.layer_1.bias ≈ T[2] (rtol=0.001)
Evaluated: Float32[0.0] ≈ Float32[2.0] (rtol=0.001)

After: 24 passed, 24 total (exit 0)
```

The failures cover each reverse-mode `Float32`-parameter case. No-SciML linear-model controls and the complete NNODE group confirm that using the coarser of time and parameter precision restores the intended derivative without weakening the regression.

## Native verification

The full NNODE and QA groups ran from clean detached worktrees at exact head `ffeecf2a7e48bc7514bfe08396d90ad42aeef628`, based on current master `beb5efa0802431b63ff603e53780df014f23fb86`:

```text
GROUP=NNODE timeout 7200 ~/.juliaup/bin/julia +1.11 --project -e 'using Pkg; Pkg.test()'
73 passed, 73 total, including 24/24 precision assertions
Testing NeuralPDE tests passed (exit 0)

GROUP=QA timeout 7200 ~/.juliaup/bin/julia +1.12 --project -e 'using Pkg; Pkg.test()'
QA/qa.jl | 80 passed, 80 total | 14m16.7s
Testing NeuralPDE tests passed (exit 0)

~/.juliaup/bin/julia +1.12 --project=~/.julia/environments/runic -m Runic --check <changed files>
exit 0

typos <changed files>
exit 0

git diff --check origin/master...HEAD
exit 0
```

An earlier concurrent NNODE run was externally terminated with signal 15 after 31 passing assertions and is not counted as verification. The detached rerun above completed all 73 assertions.

Earlier byte-identical source and regression trees also passed NNODE on Julia 1.10 LTS, 73/73. GPU, prerelease, downstream, and unrelated groups were not run locally. No docs build was run because this changes neither documentation nor public API.

Review the numerical choice to use the coarser precision. The full NNODE group covers complex-valued, parameter-estimation, and training-strategy cases.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Links

- Superseded broader draft: https://github.com/SciML/NeuralPDE.jl/pull/1150
- Current RHS correction: https://github.com/SciML/NeuralPDE.jl/pull/1139
- Separate NNSDE precision correction: https://github.com/SciML/NeuralPDE.jl/pull/1152

🤖 Initially generated with Codex CLI 0.153.4 (model: gpt-6-astra); local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d. No shareable conversation URL is exposed.

🤖 Updated with Codex CLI 0.153.4 (model: unknown); local session ID 01a0501c-815c-7cf1-93c4-ddb4fab68924. No shareable conversation URL is exposed.
