### PR TITLE
Release NeuralPDE 6.3.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralPDE"
 uuid = "315f7962-48a3-4962-8226-d0f33b1235f0"
-version = "6.3.1"
+version = "6.3.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `NeuralPDE` 6.3.1 -> 6.3.2 (patch).

Source files changed since 6.3.1:
- `src/discretize.jl`
- `src/symbolic_utilities.jl`
- `src/transform_inf_integral.jl`

Commits:
- Add 32-bit Interface CI lane via test_groups.toml (#1154)
- Support locally bound variables in PINN integrals (#1149)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
