### PR TITLE
Source Integrals/MonteCarloIntegration from master to fix x86 CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -118,6 +118,7 @@ Zygote = "0.7.10"
 julia = "1.10"
 
 [extras]
+MonteCarloIntegration = "4886b29c-78c9-11e9-0a6e-41e1f4161f7b"
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
 Boltz = "4544d5e4-abc5-4dea-817f-29e4c205d9c8"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -142,4 +143,8 @@ TensorBoardLogger = "899adc3e-224a-11e9-021f-63837185c80f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AdvancedHMC", "Boltz", "CUDA", "DiffEqNoiseProcess", "FastGaussQuadrature", "Flux", "InteractiveUtils", "LineSearches", "LogDensityProblems", "LuxCUDA", "LuxCore", "LuxLib", "MCMCChains", "Optim", "OptimizationOptimJL", "OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "StableRNGs", "StochasticDiffEq", "TensorBoardLogger", "Test"]
+test = ["AdvancedHMC", "MonteCarloIntegration", "Boltz", "CUDA", "DiffEqNoiseProcess", "FastGaussQuadrature", "Flux", "InteractiveUtils", "LineSearches", "LogDensityProblems", "LuxCUDA", "LuxCore", "LuxLib", "MCMCChains", "Optim", "OptimizationOptimJL", "OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "StableRNGs", "StochasticDiffEq", "TensorBoardLogger", "Test"]
+
+[sources]
+Integrals = {url = "https://github.com/SciML/Integrals.jl.git", rev = "master"}
+MonteCarloIntegration = {url = "https://github.com/ranjanan/MonteCarloIntegration.jl.git", rev = "master"}


### PR DESCRIPTION
## Summary

The `tests / Interface (julia 1, ubuntu-latest, x86)` job on master fails during precompilation:

```
ArgumentError: maximum number of points n must be less than or equal to 2^32
```

Chain: the test env resolves `MonteCarloIntegration v0.2.0` (via `Integrals`), whose compat caps `QuasiMonteCarlo` at `0.3.x`. QMC 0.3.x requires `LatticeRules = "0.0.1"`, and in LatticeRules 0.0.1 `typemax(UInt32) + 1` **wraps to 0 on 32-bit Julia** (verified: `UInt32 + Int32` promotes to `UInt32`), so every `LatticeRule32` construction throws. LatticeRules 0.0.2 fixes this, but only QMC ≥ 0.4.3 allows it.

`MonteCarloIntegration` master (v0.3.0) supports `QuasiMonteCarlo 0.4`, but no *registered* Integrals version accepts MCI 0.3 (`Integrals 4.3 - 5 => MCI 0.2`), so this PR sources both `Integrals` and `MonteCarloIntegration` from master — the same approach as `Integrals.jl`'s own `[sources]` entry and BoundaryValueDiffEq#634. MCI is added to `extras` + the `test` target so the source applies to the test sandbox.

These `[sources]` entries should be dropped once MCI 0.3.0 is registered and an Integrals release ships `MonteCarloIntegration = "0.3"` compat.

#### Test plan
- [x] `Pkg.test()` env resolves to `Integrals#master`, `MonteCarloIntegration v0.3.0#master`, `QuasiMonteCarlo v0.4.3` (was MCI 0.2.0 + QMC 0.3.11)
- [x] On Julia 1.13.0 x86: `using QuasiMonteCarlo` + `sample(Int32(10), [0.0,0.0], [1.0,1.0], LatticeRuleSample())` succeeds with QMC 0.4.3 / LatticeRules 0.0.2
- [x] The same call fails under QMC 0.3.11 / LatticeRules 0.0.1 (reproduces the CI error)

🤖 Generated with Devin CLI (model: SWE-2 Max) — local session, no shareable URL