### PR TITLE
Support CUDA residuals with QuadratureTraining

### DIFF
--- a/docs/src/manual/training_strategies.md
+++ b/docs/src/manual/training_strategies.md
@@ -8,7 +8,8 @@ of the physics-informed loss.
 `QuasiRandomTraining` with its default `LatinHyperCubeSample()` is a well-rounded training
 strategy which can be used for most situations. It scales well for high dimensional
 spaces and is GPU-compatible. `QuadratureTraining` can lead to faster or more robust convergence
-with one of the H-Cubature or P-Cubature methods, but are not currently GPU compatible.
+with one of the H-Cubature or P-Cubature methods. Its quadrature backend generates points and
+accumulates integral values on the CPU, while residual evaluation follows the parameter device.
 For very high dimensional cases, `QuadratureTraining` with an adaptive Monte Carlo quadrature
 method, such as `CubaVegas`, can be beneficial for difficult or stiff problems.
 

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -478,11 +478,7 @@ function get_loss_function(
     ) -> begin
         function integrand(x, θ)
             x = x |> dev |> EltypeAdaptor{eltypeθ}()
-            θ_device = dev(θ)
-            if eltype(θ_device) !== eltype(θ)
-                θ_device = copyto!(similar(θ_device, eltype(θ)), θ)
-            end
-            θ = θ_device
+            θ = _adapt_preserving_eltype(dev, θ)
             isempty(x) && return cdev(similar(x, recursive_eltype(θ), 0))
             # CPU quadrature backends apply their Jacobian and accumulate on the host.
             return cdev(sum(abs2, view(loss_(x, θ), 1, :), dims = 2)) #./ size_x
@@ -495,6 +491,26 @@ function get_loss_function(
         ).u
     end
     return (θ) -> f_(lb, ub, loss_function, θ) / area
+end
+
+function _adapt_preserving_eltype(dev, x::AbstractArray)
+    x_device = dev(x)
+    eltype(x_device) === eltype(x) && return x_device
+    return copyto!(similar(x_device, eltype(x)), x)
+end
+
+function ChainRulesCore.rrule(::typeof(_adapt_preserving_eltype), dev, x::AbstractArray)
+    y = _adapt_preserving_eltype(dev, x)
+    function pullback(ȳ)
+        x̄ = ChainRulesCore.@thunk begin
+            ȳ_source = _adapt_preserving_eltype(
+                safe_get_device(x), ChainRulesCore.unthunk(ȳ)
+            )
+            ChainRulesCore.ProjectTo(x)(ȳ_source)
+        end
+        return ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent(), x̄
+    end
+    return y, pullback
 end
 
 """

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -478,8 +478,9 @@ function get_loss_function(
     ) -> begin
         function integrand(x, θ)
             x = x |> dev |> EltypeAdaptor{eltypeθ}()
-            isempty(x) && return similar(x, recursive_eltype(θ), 0)
-            return sum(abs2, view(loss_(x, θ), 1, :), dims = 2) #./ size_x
+            isempty(x) && return cdev(similar(x, recursive_eltype(θ), 0))
+            # CPU quadrature backends apply their Jacobian and accumulate on the host.
+            return cdev(sum(abs2, view(loss_(x, θ), 1, :), dims = 2)) #./ size_x
         end
         integral_function = BatchIntegralFunction(integrand, max_batch = strategy.batch)
         prob = IntegralProblem(integral_function, (lb, ub), θ)

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -478,9 +478,11 @@ function get_loss_function(
     ) -> begin
         function integrand(x, θ)
             x = x |> dev |> EltypeAdaptor{eltypeθ}()
-            θ_eltype = eltype(θ)
-            θ = dev(θ)
-            θ_eltype <: AbstractFloat && (θ = θ |> EltypeAdaptor{θ_eltype}())
+            θ_device = dev(θ)
+            if eltype(θ_device) !== eltype(θ)
+                θ_device = copyto!(similar(θ_device, eltype(θ)), θ)
+            end
+            θ = θ_device
             isempty(x) && return cdev(similar(x, recursive_eltype(θ), 0))
             # CPU quadrature backends apply their Jacobian and accumulate on the host.
             return cdev(sum(abs2, view(loss_(x, θ), 1, :), dims = 2)) #./ size_x

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -478,12 +478,13 @@ function get_loss_function(
     ) -> begin
         function integrand(x, θ)
             x = x |> dev |> EltypeAdaptor{eltypeθ}()
+            θ = dev(θ)
             isempty(x) && return cdev(similar(x, recursive_eltype(θ), 0))
             # CPU quadrature backends apply their Jacobian and accumulate on the host.
             return cdev(sum(abs2, view(loss_(x, θ), 1, :), dims = 2)) #./ size_x
         end
         integral_function = BatchIntegralFunction(integrand, max_batch = strategy.batch)
-        prob = IntegralProblem(integral_function, (lb, ub), θ)
+        prob = IntegralProblem(integral_function, (lb, ub), cdev(θ))
         return solve(
             prob, strategy.quadrature_alg; strategy.reltol, strategy.abstol,
             strategy.maxiters

--- a/src/training_strategies.jl
+++ b/src/training_strategies.jl
@@ -478,7 +478,9 @@ function get_loss_function(
     ) -> begin
         function integrand(x, θ)
             x = x |> dev |> EltypeAdaptor{eltypeθ}()
+            θ_eltype = eltype(θ)
             θ = dev(θ)
+            θ_eltype <: AbstractFloat && (θ = θ |> EltypeAdaptor{θ_eltype}())
             isempty(x) && return cdev(similar(x, recursive_eltype(θ), 0))
             # CPU quadrature backends apply their Jacobian and accumulate on the host.
             return cdev(sum(abs2, view(loss_(x, θ), 1, :), dims = 2)) #./ size_x

--- a/test/CUDA/nnpde_cuda__quadrature_empty_batch.jl
+++ b/test/CUDA/nnpde_cuda__quadrature_empty_batch.jl
@@ -1,4 +1,4 @@
-using CUDA, NeuralPDE, SciMLBase, Test
+using CUDA, Integrals, NeuralPDE, SciMLBase, Test, Zygote
 
 mutable struct EmptyBatchProbe <: SciMLBase.AbstractIntegralAlgorithm
     prototype::Any
@@ -8,7 +8,7 @@ function SciMLBase.solve(
         prob::SciMLBase.IntegralProblem, alg::EmptyBatchProbe; kwargs...
     )
     alg.prototype = prob.f(CUDA.zeros(Float64, 1, 0), prob.p)
-    return (; u = CUDA.ones(Float64, 1))
+    return (; u = ones(Float64, 1))
 end
 
 @testset "QuadratureTraining skips CUDA empty prototype batches" begin
@@ -23,7 +23,23 @@ end
         parameters, residuals, [0.0], [1.0], Float64, strategy
     )
 
-    @test only(Array(loss(parameters))) == 1.0
-    @test probe.prototype isa CuArray{Float64, 1}
+    @test only(loss(parameters)) == 1.0
+    @test probe.prototype isa Vector{Float64}
     @test isempty(probe.prototype)
+end
+
+@testset "QuadratureTraining evaluates residuals on CUDA" begin
+    residuals = (x, θ) -> θ .* x
+    parameters = CUDA.fill(2.0, 1)
+    strategy = QuadratureTraining(
+        quadrature_alg = CubatureJLh(), reltol = 1.0e-8, abstol = 1.0e-8,
+        maxiters = 10_000, batch = 16
+    )
+    loss = NeuralPDE.get_loss_function(
+        parameters, residuals, [0.0], [1.0], Float64, strategy
+    )
+
+    @test only(loss(parameters)) ≈ 4 / 3
+    gradient = only(Zygote.gradient(p -> only(loss(p)), parameters))
+    @test only(Array(gradient)) ≈ 4 / 3
 end


### PR DESCRIPTION
Please ignore this draft until reviewed by @ChrisRackauckas.

## What changed and why

`QuadratureTraining` uses CPU quadrature backends while residual evaluation may follow CUDA parameters. The prior implementation crossed that boundary unsafely: it returned CUDA residuals to the CPU cubature callback, stored a CUDA problem parameter for Integrals' CPU reverse pass, and allowed the device transfer to narrow a host `Float64` parameter to `Float32`.

The integrand now returns empty prototypes and nonempty values to the CPU, the `IntegralProblem` stores a CPU parameter copy, and each callback moves parameters to the residual device. If that device transfer changes the element type, an internal helper allocates same-device storage with the original element type and copies into it; its ChainRules pullback transfers and projects the cotangent back to the source array. This preserves both ordinary `Float64` precision and the complete ForwardDiff dual type without asking Zygote to differentiate the mutating device copy. The strict CUDA regression exercises a complete `CubatureJLh` forward loss and Zygote gradient, including the empty prototype path. No tolerance was loosened.

## Failing before the fix

The test-only commit first failed in the unfixed primal calculation on the V100:

```text
ERROR: LoadError: GPU compilation ... failed
KernelError: passing non-bitstype argument
Base.Broadcast.Extruded{Vector{Float64}, ...} ... is not isbits
```

After returning primal values to the CPU, the forward assertion passed but `Zygote.gradient` failed when Integrals tried to run its CPU quadrature adjoint with a CUDA problem parameter:

```text
Scalar indexing is disallowed.
Invocation of getindex resulted in scalar indexing of a GPU array.
```

After moving that parameter to the host, the error disappeared and exposed the precision bug:

```text
probe.prototype isa Vector{Float64}
Evaluated: Float32[] isa Vector{Float64}

only(Array(gradient)) ≈ 4 / 3
Evaluated: 1.3333333730697632 ≈ 1.3333333333333333
```

The first attempt to restore precision unconditionally then failed the CPU Interface lane:

```text
MethodError: no method matching Float64(::ForwardDiff.Dual{...})
```

A focused diagnostic showed why: adapting a `ReinterpretArray{Dual}` as ordinary `Dual` elements materialized primal and partial storage as separate zero-partial values. Restricting that conversion to `AbstractFloat` fixed the CPU regression but still left the V100 gradient rounded through `Float32`:

```text
only(Array(gradient)) ≈ 4 / 3
Evaluated: 1.3333333730697632 ≈ 1.3333333333333333
```

Using the transferred array as the same-device prototype and copying the original parameter into exact-element-type storage preserved precision, but Zygote then correctly rejected the visible mutation:

```text
Mutating arrays is not supported -- called copyto!(CuArray{Float64, 1, DeviceMemory}, ...)
```

The final implementation keeps that transfer behind a small internal helper with an explicit pullback. The pullback moves the cotangent to the parameter's source device and uses `ProjectTo` to restore its tangent shape and type. A focused local diagnostic deliberately narrowed a `Float64` vector to `Float32`, then observed an exact `Float64` result and Zygote gradient `[4.0]` through the helper.

## Native verification

Interface, NNPDE1, and QA ran on the exact source committed as `c9deb747d05913d5daaea9c2626c19a75a46c30a`, based on current master `beb5efa0802431b63ff603e53780df014f23fb86`:

```text
GROUP=Interface timeout 3600 ~/.juliaup/bin/julia +1.11 --project -e 'using Pkg; Pkg.test()'
23 passed, 23 total
Testing NeuralPDE tests passed (real 197.84s)

GROUP=NNPDE1 timeout 3600 ~/.juliaup/bin/julia +1.11 --project -e 'using Pkg; Pkg.test()'
23 passed, 23 total
Testing NeuralPDE tests passed (real 2896.83s)

GROUP=QA timeout 3600 ~/.juliaup/bin/julia +1.11 --project -e 'using Pkg; Pkg.test()'
QA/qa.jl | 80 passed, 80 total | 4m15.9s
Testing NeuralPDE tests passed (real 302.46s)

~/.juliaup/bin/julia +1.12 --project -e '<narrowing-device Zygote diagnostic>'
eltype=Float64 gradient=[4.0]

~/.juliaup/bin/julia +1.12 -m Runic --check <changed files>
exit 0

typos <changed files>
exit 0

git diff --check
exit 0

~/.juliaup/bin/julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
~/.juliaup/bin/julia +1.12 --project=docs docs/make.jl
exit 0 (real 19653.00s)
```

The docs build ran in a detached worktree whose `src/training_strategies.jl` diff hash exactly matched `c1a2de869f96c913cd68211709d8d84fb9a2b4d8..c9deb747d05913d5daaea9c2626c19a75a46c30a` before and after the run. An earlier QA run launched concurrently with two cold Julia 1.11 test environments reproduced the existing Aqua persistent-task failure (79/80, missing `done.log`). The exact final source passed 80/80 when QA was rerun, matching the already-investigated failure mode in the linked tracking issue.

This machine has no functional CUDA device. The prior head's V100 regression passed 4/5 assertions but still rounded the `Float64` gradient through `Float32`; pass-after for the strict CUDA regression is pending on the workflow triggered by this new head. GPU behavior is not claimed until that job passes. Prerelease and downstream groups were not run locally.

## Links

- Initial primal GPU failure: https://github.com/SciML/NeuralPDE.jl/actions/runs/34218791811/job/102036925412
- Reverse-pass scalar-indexing failure: https://github.com/SciML/NeuralPDE.jl/actions/runs/34265410058/job/102193516684
- Precision-discriminating GPU failure: https://github.com/SciML/NeuralPDE.jl/actions/runs/34271725108/job/102215233642
- ForwardDiff Interface regression: https://github.com/SciML/NeuralPDE.jl/actions/runs/34686342804/job/103536837817
- Float32-rounded V100 gradient after the first precision fix: https://github.com/SciML/NeuralPDE.jl/actions/runs/34717404461/job/103617045128
- Zygote mutation failure after the exact-element-type copy: https://github.com/SciML/NeuralPDE.jl/actions/runs/34726700221/job/103642810706
- Original SciMLBenchmarks failure: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/34239973950/job/102107470012
- Blocked PINNErrorsVsTime update: https://github.com/SciML/SciMLBenchmarks.jl/pull/1845
- Blocked PINNOptimizers update: https://github.com/SciML/SciMLBenchmarks.jl/pull/1842
- Existing Aqua persistent-task tracking issue: https://github.com/SciML/NeuralPDE.jl/issues/1109
- Historical Codex session for the first three commits: https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512

🤖 Initially generated with Codex CLI 0.153.4 (model: unknown); session https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512.

🤖 Updated with Codex CLI 0.153.4 (model: unknown); local session ID 01a0501c-815c-7cf1-93c4-ddb4fab68924. No shareable conversation URL is exposed.
